### PR TITLE
ATMI Hostcall Optimization

### DIFF
--- a/openmp/libomptarget/plugins/hsa/CMakeLists.txt
+++ b/openmp/libomptarget/plugins/hsa/CMakeLists.txt
@@ -151,7 +151,7 @@ install(TARGETS omptarget.rtl.hsa LIBRARY DESTINATION "lib${OPENMP_LIBDIR_SUFFIX
 # Also, the AOMP specific build of ATMI has seperate release and debug builds. 
 target_link_libraries(
   omptarget.rtl.hsa
-  -L${AOMP_LIBDIR}${OPENMP_LIBDIR_SUFFIX} -latmi_runtime -Wl,-rpath,${AOMP_LIBDIR}${OPENMP_LIBDIR_SUFFIX}
+  -L${AOMP_LIBDIR}${OPENMP_LIBDIR_SUFFIX} -lamd_hostcall -latmi_runtime -Wl,-rpath,${AOMP_LIBDIR}${OPENMP_LIBDIR_SUFFIX}
   -L${LIBOMPTARGET_DEP_LIBHSA_LIBRARIES_DIRS} -L${LIBOMPTARGET_DEP_LIBHSAKMT_LIBRARIES_DIRS} -lhsa-runtime64 -lhsakmt  -Wl,-rpath,${LIBOMPTARGET_DEP_LIBHSA_LIBRARIES_DIRS},-rpath,${LIBOMPTARGET_DEP_LIBHSAKMT_LIBRARIES_DIRS}
   -L${AOMP_LIBDIR} -lLLVMAMDGPUDesc -lLLVMAMDGPUUtils -lLLVMMC -lLLVMCore -lLLVMSupport -Wl,-rpath,${AOMP_LIBDIR}
   -lelf

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -29,6 +29,8 @@
 // Header from ATMI interface
 #include "atmi_interop_hsa.h"
 #include "atmi_runtime.h"
+// Header from hostcall
+#include "amd_hostcall.h"
 
 #include "omptargetplugin.h"
 
@@ -244,12 +246,14 @@ public:
       print_kernel_trace = 0;
 
     DP("Start initializing HSA-ATMI\n");
-
     atmi_status_t err = atmi_init(ATMI_DEVTYPE_GPU);
     if (err != ATMI_STATUS_SUCCESS) {
       DP("Error when initializing HSA-ATMI\n");
       return;
     }
+    // Init hostcall soon after initializing ATMI
+    atmi_hostcall_init();
+
     atmi_machine_t *machine = atmi_machine_get_info();
     NumberOfiGPUs = machine->device_count_by_type[ATMI_DEVTYPE_iGPU];
     NumberOfdGPUs = machine->device_count_by_type[ATMI_DEVTYPE_dGPU];
@@ -330,6 +334,8 @@ public:
 
   ~RTLDeviceInfoTy() {
     DP("Finalizing the HSA-ATMI DeviceInfo.\n");
+    // Terminate hostcall before finalizing ATMI
+    atmi_hostcall_terminate();
     atmi_finalize();
   }
 };


### PR DESCRIPTION
[ATMI Hostcall] libomptarget to depend on libamd_hostcall and ATMI, and libamd_hostcall depends on ATMI. The libamd_hostcall library will
make the necessary ATMI API calls to register task callbacks
as necessary.