### PR TITLE
Error on missing symbols in hsa plugin at link time

### DIFF
--- a/openmp/libomptarget/plugins/hsa/CMakeLists.txt
+++ b/openmp/libomptarget/plugins/hsa/CMakeLists.txt
@@ -88,6 +88,7 @@ target_link_libraries(
   -L${LLVM_LIBDIR} -lLLVMAMDGPUDesc -lLLVMAMDGPUUtils -lLLVMMC -lLLVMCore -lLLVMSupport -Wl,-rpath,${LLVM_LIBDIR}
   -lelf
   "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/../exports"
+  "-Wl,-z,defs"
   )
 
 # Report to the parent scope that we are building a plugin for hsa


### PR DESCRIPTION
At present, if one writes a function in rtl.cpp which refers to a symbol which is unresolved at link time then the plugin reports zero devices.

This is especially confusing in that the tests fail even though the new function is never called, and easily done because there is an `extern "C"` clause wrapping most of the rtl.cpp implementation which means the name mangling doesn't line up with C++ libraries.

Instead, this linker option produces a coherent error about the unresolved symbol at build time.