### PR TITLE
I think this was a typo and does not belong here. Removed setting of …

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -345,7 +345,6 @@ void AMDGPUTargetInfo::getTargetDefines(const LangOptions &Opts,
     Builder.defineMacro("__HAS_FP64__");
   if (hasFastFMA())
     Builder.defineMacro("FP_FAST_FMA");
-  Builder.defineMacro("__CUDA_ARCH__", "320");
 }
 
 void AMDGPUTargetInfo::setAuxTarget(const TargetInfo *Aux) {


### PR DESCRIPTION
…cuda arch, which caused HIP_DEVICE_COMPILE to be enabled on host passes due to the logic in hip_common.h. Smoke test for verification: hip-device-compile. GitHub issue #28