### PR TITLE
[Clang]-Added libm to the do not search for SDL list because of autom…

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1795,8 +1795,8 @@ void tools::AddStaticDeviceLibs(Compilation *C,
   // Build list of Static Device Libraries SDLs specified by -l option
   SmallVector<std::string, 16> SDL_Names;
   for (std::string SDL_Name : DriverArgs.getAllArgValues(options::OPT_l)) {
-    // No SDL for -lomp or -lcudart, they only have host libs
-    if (SDL_Name != "omp" && SDL_Name != "cudart") {
+    // No SDL for -lomp or -lcudart, they only have host libs, SDL for -lm added automatically
+    if (SDL_Name != "omp" && SDL_Name != "cudart" && SDL_Name != "m") {
       bool inSDL_Names = false;
       for (std::string OldName : SDL_Names) {
         if (OldName == SDL_Name)


### PR DESCRIPTION
…ation. If the user adds -lm to the ld flags, this will avoid a double inclusion of the device lib (libm-amdgcn-gfxXXX) during the clang-build-select-link step and allow for the -lm flag to be added for the ld step of C compilation. Note: -lm on the ld link step is added by default with clang++.

This will fix 4 openmpapps that currently will not link.