### PR TITLE
Drop temporary fix for quadratic binary loading

### DIFF
--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -621,18 +621,12 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
   }
 
   atmi_status_t err;
-  // Temporaryily adding a fix to 7 and 8 gpu cards working.
-  // This patch needs to be reverted once we have a fix as described in:
-  // https://github.com/RadeonOpenCompute/atmi-staging/issues/67
-  // https://github.com/RadeonOpenCompute/atmi-staging/issues/65
-
-  static int visited = 0;
-  if (!visited) {
+  {
     atmi_platform_type_t platform = (useBrig ? BRIG : AMDGCN);
     void *new_img = malloc(img_size);
     memcpy(new_img, image->ImageStart, img_size);
-    err = atmi_module_register_from_memory((void **)&new_img, &img_size,
-                                           &platform, 1);
+    err = atmi_module_register_from_memory_to_place(
+        (void **)&new_img, &img_size, &platform, 1, get_gpu_place(device_id));
 
     free(new_img);
     check("Module registering", err);
@@ -644,7 +638,6 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
       return NULL;
     }
     new_img = NULL;
-    visited = 1;
   }
 
   DP("ATMI module successfully loaded!\n");


### PR DESCRIPTION
ATMI now has an interface that lets one specify the gpu to load onto, so the foreach gpu within ATMI can be skipped.