### PR TITLE
Update libcall to use target_impl functions, fix return type of __clock64

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/cuda_shim.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/cuda_shim.h
@@ -45,11 +45,11 @@ __OVERL__ int __shfl_down(int a, unsigned int b, int c);
 __OVERL__
 int __shfl(int var, int src_lane, int width = warpSize);
 
-__device__ static long long __clock64(void) {
+__device__ static uint64_t __clock64(void) {
 #if __AMDGCN__ > 800
   return __builtin_amdgcn_s_memrealtime();
 #else
-  __device__ long long __llvm_amdgcn_s_memrealtime(void);
+  __device__ uint64_t __llvm_amdgcn_s_memrealtime(void);
   return __llvm_amdgcn_s_memrealtime();
 #endif
 }

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
@@ -116,6 +116,12 @@ INLINE uint32_t __kmpc_impl_smid() {
   return __smid();
 }
 
+INLINE double __target_impl_get_wtick() { return ((double)1E-9); }
+
+INLINE double __target_impl_get_wtime() {
+  return ((double)1.0 / 745000000.0) * __clock64();
+}
+
 INLINE uint64_t __kmpc_impl_ffs(uint64_t x) { return __builtin_ffsl(x); }
 
 INLINE uint64_t __kmpc_impl_popc(uint64_t x) { return __builtin_popcountl(x); }

--- a/openmp/libomptarget/deviceRTLs/common/src/libcall.cu
+++ b/openmp/libomptarget/deviceRTLs/common/src/libcall.cu
@@ -1,4 +1,4 @@
-//===------------ libcall.cu - NVPTX OpenMP user calls ----------- CUDA -*-===//
+//===------------ libcall.cu - OpenMP GPU user calls ------------- CUDA -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -17,22 +17,14 @@
 
 #include <time.h>
 
-// Timer precision is 1ns
-#define TIMER_PRECISION ((double)1E-9)
-
 EXTERN double omp_get_wtick(void) {
-  PRINT(LD_IO, "omp_get_wtick() returns %g\n", TIMER_PRECISION);
-  return TIMER_PRECISION;
+  double rc = __target_impl_get_wtick();
+  PRINT(LD_IO, "omp_get_wtick() returns %g\n", rc);
+  return rc;
 }
 
 EXTERN double omp_get_wtime(void) {
-#ifdef __AMDGCN__
-  double rc = ((double)1.0 / 745000000.0) * __clock64();
-#else
-  unsigned long long nsecs;
-  asm("mov.u64  %0, %%globaltimer;" : "=l"(nsecs));
-  double rc = (double)nsecs * TIMER_PRECISION;
-#endif
+  double rc = __target_impl_get_wtime();
   PRINT(LD_IO, "call omp_get_wtime() returns %g\n", rc);
   return rc;
 }


### PR DESCRIPTION
Upstream D71584, plus fix a missing unsigned on clock64 (based on aomp-extras clock.cl)