### PR TITLE
[OpenMP]-Added volatile to shared parallelLevel array for AMDGCN

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/omp_data.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/omp_data.cu
@@ -30,8 +30,11 @@ __device__ omptarget_nvptx_SimpleMemoryManager
     omptarget_nvptx_simpleMemoryManager;
 __device__ __shared__ uint32_t usedMemIdx;
 __device__ __shared__ uint32_t usedSlotIdx;
-
+#ifdef __AMDGCN__
+__device__ volatile __shared__ uint8_t parallelLevel[MAX_THREADS_PER_TEAM / WARPSIZE];
+#else
 __device__ __shared__ uint8_t parallelLevel[MAX_THREADS_PER_TEAM / WARPSIZE];
+#endif
 __device__ __shared__ uint16_t threadLimit;
 __device__ __shared__ uint16_t threadsInTeam;
 __device__ __shared__ uint16_t nThreads;

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
@@ -422,8 +422,13 @@ extern __device__ omptarget_nvptx_SimpleMemoryManager
     omptarget_nvptx_simpleMemoryManager;
 extern __device__ __shared__ uint32_t usedMemIdx;
 extern __device__ __shared__ uint32_t usedSlotIdx;
+#ifdef __AMDGCN__
+extern __device__ volatile __shared__ uint8_t
+    parallelLevel[MAX_THREADS_PER_TEAM / WARPSIZE];
+#else
 extern __device__ __shared__ uint8_t
     parallelLevel[MAX_THREADS_PER_TEAM / WARPSIZE];
+#endif
 extern __device__ __shared__ uint16_t threadLimit;
 extern __device__ __shared__ uint16_t threadsInTeam;
 extern __device__ __shared__ uint16_t nThreads;


### PR DESCRIPTION
Needed to add volatile to the shared parallelLevel array so that all threads in warp can get the same value and avoid caching issues.