### PR TITLE
Revert "Localise malloc override, update whitespace to match upstream"

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/omptarget-nvptx.h
@@ -39,12 +39,24 @@
 #define BARRIER_COUNTER 0
 #define ORDERED_COUNTER 1
 
+// Macros for Cuda intrinsics
+// In Cuda 9.0, the *_sync() version takes an extra argument 'mask'.
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+#define __SHFL_SYNC(mask, var, srcLane) __shfl_sync((mask), (var), (srcLane))
+#else
+#ifdef __AMDGCN__
+#define __SHFL_SYNC(mask, var, srcLane) __shfl((var), (srcLane), WARPSIZE)
+#else
+#define __SHFL_SYNC(mask, var, srcLane) __shfl((var), (srcLane))
+#endif
+#endif
+
 // arguments needed for L0 parallelism only.
 class omptarget_nvptx_SharedArgs {
 public:
   // All these methods must be called by the master thread only.
   INLINE void Init() {
-    args  = buffer;
+    args = buffer;
     nArgs = MAX_SHARED_ARGS;
   }
   INLINE void DeInit() {
@@ -60,7 +72,8 @@ public:
       if (nArgs > MAX_SHARED_ARGS) {
         SafeFree(args, "new extended args");
       }
-      args = (void **)SafeMalloc(size * sizeof(void *), "new extended args");
+      args = (void **)SafeMalloc(size * sizeof(void *),
+                                "new extended args");
       nArgs = size;
     }
   }

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/parallel.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/parallel.cu
@@ -413,7 +413,7 @@ EXTERN void __kmpc_end_serialized_parallel(kmp_Ident *loc,
   omptarget_nvptx_threadPrivateContext->SetTopLevelTaskDescr(
       threadId, currTaskDescr->GetPrevTaskDescr());
   // free
-  SafeFree(currTaskDescr, "new seq parallel task");
+  SafeFree(currTaskDescr, (char *)"new seq parallel task");
   currTaskDescr = getMyTopTaskDescriptor(threadId);
   currTaskDescr->RestoreLoopData();
 }

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/support.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/support.cu
@@ -247,25 +247,6 @@ DEVICE int GetNumberOfProcsInTeam(bool isSPMDExecutionMode) {
 // Memory
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef __AMDGCN__
-
-// memory allocation
-EXTERN void *__malloc(size_t);
-EXTERN void __free(void *);
-
-#ifdef malloc
-#undef malloc
-#endif
-#define malloc __malloc
-
-#ifdef free
-#undef free
-#endif
-#define free __free
-
-// end if AMDGCN
-#endif 
-
 DEVICE unsigned long PadBytes(unsigned long size,
                               unsigned long alignment) // must be a power of 2
 {

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/support.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/support.h
@@ -19,6 +19,25 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Execution Parameters
 ////////////////////////////////////////////////////////////////////////////////
+#ifdef __AMDGCN__
+
+// memory allocation
+EXTERN void *__malloc(size_t);
+EXTERN void __free(void *);
+
+#ifdef malloc
+#undef malloc
+#endif
+#define malloc __malloc
+
+#ifdef free
+#undef free
+#endif
+#define free __free
+
+// end if AMDGCN
+#endif 
+
 enum ExecutionMode {
   Spmd = 0x00u,
   Generic = 0x01u,


### PR DESCRIPTION
This reverts commit 9580c0d807d0514e248fa75c6b82c6ccbb7e8b5a.

needed to fix failing tests in smoke where malloc free are unresolved.

this will unblock smoke, and allow Jon or someone to work on it later.
