### PR TITLE
prefer clang intrinsics to opencl, following upstream D73076

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/hip_atomics.h
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/hip_atomics.h
@@ -13,8 +13,8 @@
 
 namespace {
 
-template <typename T> DEVICE T atomicAdd(volatile T *x, T v) {
-  return __atomic_fetch_add(x, v, __ATOMIC_SEQ_CST);
+template <typename T> DEVICE T atomicAdd(T *address, T val) {
+  return __atomic_fetch_add(address, val, __ATOMIC_SEQ_CST);
 }
 
 // Only implemented for i32 as that's the only call site
@@ -23,23 +23,19 @@ INLINE uint32_t atomicInc(uint32_t *address, uint32_t val) {
   return __amdgcn_atomic_inc_i32(address, val);
 }
 
-template <typename T> DEVICE T atomicMax(volatile T *address, T val) {
-  return __opencl_atomic_fetch_max((_Atomic volatile T *)address, val,
-                                   __ATOMIC_SEQ_CST,
-                                   __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES);
+template <typename T> DEVICE T atomicMax(T *address, T val) {
+  return __atomic_fetch_max(address, val, __ATOMIC_SEQ_CST);
 }
 
-template <typename T> DEVICE T atomicExch(volatile T *address, T val) {
-  return __opencl_atomic_exchange((_Atomic volatile T *)address, val,
-                                  __ATOMIC_SEQ_CST,
-                                  __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES);
+template <typename T> DEVICE T atomicExch(T *address, T val) {
+  T r;
+  __atomic_exchange(address, &val, &r, __ATOMIC_SEQ_CST);
+  return r;
 }
 
-template <typename T>
-DEVICE T atomicCAS(volatile T *address, T compare, T val) {
-  (void)__opencl_atomic_compare_exchange_strong(
-      (_Atomic volatile T *)address, &compare, val, __ATOMIC_SEQ_CST,
-      __ATOMIC_RELAXED, __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES);
+template <typename T> DEVICE T atomicCAS(T *address, T compare, T val) {
+  (void)__atomic_compare_exchange(address, &compare, &val, false,
+                                  __ATOMIC_SEQ_CST, __ATOMIC_RELAXED);
   return compare;
 }
 


### PR DESCRIPTION
We can't have this yet, because the fetch_max intrinsic is not available in llvm 9 and we aren't rebased on trunk yet. Creating the PR now so I don't forget about it.