### PR TITLE
Move interface.h to target independent directory

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/CMakeLists.txt
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/CMakeLists.txt
@@ -88,6 +88,10 @@ endif()
 
 separate_arguments(mcpus)
 
+get_filename_component(devicertl_base_directory
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  DIRECTORY)
+
 macro(collect_sources name dir)
   set(cuda_sources)
   set(ocl_sources)
@@ -126,7 +130,8 @@ macro(add_cuda_bc_library name dir)
     -O${optimization_level}
     --cuda-gpu-arch=${mcpu}
     ${CUDA_DEBUG}
-    -I${CMAKE_CURRENT_SOURCE_DIR}/src)
+    -I${CMAKE_CURRENT_SOURCE_DIR}/src
+    -I${devicertl_base_directory})
 
   set(bc1_files)
 

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_interface.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_interface.h
@@ -1,0 +1,17 @@
+//===--- amdgcn_interface.h - OpenMP interface definitions ------- CUDA -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _AMDGCN_INTERFACE_H_
+#define _AMDGCN_INTERFACE_H_
+
+#include <stdint.h>
+
+#define EXTERN extern "C" __attribute__((device))
+typedef uint64_t __kmpc_impl_lanemask_t;
+
+#endif

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/option.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/option.h
@@ -12,6 +12,7 @@
 #ifndef _OPTION_H_
 #define _OPTION_H_
 
+#include "interface.h"
 #include "cuda_shim.h"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,7 +66,6 @@
 // misc options (by def everythig here is device)
 ////////////////////////////////////////////////////////////////////////////////
 
-#define EXTERN extern "C" __device__
 #define INLINE __inline__ __device__
 #define NOINLINE __noinline__ __device__
 #ifndef TRUE

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
@@ -48,7 +48,6 @@ INLINE uint64_t __kmpc_impl_pack(uint32_t lo, uint32_t hi) {
   return (((uint64_t)hi) << 32) | (uint64_t)lo;
 }
 
-typedef uint64_t __kmpc_impl_lanemask_t;
 static const __kmpc_impl_lanemask_t __kmpc_impl_all_lanes =
     UINT64_C(0xffffffffffffffff);
 

--- a/openmp/libomptarget/deviceRTLs/interface.h
+++ b/openmp/libomptarget/deviceRTLs/interface.h
@@ -1,12 +1,10 @@
-//===------- interface.h - NVPTX OpenMP interface definitions ---- CUDA -*-===//
+//===------- interface.h - OpenMP interface definitions ---------- CUDA -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// This file contains debug macros to be used in the application.
 //
 //  This file contains all the definitions that are relevant to
 //  the interface. The first section contains the interface as
@@ -19,8 +17,14 @@
 #ifndef _INTERFACES_H_
 #define _INTERFACES_H_
 
-#include "option.h"
-#include "target_impl.h"
+#include <stdint.h>
+
+#ifdef __AMDGCN__
+#include "amdgcn/src/amdgcn_interface.h"
+#endif
+#ifdef __CUDACC__
+#include "nvptx/src/nvptx_interface.h"
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // OpenMP interface

--- a/openmp/libomptarget/deviceRTLs/nvptx/src/nvptx_interface.h
+++ b/openmp/libomptarget/deviceRTLs/nvptx/src/nvptx_interface.h
@@ -1,0 +1,17 @@
+//===--- nvptx_interface.h - OpenMP interface definitions -------- CUDA -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _NVPTX_INTERFACE_H_
+#define _NVPTX_INTERFACE_H_
+
+#include <stdint.h>
+
+#define EXTERN extern "C" __device__
+typedef uint32_t __kmpc_impl_lanemask_t;
+
+#endif


### PR DESCRIPTION
Move interface.h to target independent directory

Approximately corresponds to https://reviews.llvm.org/D68615. The interface.h file moved under deviceRTLs/ is a superset of the upstream. The extensions can be moved into amdgcn_interface.h (subsequent patch) until such point as they're also accepted for other targets.