### PR TITLE
Check if an archive contains device code for AMDGCN also.

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2959,7 +2959,8 @@ class OffloadingActionBuilder final {
         for (unsigned I = 0; I < ToolChains.size(); ++I) {
           bool foundDeviceCode = false;
           for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I) {
-            if (VirtualArchForCudaArch(GpuArchList[I]) == CudaVirtualArch::COMPUTE_AMDGCN ||
+            StringRef Extension = llvm::sys::path::extension(FileName).drop_front();
+            if (Extension != "a" ||
                 archiveContainsDeviceCode(
                   ToolChains[I]->GetProgramPath(
                     "clang-unbundle-archive").c_str(),


### PR DESCRIPTION
This fixes a couple of issues found when trying to compile RAJA, if there is an archive we have to check if there is device code or the unbundler will fail, because there is no device code to extract. The driver will have to inspect the archive file, which makes the compilation slightly slower, but there is currently no other way of doing this.