### PR TITLE
[nfc] Import first_active interface from upstream

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
@@ -146,6 +146,8 @@ INLINE int GetBlockIdInKernel() { return __builtin_amdgcn_workgroup_id_x(); }
 INLINE int GetNumberOfBlocksInKernel() { return __ockl_get_num_groups(0); }
 INLINE int GetNumberOfThreadsInBlock() { return __ockl_get_local_size(0); }
 
+DEVICE bool __kmpc_impl_is_first_active_thread();
+
 // Locks
 DEVICE void __kmpc_impl_init_lock(omp_lock_t *lock);
 DEVICE void __kmpc_impl_destroy_lock(omp_lock_t *lock);

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
@@ -42,6 +42,23 @@ DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_gt() {
   return mask & ballot;
 }
 
+DEVICE bool __kmpc_impl_is_first_active_thread() {
+  __kmpc_impl_lanemask_t Mask = __kmpc_impl_activemask();
+  unsigned tid = GetThreadIdInBlock();
+  unsigned laneid = (tid & 0X3F);
+  int64_t Sh;
+  unsigned Shnum;
+  if (laneid < 32) {
+    Mask = Mask << 32;
+    Shnum = 32 - laneid;
+  } else {
+    Shnum = 64 - laneid;
+  }
+  Sh = Mask << Shnum;
+  //  unsigned popret = __popcll(Sh);
+  return (Sh == (unsigned long long)0);
+}
+
 // CU id
 EXTERN unsigned __smid();
 DEVICE uint32_t __kmpc_impl_smid() { return __smid(); }


### PR DESCRIPTION
Replaced threadIdx.x with the corresponding target_impl call. Otherwise left the code unchanged.