### PR TITLE
hip expects the __HIP__ macro to have a value in hip_texture_types.h,…

### DIFF
--- a/clang/lib/Headers/openmp_wrappers/cmath
+++ b/clang/lib/Headers/openmp_wrappers/cmath
@@ -81,7 +81,7 @@ __DEVICE__ float tgamma(float __x) { return ::tgammaf(__x); }
 #ifdef __AMDGCN__
 #pragma omp begin declare variant match(                                       \
     device = {arch(amdgcn)}, implementation = {extension(match_any, allow_templates)})
-#define __HIP__
+#define __HIP__ 1
 #define __OPENMP_AMDGCN__
 #include <__clang_hip_cmath.h>
 #undef __HIP__

--- a/clang/lib/Headers/openmp_wrappers/math.h
+++ b/clang/lib/Headers/openmp_wrappers/math.h
@@ -60,7 +60,7 @@
 #endif
 
 #ifndef __HIP__
-#define __HIP__
+#define __HIP__ 1
 #endif
 
 #include <__clang_hip_math.h>


### PR DESCRIPTION
… so give it a value of 1.  See https://github.com/ROCm-Developer-Tools/aomp/issues/174