### PR TITLE
Apply fix from aomp11 (2453e00) to resolve ambiguous max issue.

### DIFF
--- a/clang/lib/Headers/__clang_hip_math.h
+++ b/clang/lib/Headers/__clang_hip_math.h
@@ -1354,6 +1354,19 @@ __DEVICE__ int max(int __arg1, int __arg2) {
   return (__arg1 > __arg2) ? __arg1 : __arg2;
 }
 
+__DEVICE__ unsigned int min(unsigned int __arg1, unsigned int __arg2) {
+  return (__arg1 < __arg2) ? __arg1 : __arg2;
+}
+__DEVICE__ unsigned int max(unsigned int __arg1, unsigned int __arg2) {
+  return (__arg1 > __arg2) ? __arg1 : __arg2;
+}
+__DEVICE__ unsigned long min(unsigned long __arg1, unsigned long __arg2) {
+  return (__arg1 < __arg2) ? __arg1 : __arg2;
+}
+__DEVICE__ unsigned long max(unsigned long __arg1, unsigned long __arg2) {
+  return (__arg1 > __arg2) ? __arg1 : __arg2;
+}
+
 __DEVICE__
 float max(float __x, float __y) { return fmaxf(__x, __y); }
 


### PR DESCRIPTION
First noticed in the build of Raja. Code has 'using namespace std'
and calls the max function with size_t type parameters. This causes
a conflict between templated max functions in algorithm headers and
clang_hip_math.h. This patch adds additional max/min type variations.