### PR TITLE
[nfc] Factor locks out of libcall.cu, into target specific source

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_interface.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_interface.h
@@ -14,6 +14,7 @@
 
 #define EXTERN extern "C" __attribute__((device))
 typedef uint64_t __kmpc_impl_lanemask_t;
+typedef uint32_t omp_lock_t; /* arbitrary type of the right length */
 
 ////////////////////////////////////////////////////////////////////////////////
 // OpenMP interface

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_locks.hip
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_locks.hip
@@ -1,0 +1,56 @@
+//===-- amdgcn_locks.hip - AMDGCN OpenMP GPU lock implementation -- HIP -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions of openmp lock functions
+// Warning: Derived from nvptx, suspected to deadlock on amdgcn: aomp/issues/50
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/debug.h"
+#include "common/target_atomic.h"
+#include "target_impl.h"
+
+#define __OMP_SPIN 1000
+#define UNSET 0u
+#define SET 1u
+
+DEVICE void __kmpc_impl_init_lock(omp_lock_t *lock) {
+  __kmpc_impl_unset_lock(lock);
+}
+
+DEVICE void __kmpc_impl_destroy_lock(omp_lock_t *lock) {
+  __kmpc_impl_unset_lock(lock);
+}
+
+DEVICE void __kmpc_impl_set_lock(omp_lock_t *lock) {
+  // int atomicCAS(int* address, int compare, int val);
+  // (old == compare ? val : old)
+
+  // TODO: not sure spinning is a good idea here..
+  while (__kmpc_atomic_cas(lock, UNSET, SET) != UNSET) {
+    uint64_t start = __clock64();
+    uint64_t now;
+    for (;;) {
+      now = __clock64();
+      uint64_t cycles = now > start ? now - start : now + (0xffffffff - start);
+      if (cycles >= __OMP_SPIN * GetBlockIdInKernel()) {
+        break;
+      }
+    }
+  } // wait for 0 to be the read value
+}
+
+DEVICE void __kmpc_impl_unset_lock(omp_lock_t *lock) {
+  (void)__kmpc_atomic_exchange(lock, UNSET);
+}
+
+DEVICE int __kmpc_impl_test_lock(omp_lock_t *lock) {
+  // int atomicCAS(int* address, int compare, int val);
+  // (old == compare ? val : old)
+  return __kmpc_atomic_add(lock, 0u);
+}

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
@@ -146,6 +146,13 @@ INLINE int GetBlockIdInKernel() { return __builtin_amdgcn_workgroup_id_x(); }
 INLINE int GetNumberOfBlocksInKernel() { return __ockl_get_num_groups(0); }
 INLINE int GetNumberOfThreadsInBlock() { return __ockl_get_local_size(0); }
 
+// Locks
+DEVICE void __kmpc_impl_init_lock(omp_lock_t *lock);
+DEVICE void __kmpc_impl_destroy_lock(omp_lock_t *lock);
+DEVICE void __kmpc_impl_set_lock(omp_lock_t *lock);
+DEVICE void __kmpc_impl_unset_lock(omp_lock_t *lock);
+DEVICE int __kmpc_impl_test_lock(omp_lock_t *lock);
+
 // Memory
 EXTERN void *__kmpc_impl_malloc(size_t x);
 EXTERN void __kmpc_impl_free(void *x);

--- a/openmp/libomptarget/deviceRTLs/interface.h
+++ b/openmp/libomptarget/deviceRTLs/interface.h
@@ -30,7 +30,6 @@
 // OpenMP interface
 ////////////////////////////////////////////////////////////////////////////////
 
-typedef uint32_t omp_lock_t;      /* arbitrary type of the right length */
 typedef uint64_t omp_nest_lock_t; /* arbitrary type of the right length */
 
 typedef enum omp_sched_t {


### PR DESCRIPTION
Part of reducing the difference between aomp's common subdir and upstream, specifically libcall.cu.

Drops the clock_t type in favour of uint64_t. Corresponds relatively closely to upstream target_impl.cu.