### PR TITLE
default to code-object-v3

### DIFF
--- a/clang/lib/Driver/ToolChains/HIP.cpp
+++ b/clang/lib/Driver/ToolChains/HIP.cpp
@@ -232,7 +232,7 @@ const char *AMDGCN::Linker::constructLlcCommand(
   ArgStringList LlcArgs{InputFileName,
                         "-mtriple=amdgcn-amd-amdhsa",
                         "-filetype=obj",
-                        "-mattr=-code-object-v3",
+                        "-mattr=+code-object-v3",
                         "-disable-promote-alloca-to-lds",
                         Args.MakeArgString("-mcpu=" + SubArchName)};
 


### PR DESCRIPTION
Enabled +code-object-v3 in llvm-project, 
rebuilt aomp, 
ran and passed smoke tests, openmpapps, hpc2020 MPI, hpc2020 OMP.

enabled verbose mode and visually verified we are emitting -mattr=+code-object-v3
