### PR TITLE
NFC. Update loop.cu to use target_impl, matching upstream.

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/loop.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/loop.cu
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "omptarget-nvptx.h"
+#include "target_impl.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -380,23 +381,20 @@ public:
   // Support for dispatch next
 
 #ifdef __AMDGCN__
-  INLINE static uint64_t Shuffle(uint64_t active, int64_t val, int leader) {
-    // unpack
-    int lo = (uint32_t) ( val & 0x00000000FFFFFFFFL);
-    int hi = (uint32_t) ((val & 0xFFFFFFFF00000000L) >> 32);
-    // shuffle
-    hi = __SHFL_SYNC(active, hi, leader);
-    lo = __SHFL_SYNC(active, lo, leader);
-    // pack
-    return (((uint64_t) hi)<<32) | (uint64_t) lo;
+  INLINE static uint64_t Shuffle(__kmpc_impl_lanemask_t active, int64_t val, int leader) {
+    uint32_t lo, hi;
+    __kmpc_impl_unpack(val, lo, hi);
+    hi = __kmpc_impl_shfl_sync(active, hi, leader);
+    lo = __kmpc_impl_shfl_sync(active, lo, leader);
+    return __kmpc_impl_pack(lo, hi);
   }
 
   INLINE static uint64_t NextIter() {
-    uint64_t  active = __ballot64(true);
-    int leader = __ffsll(active) - 1;
-    int change = __popcll(active);
-    uint64_t lane_mask_lt = __lanemask_lt();
-    unsigned int rank = __popcll(active & lane_mask_lt);
+    __kmpc_impl_lanemask_t active = __ballot64(true);
+    uint32_t leader = __kmpc_impl_ffs(active) - 1;
+    uint32_t change = __kmpc_impl_popc(active);
+    __kmpc_impl_lanemask_t lane_mask_lt = __kmpc_impl_lanemask_lt();
+    unsigned int rank = __kmpc_impl_popc(active & lane_mask_lt);
     uint64_t warp_res;
     if (rank == 0) {
       warp_res = atomicAdd(

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
@@ -1,0 +1,44 @@
+//===------------ target_impl.h - NVPTX OpenMP GPU options ------- CUDA -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions of target specific functions
+//
+//===----------------------------------------------------------------------===//
+#ifndef _TARGET_IMPL_H_
+#define _TARGET_IMPL_H_
+
+#include <stdint.h>
+
+#include "option.h"
+#include "omptarget-nvptx.h"
+
+INLINE void __kmpc_impl_unpack(uint64_t val, uint32_t &lo, uint32_t &hi) {
+  lo = (uint32_t)(val & 0x00000000FFFFFFFFL);
+  hi = (uint32_t)((val & 0xFFFFFFFF00000000L) >> 32);
+}
+
+INLINE uint64_t __kmpc_impl_pack(uint32_t lo, uint32_t hi) {
+  return (((uint64_t)hi) << 32) | (uint64_t)lo;
+}
+
+typedef uint64_t __kmpc_impl_lanemask_t;
+
+INLINE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_lt() {
+  return __lanemask_lt();
+}
+
+INLINE uint64_t __kmpc_impl_ffs(uint64_t x) { return __ffsll(x); }
+
+INLINE uint64_t __kmpc_impl_popc(uint64_t x) { return __popcll(x); }
+
+INLINE int32_t __kmpc_impl_shfl_sync(__kmpc_impl_lanemask_t Mask, int32_t Var,
+                                     int32_t SrcLane) {
+  return __SHFL_SYNC(Mask, Var, SrcLane);
+}
+
+#endif


### PR DESCRIPTION
Upstream nvptx now has a number of target hooks defined in target_impl.h. Implementing these for amdgcn will significantly decrease the delta between nvptx/src and amdgcn/src.

This patch introduces the corresponding target_impl file containing the functions used by the changes to loop.cu.

The dependency on omptarget-nvptx.h will be dropped (by inlining the macros) once all uses of __SHFL_SYNC are replaced with the inline function call, as implemented upstream.