### PR TITLE
Rename active_thread_mask64 to active_thread_mask

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/interface.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/interface.h
@@ -473,11 +473,7 @@ EXTERN void __kmpc_end_critical(kmp_Ident *loc, int32_t global_tid,
 EXTERN void __kmpc_flush(kmp_Ident *loc);
 
 // vote
-#ifdef __AMDGCN__
-EXTERN __kmpc_impl_lanemask_t __kmpc_warp_active_thread_mask64();
-#else
 EXTERN __kmpc_impl_lanemask_t __kmpc_warp_active_thread_mask();
-#endif
 
 // tasks
 EXTERN kmp_TaskDescr *__kmpc_omp_task_alloc(kmp_Ident *loc,

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/sync.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/sync.cu
@@ -200,14 +200,7 @@ EXTERN void __kmpc_flush(kmp_Ident *loc) {
 // Vote
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef __AMDGCN__
-EXTERN __kmpc_impl_lanemask_t __kmpc_warp_active_thread_mask64() {
-  PRINT0(LD_IO, "call __kmpc_warp_active_thread_mask64\n");
-  return __kmpc_impl_activemask();
-}
-#else
 EXTERN __kmpc_impl_lanemask_t __kmpc_warp_active_thread_mask() {
   PRINT0(LD_IO, "call __kmpc_warp_active_thread_mask\n");
   return __kmpc_impl_activemask();
 }
-#endif


### PR DESCRIPTION
Rename active_thread_mask64 to active_thread_mask

Tests pass as before. Grep suggests this function isn't currently in use.