### PR TITLE
fix problem where nonspmd kernels hang because amd_master_end is not …

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/interface.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/interface.h
@@ -452,6 +452,7 @@ EXTERN void __kmpc_amd_worker_start(kmp_Ident *loc_ref, int32_t tid);
 EXTERN void __kmpc_amd_worker_end(kmp_Ident *loc_ref, int32_t tid);
 EXTERN void __kmpc_amd_master_start(kmp_Ident *loc_ref, int32_t tid);
 EXTERN void __kmpc_amd_master_end(kmp_Ident *loc_ref, int32_t tid);
+EXTERN void __kmpc_amd_master_terminate(kmp_Ident *loc_ref, int32_t tid);
 EXTERN void __kmpc_barrier_simple_generic(kmp_Ident *loc_ref, int32_t tid);
 EXTERN int32_t __kmpc_cancel_barrier(kmp_Ident *loc, int32_t global_tid);
 

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/sync.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/sync.cu
@@ -132,6 +132,13 @@ EXTERN void __kmpc_amd_master_end(kmp_Ident *loc_ref, int32_t tid) {
   PRINT0(LD_SYNC, "completed kmpc_amd_master_end\n");
 }
 
+EXTERN void __kmpc_amd_master_terminate(kmp_Ident *loc_ref, int32_t tid) {
+  PRINT0(LD_SYNC, "call kmpc_amd_master_terminate\n");
+  omptarget_master_active = false;
+  __kmpc_impl_syncthreads();
+  PRINT0(LD_SYNC, "completed kmpc_amd_master_terminate\n");
+}
+
 // Emit a simple barrier call in Generic mode.  Assumes the caller is in an L0
 // parallel region and that all worker threads participate.
 EXTERN void __kmpc_barrier_simple_generic(kmp_Ident *loc_ref, int32_t tid) {


### PR DESCRIPTION
…getting called.   We introduce a new function __kmpc_amd_master_terminate that sets libomptarget_master_active to false so worker warps can terminate