### PR TITLE
Implement lanemask_xt, activemask. Start of a standalone deviceRTL

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
@@ -1,4 +1,4 @@
-//===------------ target_impl.hip - AMDGCN OpenMP GPU options ------ HIP -*-===//
+//===------------ target_impl.hip - AMDGCN OpenMP GPU options ----- HIP -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,30 +12,36 @@
 
 #include "target_impl.h"
 
+// Implementations initially derived from hip/hcc_detail/device_functions.h
+
 // warp vote function
-EXTERN uint64_t __ballot64(int predicate);
+DEVICE __kmpc_impl_lanemask_t __kmpc_impl_activemask() {
+  // 33 is ICMP_NE from llvm/include/llvm/IR/InstrTypes.h
+  return __builtin_amdgcn_uicmp(1, 0, 33);
+}
+
+EXTERN uint32_t __ockl_lane_u32(void);
+
 // initialized with a 64-bit mask with bits set in positions less than the
 // thread's lane number in the warp
-EXTERN uint64_t __lanemask_lt();
+DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_lt() {
+  uint32_t lane = __ockl_lane_u32();
+  int64_t ballot = __kmpc_impl_activemask();
+  uint64_t mask = ((uint64_t)1 << lane) - (uint64_t)1;
+  return mask & ballot;
+}
+
 // initialized with a 64-bit mask with bits set in positions greater than the
 // thread's lane number in the warp
-EXTERN uint64_t __lanemask_gt();
+DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_gt() {
+  uint32_t lane = __ockl_lane_u32();
+  if (lane == 63)
+    return 0;
+  uint64_t ballot = __kmpc_impl_activemask();
+  uint64_t mask = (~((uint64_t)0)) << (lane + 1);
+  return mask & ballot;
+}
 
 // CU id
 EXTERN unsigned __smid();
-
-DEVICE __kmpc_impl_lanemask_t __kmpc_impl_activemask() {
-  return __ballot64(1);
-}
-
-DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_lt() {
-  return __lanemask_lt();
-}
-
-DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_gt() {
-  return __lanemask_gt();
-}
-
-DEVICE uint32_t __kmpc_impl_smid() {
-  return __smid();
-}
+DEVICE uint32_t __kmpc_impl_smid() { return __smid(); }


### PR DESCRIPTION
Implements a few functions used by target_impl. Before this patch, they call through into IR in aomp-extras. After this patch, they depend on ockl directly.

I have a local prototype of deviceRTL building without any dependencies other than the clang hip compiler. This patch is broadly representative - functions are ported to hip where necessary and added to the deviceRTL library with care taken to avoid potential symbol collisions with the device runtime libraries.

The motivation is to simplify the upstreaming story. The deviceRTL then becomes some standalone bitcode that gets linked in to make OpenMP target offloading work, where users only need to worry about finding other runtime libraries if they want to call functions from them.