### PR TITLE
Use target_impl to reduce the delta vs nvptx upstream

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/data_sharing.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/data_sharing.cu
@@ -43,7 +43,7 @@ INLINE static bool IsWarpMasterActiveThread() {
   //  unsigned popret = __popcll(Sh);
   return (Sh == (unsigned long long)0);
 #else
-  unsigned long long Mask = __ACTIVEMASK();
+  unsigned long long Mask = __kmpc_impl_activemask();
   unsigned long long ShNum = WARPSIZE - (GetThreadIdInBlock() % WARPSIZE);
   unsigned long long Sh = Mask << ShNum;
   // Truncate Sh to the 32 lower bits
@@ -140,11 +140,7 @@ EXTERN void *__kmpc_data_sharing_environment_begin(
           (unsigned long long)SharingDefaultDataSize);
 
   unsigned WID = getWarpId();
-#ifdef __AMDGCN__
   __kmpc_impl_lanemask_t CurActiveThreads = __kmpc_impl_activemask();
-#else
-  unsigned CurActiveThreads = __ACTIVEMASK();
-#endif
 
   __kmpc_data_sharing_slot *&SlotP = DataSharingState.SlotPtr[WID];
   void *&StackP = DataSharingState.StackPtr[WID];
@@ -292,11 +288,7 @@ EXTERN void __kmpc_data_sharing_environment_end(
     return;
   }
 
-#ifdef __AMDGCN__
   __kmpc_impl_lanemask_t CurActive = __kmpc_impl_activemask();
-#else
-  int32_t CurActive = __ACTIVEMASK();
-#endif
 
   // Only the warp master can restore the stack and frame information, and only
   // if there are no other threads left behind in this environment (i.e. the
@@ -426,11 +418,7 @@ INLINE static void* data_sharing_push_stack_common(size_t PushSize) {
   // Frame pointer must be visible to all workers in the same warp.
   const unsigned WID = getWarpId();
   void *FrameP = 0;
-#ifdef __AMDGCN__
   __kmpc_impl_lanemask_t CurActive = __kmpc_impl_activemask();
-#else
-  int32_t CurActive = __ACTIVEMASK();
-#endif
 
   if (IsWarpMaster) {
     // SlotP will point to either the shared memory slot or an existing

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/libcall.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/libcall.cu
@@ -12,10 +12,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "omptarget-nvptx.h"
+#include "target_impl.h"
 
 // Timer precision is 1ns
 #define TIMER_PRECISION ((double)1E-9)
-#define TICK ((double)1.0 / 745000000.0)
 
 EXTERN double omp_get_wtick(void) {
   PRINT(LD_IO, "omp_get_wtick() returns %g\n", TIMER_PRECISION);
@@ -24,7 +24,7 @@ EXTERN double omp_get_wtick(void) {
 
 EXTERN double omp_get_wtime(void) {
 #ifdef __AMDGCN__
-  double rc = TICK * __clock64();
+  double rc = ((double)1.0 / 745000000.0) * __clock64();
 #else
   unsigned long long nsecs;
   asm("mov.u64  %0, %%globaltimer;" : "=l"(nsecs));
@@ -388,7 +388,7 @@ EXTERN unsigned long long omp_ext_get_active_threads_mask() {
 }
 #else
 EXTERN unsigned long long omp_ext_get_active_threads_mask() {
-  unsigned rc = __ACTIVEMASK();
+  unsigned rc = __kmpc_impl_activemask();
   PRINT(LD_IO, "call omp_ext_get_active_threads_mask() returns %x\n", rc);
   return (unsigned long long)rc;
 }

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
@@ -49,28 +49,14 @@
 
 // Macros for Cuda intrinsics
 // In Cuda 9.0, the *_sync() version takes an extra argument 'mask'.
-// Also, __ballot(1) in Cuda 8.0 is replaced with __activemask().
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-
 #define __SHFL_SYNC(mask, var, srcLane) __shfl_sync((mask), (var), (srcLane))
-#define __SHFL_DOWN_SYNC(mask, var, delta, width)                              \
-  __shfl_down_sync((mask), (var), (delta), (width))
-#define __ACTIVEMASK() __activemask()
 #else
-
-#define __SHFL_DOWN_SYNC(mask, var, delta, width)                              \
-  __shfl_down((var), (delta), (width))
 #ifdef __AMDGCN__
 #define __SHFL_SYNC(mask, var, srcLane) __shfl((var), (srcLane), WARPSIZE)
-extern "C" __device__ void llvm_amdgcn_s_barrier();
-#define __SYNCTHREADS_N(n) llvm_amdgcn_s_barrier()
-#else 
+#else
 #define __SHFL_SYNC(mask, var, srcLane) __shfl((var), (srcLane))
-#define __ACTIVEMASK() __ballot(1)
-#define __SYNCTHREADS_N(n) asm volatile("bar.sync %0;" : : "r"(n) : "memory");
 #endif
-#define __SYNCTHREADS() __SYNCTHREADS_N(0)
-
 #endif
 
 // arguments needed for L0 parallelism only.

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/parallel.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/parallel.cu
@@ -51,25 +51,21 @@ EXTERN bool __kmpc_kernel_convergent_simd(void *buffer, uint64_t Mask,
   PRINT0(LD_IO, "call to __kmpc_kernel_convergent_simd\n");
   __kmpc_impl_lanemask_t ConvergentMask = Mask;
   int32_t ConvergentSize = __kmpc_impl_popc(ConvergentMask);
-  uint64_t WorkRemaining = ConvergentMask >> (*LaneSource + 1);
-  *LaneSource += __kmpc_impl_ffs(WorkRemaining);
-  *IsFinal = __kmpc_impl_popc(WorkRemaining) == 1;
-  __kmpc_impl_lanemask_t lanemask_lt = __kmpc_impl_lanemask_lt();
-  *LaneId = __kmpc_impl_popc(ConvergentMask & lanemask_lt);
+  __kmpc_impl_lanemask_t WorkRemaining = ConvergentMask >> (*LaneSource + 1);
 #else
 EXTERN bool __kmpc_kernel_convergent_simd(void *buffer, uint32_t Mask,
                                           bool *IsFinal, int32_t *LaneSource,
                                           int32_t *LaneId, int32_t *NumLanes) {
   PRINT0(LD_IO, "call to __kmpc_kernel_convergent_simd\n");
   uint32_t ConvergentMask = Mask;
-  int32_t ConvergentSize = __popc(ConvergentMask);
+  int32_t ConvergentSize = __kmpc_impl_popc(ConvergentMask);
   uint32_t WorkRemaining = ConvergentMask >> (*LaneSource + 1);
-  *LaneSource += __ffs(WorkRemaining);
-  *IsFinal = __popc(WorkRemaining) == 1;
-  uint32_t lanemask_lt;
-  asm("mov.u32 %0, %%lanemask_lt;" : "=r"(lanemask_lt));
-  *LaneId = __popc(ConvergentMask & lanemask_lt);
 #endif
+
+  *LaneSource += __kmpc_impl_ffs(WorkRemaining);
+  *IsFinal = __kmpc_impl_popc(WorkRemaining) == 1;
+  __kmpc_impl_lanemask_t lanemask_lt = __kmpc_impl_lanemask_lt();
+  *LaneId = __kmpc_impl_popc(ConvergentMask & lanemask_lt);
 
   int threadId = GetLogicalThreadIdInBlock(isSPMDMode());
   int sourceThreadId = (threadId & ~(WARPSIZE - 1)) + *LaneSource;
@@ -140,24 +136,20 @@ EXTERN bool __kmpc_kernel_convergent_parallel(void *buffer, uint64_t Mask,
    __kmpc_impl_lanemask_t ConvergentMask = Mask;
   int32_t ConvergentSize = __kmpc_impl_popc(ConvergentMask);
   uint64_t WorkRemaining = ConvergentMask >> (*LaneSource + 1);
-  *LaneSource += __kmpc_impl_ffs(WorkRemaining);
-  *IsFinal = __kmpc_impl_popc(WorkRemaining) == 1;
-  __kmpc_impl_lanemask_t lanemask_lt = __kmpc_impl_lanemask_lt();
-  uint32_t OmpId = __kmpc_impl_popc(ConvergentMask & lanemask_lt);
 #else
 EXTERN bool __kmpc_kernel_convergent_parallel(void *buffer, uint32_t Mask,
                                               bool *IsFinal,
                                               int32_t *LaneSource) {
   PRINT0(LD_IO, "call to __kmpc_kernel_convergent_parallel\n");
   uint32_t ConvergentMask = Mask;
-  int32_t ConvergentSize = __popc(ConvergentMask);
+  int32_t ConvergentSize = __kmpc_impl_popc(ConvergentMask);
   uint32_t WorkRemaining = ConvergentMask >> (*LaneSource + 1);
-  *LaneSource += __ffs(WorkRemaining);
-  *IsFinal = __popc(WorkRemaining) == 1;
-  uint32_t lanemask_lt;
-  asm("mov.u32 %0, %%lanemask_lt;" : "=r"(lanemask_lt));
-  uint32_t OmpId = __popc(ConvergentMask & lanemask_lt);
 #endif
+
+  *LaneSource += __kmpc_impl_ffs(WorkRemaining);
+  *IsFinal = __kmpc_impl_popc(WorkRemaining) == 1;
+  __kmpc_impl_lanemask_t lanemask_lt = __kmpc_impl_lanemask_lt();
+  uint32_t OmpId = __kmpc_impl_popc(ConvergentMask & lanemask_lt);
 
   int threadId = GetLogicalThreadIdInBlock(isSPMDMode());
   int sourceThreadId = (threadId & ~(WARPSIZE - 1)) + *LaneSource;

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/supporti.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/supporti.h
@@ -204,13 +204,8 @@ INLINE int IsTeamMaster(int ompThreadId) { return (ompThreadId == 0); }
 // Parallel level
 
 INLINE void IncParallelLevel(bool ActiveParallel) {
-#ifdef __AMDGCN__
   __kmpc_impl_lanemask_t tnum = __kmpc_impl_activemask();
   int leader = __kmpc_impl_ffs(tnum) - 1;
-#else
-  unsigned tnum = __ACTIVEMASK();
-  int leader = __ffs(tnum) - 1;
-#endif
   __SHFL_SYNC(tnum, leader, leader);
   if (GetLaneId() == leader) {
     parallelLevel[GetWarpId()] +=
@@ -220,13 +215,8 @@ INLINE void IncParallelLevel(bool ActiveParallel) {
 }
 
 INLINE void DecParallelLevel(bool ActiveParallel) {
-#ifdef __AMDGCN__
   __kmpc_impl_lanemask_t tnum = __kmpc_impl_activemask();
   int leader = __kmpc_impl_ffs(tnum) - 1;
-#else
-  unsigned tnum = __ACTIVEMASK();
-  int leader = __ffs(tnum) - 1;
-#endif
   __SHFL_SYNC(tnum, leader, leader);
   if (GetLaneId() == leader) {
     parallelLevel[GetWarpId()] -=

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/sync.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/sync.cu
@@ -208,6 +208,6 @@ EXTERN int64_t __kmpc_warp_active_thread_mask64() {
 #else
 EXTERN int32_t __kmpc_warp_active_thread_mask() {
   PRINT0(LD_IO, "call __kmpc_warp_active_thread_mask\n");
-  return __ACTIVEMASK();
+  return __kmpc_impl_activemask();
 }
 #endif


### PR DESCRIPTION
NFC. Use target_impl to reduce the delta vs nvptx upstream

The code will still compile as nvptx (given appropriate macros).