### PR TITLE
Implement atomic_inc in IR. Fixes aomp/issues/72

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/atomic_inc.ll
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/atomic_inc.ll
@@ -1,0 +1,19 @@
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5"
+target triple = "amdgcn-amd-amdhsa"
+
+declare i32 @llvm.amdgcn.atomic.inc.i32.p0i32(i32* nocapture, i32, i32, i32, i1) #1
+
+; Function Attrs: alwaysinline nounwind
+define i32 @__amdgcn_atomic_inc_i32(i32* %x, i32 %v) #0 {
+entry:
+
+  %ret = call i32 @llvm.amdgcn.atomic.inc.i32.p0i32(i32* %x, i32 %v,
+  i32 5, ; Ordering. AtomicOrdering.h: sequentially consistent
+  i32 2, ; Scope. SyncScope.h:  OpenCLAllSVMDevices is 2
+  i1 1 ; Volatile.  True for consistency with other atomic operations
+  )
+  ret i32 %ret
+}
+
+attributes #0 = { alwaysinline nounwind }
+attributes #1 = { nounwind argmemonly }

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/hip_atomics.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/hip_atomics.h
@@ -17,12 +17,10 @@ template <typename T> DEVICE T atomicAdd(volatile T *x, T v) {
   return __atomic_fetch_add(x, v, __ATOMIC_SEQ_CST);
 }
 
-template <typename T> DEVICE T atomicInc(T *x, T v) {
-  if (*x >= v) {
-    return *x;
-  } else {
-    return __atomic_fetch_add((volatile T *)x, 1, __ATOMIC_SEQ_CST);
-  }
+// Only implemented for i32 as that's the only call site
+EXTERN uint32_t __amdgcn_atomic_inc_i32(uint32_t *, uint32_t);
+INLINE uint32_t atomicInc(uint32_t *address, uint32_t val) {
+  return __amdgcn_atomic_inc_i32(address, val);
 }
 
 template <typename T> DEVICE T atomicMax(volatile T *address, T val) {


### PR DESCRIPTION
The existing atomicInc is missing a write of zero when the value overflows and does not execute atomically. deviceRTL has a single use of this function, acting on unsigned.

The ISA support is exposed as an IR intrinsic but not as a clang intrinsic. The memory ordering and scope values are chosen for consistency with the other functions in hip_atomics.h (and consistency with the previously used hc_atomic.ll).

Encoding as immediate values is unfortunate. The better fix will be to implement the clang intrinsic and then use that. This is an expedient workaround.