### PR TITLE
Refactor cuda_shim

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/cuda_shim.ll
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/cuda_shim.ll
@@ -1,97 +1,19 @@
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5"
 target triple = "amdgcn-amd-amdhsa"
 
-declare i64 @__ockl_get_local_size(i32) #0
-declare i64 @__ockl_get_num_groups(i32) #0
-declare i32 @llvm.amdgcn.workitem.id.x() #1
-declare i32 @llvm.amdgcn.workgroup.id.x() #1
-declare i32 @llvm.amdgcn.workitem.id.y() #1
-declare i32 @llvm.amdgcn.workgroup.id.y() #1
-declare i32 @llvm.amdgcn.workitem.id.z() #1
-declare i32 @llvm.amdgcn.workgroup.id.z() #1
-
-define void @__nvvm_membar_gl() #2 {
+define void @__threadfence() #0 {
   fence syncscope("agent") seq_cst
   ret void
 }
 
-define void @__nvvm_membar_cta() #2 {
+define void @__threadfence_block() #0 {
   fence syncscope("workgroup") seq_cst
   ret void
 }
 
-define void @__nvvm_membar_sys() #2 {
+define void @__threadfence_system() #0 {
   fence seq_cst
   ret void
 }
 
-define i32 @__nvvm_read_ptx_sreg_tid_x() #2 {
-  %id.i = tail call i32 @llvm.amdgcn.workitem.id.x() #3
-  ret i32 %id.i
-}
-
-define i32 @__nvvm_read_ptx_sreg_tid_y() #2 {
-  %id.i = tail call i32 @llvm.amdgcn.workitem.id.y() #3
-  ret i32 %id.i
-}
-
-define i32 @__nvvm_read_ptx_sreg_tid_z() #2 {
-  %id.i = tail call i32 @llvm.amdgcn.workitem.id.z() #3
-  ret i32 %id.i
-}
-
-define i32 @__nvvm_read_ptx_sreg_ctaid_x() #2 {
-  %id.i = tail call i32 @llvm.amdgcn.workgroup.id.x() #3
-  ret i32 %id.i
-}
-
-define i32 @__nvvm_read_ptx_sreg_ctaid_y() #2 {
-  %id.i = tail call i32 @llvm.amdgcn.workgroup.id.y() #3
-  ret i32 %id.i
-}
-
-define i32 @__nvvm_read_ptx_sreg_ctaid_z() #2 {
-  %id.i = tail call i32 @llvm.amdgcn.workgroup.id.z() #3
-  ret i32 %id.i
-}
-
-define i32 @__nvvm_read_ptx_sreg_ntid_x() #2 {
-  %call.i = tail call i64 @__ockl_get_local_size(i32 0) #0
-  %1 = trunc i64 %call.i to i32
-  ret i32 %1
-}
-
-define i32 @__nvvm_read_ptx_sreg_ntid_y() #2 {
-  %call.i = tail call i64 @__ockl_get_local_size(i32 1) #0
-  %1 = trunc i64 %call.i to i32
-  ret i32 %1
-}
-
-define i32 @__nvvm_read_ptx_sreg_ntid_z() #2 {
-  %call.i = tail call i64 @__ockl_get_local_size(i32 2) #0
-  %1 = trunc i64 %call.i to i32
-  ret i32 %1
-}
-
-define i32 @__nvvm_read_ptx_sreg_nctaid_x() #2 {
-  %call.i = tail call i64 @__ockl_get_num_groups(i32 0) #0
-  %1 = trunc i64 %call.i to i32
-  ret i32 %1
-}
-
-define i32 @__nvvm_read_ptx_sreg_nctaid_y() #2 {
-  %call.i = tail call i64 @__ockl_get_num_groups(i32 1) #0
-  %1 = trunc i64 %call.i to i32
-  ret i32 %1
-}
-
-define i32 @__nvvm_read_ptx_sreg_nctaid_z() #2 {
-  %call.i = tail call i64 @__ockl_get_num_groups(i32 2) #0
-  %1 = trunc i64 %call.i to i32
-  ret i32 %1
-}
-
-attributes #0 = { alwaysinline nounwind readnone }
-attributes #1 = { nounwind readnone speculatable }
-attributes #2 = { alwaysinline }
-attributes #3 = { nounwind }
+attributes #0 = { alwaysinline }

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/memoryheap.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/memoryheap.cu
@@ -25,7 +25,6 @@
 #define SIZE_OF_HEAP SIZE_MALLOC
 
 #ifndef nullptr
-//#define nullptr((void *)0)
 #define nullptr 0
 #endif
 
