### PR TITLE
Fix deadlock in omp_lock

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_locks.hip
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/amdgcn_locks.hip
@@ -7,15 +7,18 @@
 //===----------------------------------------------------------------------===//
 //
 // Definitions of openmp lock functions
-// Warning: Derived from nvptx, suspected to deadlock on amdgcn: aomp/issues/50
+// A 'thread' maps onto a lane of the wavefront. This means a per-thread lock
+// cannot be implemented - if one thread gets the lock, it can't continue on to
+// the next instruction in order to do anything as the other threads are waiting
+// to take the lock
+// The closest approximatation we can implement is to lock per-wavefront.
 //
 //===----------------------------------------------------------------------===//
 
-#include "common/debug.h"
+#include "common/support.h"
 #include "common/target_atomic.h"
 #include "target_impl.h"
 
-#define __OMP_SPIN 1000
 #define UNSET 0u
 #define SET 1u
 
@@ -28,29 +31,21 @@ DEVICE void __kmpc_impl_destroy_lock(omp_lock_t *lock) {
 }
 
 DEVICE void __kmpc_impl_set_lock(omp_lock_t *lock) {
-  // int atomicCAS(int* address, int compare, int val);
-  // (old == compare ? val : old)
-
-  // TODO: not sure spinning is a good idea here..
-  while (__kmpc_atomic_cas(lock, UNSET, SET) != UNSET) {
-    uint64_t start = __clock64();
-    uint64_t now;
-    for (;;) {
-      now = __clock64();
-      uint64_t cycles = now > start ? now - start : now + (0xffffffff - start);
-      if (cycles >= __OMP_SPIN * GetBlockIdInKernel()) {
-        break;
-      }
+  uint64_t lowestActiveThread = __kmpc_impl_ffs(__kmpc_impl_activemask()) - 1;
+  if (GetLaneId() == lowestActiveThread) {
+    while (__kmpc_atomic_cas(lock, UNSET, SET) != UNSET) {
+      __builtin_amdgcn_s_sleep(0);
     }
-  } // wait for 0 to be the read value
+  }
+  // test_lock will now return true for any thread in the warp
 }
 
 DEVICE void __kmpc_impl_unset_lock(omp_lock_t *lock) {
+  // Could be an atomic store of UNSET
   (void)__kmpc_atomic_exchange(lock, UNSET);
 }
 
 DEVICE int __kmpc_impl_test_lock(omp_lock_t *lock) {
-  // int atomicCAS(int* address, int compare, int val);
-  // (old == compare ? val : old)
+  // Could be an atomic load
   return __kmpc_atomic_add(lock, 0u);
 }


### PR DESCRIPTION
Fixes aomp issue 50. Test case at aomp PR 81.

Implements a cas spin lock on a per-wavefront basis. This is an improvement on the current implementation which deadlocks if called with multiple active threads.

It may be viable to build a per-thread lock by rewriting the CFG when calls to these functions are identified. A try-lock mutex could be built based on returning the ID of the thread which won the cas, but these functions are specified to return void.