### PR TITLE
Jc cpp rtl

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/CMakeLists.txt
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/CMakeLists.txt
@@ -79,20 +79,21 @@ endif()
 separate_arguments(mcpus)
 
 macro(add_cuda_bc_library)
-  set(cu_cmd ${AOMP_BINDIR}/clang++
-    -std=c++11
-    -fcuda-rdc
-    -fvisibility=default
-    --cuda-device-only
-    -Wno-unused-value
-    -x hip
-    -O${optimization_level}
-    --cuda-gpu-arch=${mcpu}
-    ${CUDA_DEBUG}
-    -I${CMAKE_CURRENT_SOURCE_DIR}/src
-    -I${devicertl_base_directory})
+set(cu_cmd ${AOMP_BINDIR}/clang++
+  -std=c++11
+  -fvisibility=default
+  -emit-llvm -c
+  -Wno-unused-value
+  -x c++
+  -ffreestanding --target=amdgcn-amd-amdhsa
+  -O${optimization_level}
+  -march=${mcpu}
+  ${CUDA_DEBUG}
+  -I${CMAKE_CURRENT_SOURCE_DIR}/src
+  -I${devicertl_base_directory})
 
-  set(bc1_files)
+
+set(bc1_files)
 
   foreach(file ${ARGN})
     get_filename_component(fname ${file} NAME_WE)

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_interface.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_interface.h
@@ -12,7 +12,11 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef __HIP__
 #define EXTERN extern "C" __attribute__((device))
+#else
+#define EXTERN extern "C"
+#endif
 typedef uint64_t __kmpc_impl_lanemask_t;
 typedef uint32_t omp_lock_t; /* arbitrary type of the right length */
 

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/memoryheap.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/memoryheap.cu
@@ -13,7 +13,6 @@
 
 #include "common/omptarget.h"
 #include "amdgcn_access_dimensions.h"
-#include <stdio.h>
 
 #ifdef __AMDGCN__
 

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.h
@@ -35,7 +35,8 @@
 #define SHARED __attribute__((shared))
 #else
 #define DEVICE
-#define SHARED //__attribute__((address_space(3)))
+// This doesn't work - need front end support
+#define SHARED __attribute__((address_space(3)))
 #endif
 
 #define INLINE inline DEVICE

--- a/openmp/libomptarget/deviceRTLs/common/debug.h
+++ b/openmp/libomptarget/deviceRTLs/common/debug.h
@@ -128,7 +128,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #if OMPTARGET_NVPTX_DEBUG || OMPTARGET_NVPTX_TEST || OMPTARGET_NVPTX_WARNING
-#include <stdio.h>
 #include "common/support.h"
 
 template <typename... Arguments>
@@ -139,7 +138,7 @@ NOINLINE static void log(const char *fmt, Arguments... parameters) {
 
 #endif
 #if OMPTARGET_NVPTX_TEST
-#include <assert.h>
+#include "common/support.h"
 
 template <typename... Arguments>
 NOINLINE static void check(bool cond, const char *fmt,

--- a/openmp/libomptarget/deviceRTLs/common/omptarget.h
+++ b/openmp/libomptarget/deviceRTLs/common/omptarget.h
@@ -14,11 +14,6 @@
 #ifndef OMPTARGET_H
 #define OMPTARGET_H
 
-// std includes
-#include <inttypes.h>
-#include <math.h>
-
-// local includes
 #include "target_impl.h"
 #include "common/debug.h"     // debug
 #include "interface.h" // interfaces with omp, compiler, and user

--- a/openmp/libomptarget/deviceRTLs/common/src/data_sharing.cu
+++ b/openmp/libomptarget/deviceRTLs/common/src/data_sharing.cu
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 #include "common/omptarget.h"
 #include "target_impl.h"
-#include <stdio.h>
 
 // Set the print format for active threads
 #ifdef __AMDGCN__


### PR DESCRIPTION
Does not build as:
- structs in address_space(3) cannot be initialized (front end error)
- assignment between variables in address_space(3) doesn't work (also front end error)

I suspect declaring the variables in openmp would fix this. Can also work around with IR.

Not production ready code, more a proof of concept sketch.