@@ -34,16 +33,12 @@
 #define hipBlockDim_z blockDim.z
 
 #define hipBlockIdx_x blockIdx.x
-#define hipBlockIdx_y blockIdx.y
-#define hipBlockIdx_z blockIdx.z
 
 #define hipGridDim_x gridDim.x
 #define hipGridDim_y gridDim.y
 #define hipGridDim_z gridDim.z
 
 #define hipThreadIdx_x threadIdx.x
-#define hipThreadIdx_y threadIdx.y
-#define hipThreadIdx_z threadIdx.z
 
 __device__ char gpuHeap[SIZE_OF_HEAP];
 __device__ uint32_t gpuFlags[NUM_PAGES];

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/reduction.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/reduction.cu
@@ -537,23 +537,14 @@ EXTERN int32_t __kmpc_nvptx_teams_reduce_nowait_v2(
   //         by returning 1 in the thread holding the reduction result.
 
   // Check if this is the very last team.
-#ifdef __AMDGCN__
-  unsigned NumRecs = (NumTeams<num_of_records) ? NumTeams : num_of_records;
-#else  
   unsigned NumRecs = min(NumTeams, num_of_records);
-#endif
-  
   if (ChunkTeamCount == NumTeams - Bound - 1) {
     //
     // Last team processing.
     //
     if (ThreadId >= NumRecs)
       return 0;
-#ifdef __AMDGCN__
-    NumThreads = roundToWarpsize((NumThreads < NumRecs) ? NumThreads : NumRecs);
-#else
     NumThreads = roundToWarpsize(min(NumThreads, NumRecs));
-#endif
     if (ThreadId >= NumThreads)
       return 0;
 
@@ -568,11 +559,7 @@ EXTERN int32_t __kmpc_nvptx_teams_reduce_nowait_v2(
 
       // When we have more than [warpsize] number of threads
       // a block reduction is performed here.
-#ifdef __AMDGCN__
-      uint32_t ActiveThreads = (NumRecs<NumThreads) ? NumRecs : NumThreads;
-#else      
       uint32_t ActiveThreads = min(NumRecs, NumThreads);
-#endif
       if (ActiveThreads > WARPSIZE) {
         uint32_t WarpsNeeded = (ActiveThreads + WARPSIZE - 1) / WARPSIZE;
         // Gather all the reduced values from each warp

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
@@ -43,7 +43,6 @@
 
 #define WARPSIZE 64
 
-
 // The named barrier for active parallel threads of a team in an L1 parallel
 // region to synchronize with each other.
 #define L1_BARRIER (1)
@@ -81,8 +80,6 @@ EXTERN uint64_t __lanemask_lt();
 // thread's lane number in the warp
 EXTERN uint64_t __lanemask_gt();
 
-EXTERN void llvm_amdgcn_s_barrier();
-
 // CU id
 EXTERN unsigned __smid();
 
@@ -113,9 +110,9 @@ INLINE uint32_t __kmpc_impl_smid() {
   return __smid();
 }
 
-INLINE uint64_t __kmpc_impl_ffs(uint64_t x) { return __ffsll(x); }
+INLINE uint64_t __kmpc_impl_ffs(uint64_t x) { return __builtin_ffsl(x); }
 
-INLINE uint64_t __kmpc_impl_popc(uint64_t x) { return __popcll(x); }
+INLINE uint64_t __kmpc_impl_popc(uint64_t x) { return __builtin_popcountl(x); }
 
 INLINE __kmpc_impl_lanemask_t __kmpc_impl_activemask() {
   return __ballot64(1);
@@ -131,7 +128,7 @@ INLINE int32_t __kmpc_impl_shfl_down_sync(__kmpc_impl_lanemask_t, int32_t Var,
   return __shfl_down(Var, Delta, Width);
 }
 
-INLINE void __kmpc_impl_syncthreads() { llvm_amdgcn_s_barrier(); }
+INLINE void __kmpc_impl_syncthreads() { __builtin_amdgcn_s_barrier(); }
 
 INLINE void __kmpc_impl_syncwarp(__kmpc_impl_lanemask_t) {
   // AMDGCN doesn't need to sync threads in a warp


### PR DESCRIPTION
Refactor cuda_shim

Inline or delete the `__nvvm` prefixed functions in cuda shim. Delete unused functions.

Adds a couple of overloads for integer min to remove #ifdef from reduction.cu

Use `__builtin_ffsl` and `__builtin_popcount`, which ultimately generate equivalent code to that from the indirection through aomp-extras and ockl.
