### PR TITLE
[OpenMP - reduction.cu]-Fixed sync issue with shuffle function. The e…

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
@@ -59,7 +59,8 @@
 #else
 
 #define __SHFL_DOWN_SYNC(mask, var, delta, width)                              \
-  __shfl_down((var), (delta), (width))
+  (__threadfence_block(),                                                     \
+  __shfl_down((var), (delta), (width)))
 #ifdef __AMDGCN__
 #define __SHFL_SYNC(mask, var, srcLane) __shfl((var), (srcLane), WARPSIZE)
 extern "C" __device__ void llvm_amdgcn_s_barrier();

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/reduction.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/reduction.cu
@@ -80,7 +80,6 @@ void __kmpc_nvptx_end_reduce_nowait(int32_t global_tid) {}
 
 #ifdef __AMDGCN__
 EXTERN int32_t __kmpc_shuffle_int32(int32_t val, int16_t delta, int16_t size) {
-  __threadfence_block();
   return __SHFL_DOWN_SYNC(0xFFFFFFFF, val, delta, size);
 }
 
@@ -88,9 +87,8 @@ EXTERN int64_t __kmpc_shuffle_int64(int64_t val, int16_t delta, int16_t size) {
   int lo, hi;
   hi = (int)((val >> 32) & 0xffffffff);
   lo = (int)(val & 0xffffffff);
-  __threadfence_block();
-  hi = __shfl_down(hi, delta, size);
-  lo = __shfl_down(lo, delta, size);
+  hi = __SHFL_DOWN_SYNC(0xFFFFFFFF, hi, delta, size);
+  lo = __SHFL_DOWN_SYNC(0xFFFFFFFF, lo, delta, size);
   val = hi;
   val <<= 32;
   val |= ((uint32_t)lo);


### PR DESCRIPTION
…nd results of the reduction were incorrect. This was not the case on NVPTX because they use _shfl_down_sync(), which syncs all threads in a warp before performing the shuffle. AMDGCN just uses the _shfl_down() non-synchrnous function.