### PR TITLE
Invert ExecutionMode enum to match upstream

### DIFF
--- a/openmp/libomptarget/deviceRTLs/common/support.h
+++ b/openmp/libomptarget/deviceRTLs/common/support.h
@@ -20,8 +20,8 @@
 // Execution Parameters
 ////////////////////////////////////////////////////////////////////////////////
 enum ExecutionMode {
-  Spmd = 0x00u,
-  Generic = 0x01u,
+  Generic = 0x00u,
+  Spmd = 0x01u,
   ModeMask = 0x01u,
 };
 


### PR DESCRIPTION
AOMP and upstream have different values for spmd and generic in this enum.

Tests pass for me with the values changed, which seems suspicious. I can't find a reason why our values should be different from trunk. However, this change looks like it should break things, so perhaps test coverage is insufficient to show the problem.

Thoughts?