### PR TITLE
Simplify macro controlling debug printing for malloc/free

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
@@ -63,17 +63,17 @@ public:
     // Free any memory allocated for outlined parallel function with a large
     // number of arguments.
     if (nArgs > MAX_SHARED_ARGS) {
-      _SAFEFREE(args, (char *)"new extended args");
+      SafeFree(args, "new extended args");
       Init();
     }
   }
   INLINE void EnsureSize(size_t size) {
     if (size > nArgs) {
       if (nArgs > MAX_SHARED_ARGS) {
-        _SAFEFREE(args, (char *)"new extended args");
+        SafeFree(args, "new extended args");
       }
-      args = (void **)_SAFEMALLOC(size * sizeof(void *),
-                                  (char *)"new extended args");
+      args = (void **)SafeMalloc(size * sizeof(void *),
+                                "new extended args");
       nArgs = size;
     }
   }

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/support.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/support.cu
@@ -259,13 +259,17 @@ DEVICE unsigned long PadBytes(unsigned long size,
 DEVICE void *SafeMalloc(size_t size, const char *msg) // check if success
 {
   void *ptr = malloc(size);
-  PRINT(LD_MEM, "malloc data of size %llu for %s: 0x%llx\n",
+#if OMPTARGET_NVPTX_DEBUG || !defined(__AMDGCN__)
+    PRINT(LD_MEM, "malloc data of size %llu for %s: 0x%llx\n",
         (unsigned long long)size, msg, (unsigned long long)ptr);
+#endif
   return ptr;
 }
 
 DEVICE void *SafeFree(void *ptr, const char *msg) {
+#if OMPTARGET_NVPTX_DEBUG || !defined(__AMDGCN__)
   PRINT(LD_MEM, "free data ptr 0x%llx for %s\n", (unsigned long long)ptr, msg);
+#endif
   free(ptr);
   return NULL;
 }

--- a/openmp/libomptarget/deviceRTLs/common/debug.h
+++ b/openmp/libomptarget/deviceRTLs/common/debug.h
@@ -118,13 +118,9 @@
 
 #if OMPTARGET_NVPTX_DEBUG
 #define OMPTARGET_NVPTX_WARNING (LT_SET_SAFETY)
-#define _SAFEMALLOC(_size, _msg) SafeMalloc(_size, _msg)
-#define _SAFEFREE(_ptr, _msg) SafeFree(_ptr, _msg)
 #else
 #undef OMPTARGET_NVPTX_WARNING
 #undef OMPTARGET_NVPTX_TEST
-#define _SAFEMALLOC(_size, _msg) malloc(_size)
-#define _SAFEFREE(_ptr, _msg) free(_ptr)
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Simplify macro controlling debug printing for malloc/free

Moves the control over printing from the debug.h header + macros into equivalent macros within the SafeMalloc/SafeFree implementation. No behaviour change.

The patch relative to upstream is now localised to support.cu.