### PR TITLE
This PR is initial support for targetid.  It includes significant fix…

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -174,6 +174,11 @@ private:
   mutable llvm::Optional<RuntimeLibType> runtimeLibType;
   mutable llvm::Optional<UnwindLibType> unwindLibType;
 
+  // OpenMP creates a toolchain for each target, which is uniquely
+  // defined as (Target Triple, TargetID).
+  // TargetID example "gfx908:sramecc+:xnack-".
+  std::string TargetID;
+
 protected:
   MultilibSet Multilibs;
   Multilib SelectedMultilib;
@@ -245,6 +250,14 @@ public:
     return EffectiveTriple;
   }
 
+  const std::string getTargetID() const {
+    return TargetID;
+  }
+
+  void setTargetID(std::string TargetID) {
+    this->TargetID = std::move(TargetID);
+  }
+  
   path_list &getLibraryPaths() { return LibraryPaths; }
   const path_list &getLibraryPaths() const { return LibraryPaths; }
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -54,13 +54,8 @@ const char *Action::getClassName(ActionClass AC) {
 
 void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch) {
   // Offload action set its own kinds on their dependences.
-  // But we still need to preserve OffloadingDeviceKind and OffloadingArch
-  // where toplevel action is an unbundle.
-  if (Kind == OffloadClass) {
-    OffloadingDeviceKind = OKind;
-    OffloadingArch = OArch;
+  if (Kind == OffloadClass)
     return;
-  }
   // Unbundling actions use the host kinds.
   if (Kind == OffloadUnbundlingJobClass)
     return;
@@ -213,11 +208,23 @@ OffloadAction::OffloadAction(const HostDependence &HDep,
                              const DeviceDependences &DDeps)
     : Action(OffloadClass, HDep.getAction()), HostTC(HDep.getToolChain()),
       DevToolChains(DDeps.getToolChains()) {
-  // We use the kinds of the host dependence for this action.
-  OffloadingArch = HDep.getBoundArch();
+  auto &OKinds = DDeps.getOffloadKinds();
+  auto &BArchs = DDeps.getBoundArchs();
+
+  // If all inputs agree on the same kind, use it also for this action.
+  if (llvm::all_of(OKinds, [&](OffloadKind K) { return K == OKinds.front(); }))
+    OffloadingDeviceKind = OKinds.front();
+
+  // If we have a single dependency, inherit the architecture from it.
+  if (OKinds.size() == 1)
+    OffloadingArch = BArchs.front();
+  else
+    // We use the kinds of the host dependence for this action.
+    OffloadingArch = HDep.getBoundArch();
+
   ActiveOffloadKindMask = HDep.getOffloadKinds();
   HDep.getAction()->propagateHostOffloadInfo(HDep.getOffloadKinds(),
-                                             HDep.getBoundArch());
+                                             OffloadingArch);
 
   // Add device inputs and propagate info to the device actions. Do work only if
   // we have dependencies.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2429,6 +2429,19 @@ class OffloadingActionBuilder final {
       ABRT_Ignore_Host,
     };
 
+    /// ID to identify each device compilation. For CUDA it is simply the
+    /// GPU arch string. For HIP it is either the GPU arch string or GPU
+    /// arch string plus feature strings delimited by a plus sign, e.g.
+    /// gfx906+xnack.
+    struct TargetID {
+      /// Target ID string which is persistent throughout the compilation.
+      const char *ID;
+      TargetID(CudaArch Arch) { ID = CudaArchToString(Arch); }
+      TargetID(const char *ID) : ID(ID) {}
+      operator const char *() { return ID; }
+      operator StringRef() { return StringRef(ID); }
+    };
+  
   protected:
     /// Compilation associated with this builder.
     Compilation &C;
@@ -2510,18 +2523,6 @@ class OffloadingActionBuilder final {
     bool EmitLLVM = false;
     bool EmitAsm = false;
 
-    /// ID to identify each device compilation. For CUDA it is simply the
-    /// GPU arch string. For HIP it is either the GPU arch string or GPU
-    /// arch string plus feature strings delimited by a plus sign, e.g.
-    /// gfx906+xnack.
-    struct TargetID {
-      /// Target ID string which is persistent throughout the compilation.
-      const char *ID;
-      TargetID(CudaArch Arch) { ID = CudaArchToString(Arch); }
-      TargetID(const char *ID) : ID(ID) {}
-      operator const char *() { return ID; }
-      operator StringRef() { return StringRef(ID); }
-    };
     /// List of GPU architectures to use in this compilation.
     SmallVector<TargetID, 4> GpuArchList;
 
@@ -3102,14 +3103,6 @@ class OffloadingActionBuilder final {
     ActionList OpenMPDeviceActions;
 
     bool CompileDeviceOnly = false;
-
-    struct TargetID {
-      const char *ID;
-      TargetID(CudaArch Arch) { ID = CudaArchToString(Arch); }
-      TargetID(const char *ID) : ID(ID) {}
-      operator const char *() { return ID; }
-      operator StringRef() { return StringRef(ID); }
-    };
 
     /// List of GPU architectures to use in this compilation.
     SmallVector<TargetID, 4> GpuArchList;

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -380,6 +380,8 @@ void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
   // Add target ID features to -target-feature options. No diagnostics should
   // be emitted here since invalid target ID is diagnosed at other places.
   StringRef TargetID = Args.getLastArgValue(options::OPT_mcpu_EQ);
+  if (TargetID.empty())
+    TargetID = Args.getLastArgValue(options::OPT_march_EQ);
   if (!TargetID.empty()) {
     llvm::StringMap<bool> FeatureMap;
     auto OptionalGpuArch = parseTargetID(Triple, TargetID, &FeatureMap);

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -376,12 +376,14 @@ void amdgpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                                      const llvm::Triple &Triple,
                                      const llvm::opt::ArgList &Args,
-                                     std::vector<StringRef> &Features) {
+                                     std::vector<StringRef> &Features,
+                                     std::string TcTargetID) {
   // Add target ID features to -target-feature options. No diagnostics should
   // be emitted here since invalid target ID is diagnosed at other places.
   StringRef TargetID = Args.getLastArgValue(options::OPT_mcpu_EQ);
-  if (TargetID.empty())
-    TargetID = Args.getLastArgValue(options::OPT_march_EQ);
+  if (TargetID.empty() && !TcTargetID.empty())
+    TargetID = TcTargetID;
+    //TargetID = Args.getLastArgValue(options::OPT_march_EQ);
   if (!TargetID.empty()) {
     llvm::StringMap<bool> FeatureMap;
     auto OptionalGpuArch = parseTargetID(Triple, TargetID, &FeatureMap);

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -39,7 +39,8 @@ public:
 
 void getAMDGPUTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                              const llvm::opt::ArgList &Args,
-                             std::vector<StringRef> &Features);
+                             std::vector<StringRef> &Features,
+                             std::string TcTargetID = std::string());
 
 } // end namespace amdgpu
 } // end namespace tools

--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
@@ -408,6 +408,16 @@ void AMDGCN::OpenMPLinker::constructLldCommand(
   LldArgs.append({"-o", Output.getFilename()});
   // Only a single input, the output of llc
   LldArgs.push_back(InputFileName);
+
+  // Get the environment variable ROCM_LLD_ARGS and add to lld.
+  Optional<std::string> OptEnv = llvm::sys::Process::GetEnv("ROCM_LLD_ARGS");
+  if (OptEnv.hasValue()) {
+    SmallVector<StringRef, 8> Envs;
+    SplitString(OptEnv.getValue(), Envs);
+    for (StringRef Env : Envs)
+      LldArgs.push_back(Args.MakeArgString(Env.trim()));
+  }
+
   const char *Lld = Args.MakeArgString(getToolChain().GetProgramPath("lld"));
   C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
                                          Lld, LldArgs, Inputs, Output));

--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -88,6 +88,12 @@ public:
                         const llvm::opt::ArgList &Args,
                         const Action::OffloadKind OK);
 
+  AMDGPUOpenMPToolChain(const Driver &D, const llvm::Triple &Triple,
+                        const ToolChain &HostTC,
+                        const llvm::opt::ArgList &Args,
+                        const Action::OffloadKind OK,
+                        const std::string TargetID);
+
   const llvm::Triple *getAuxTriple() const override {
     return &HostTC.getTriple();
   }

--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -43,14 +43,14 @@ private:
   const char *constructOmpExtraCmds(Compilation &C, const JobAction &JA,
                                     const InputInfoList &Inputs,
                                     const llvm::opt::ArgList &Args,
-                                    llvm::StringRef SubArchName,
+                                    llvm::StringRef TargetID,
                                     llvm::StringRef OutputFilePrefix) const;
 
   /// \return llvm-link output file name.
   const char *constructLLVMLinkCommand(Compilation &C, const JobAction &JA,
                                        const InputInfoList &Inputs,
                                        const llvm::opt::ArgList &Args,
-                                       llvm::StringRef SubArchName,
+                                       llvm::StringRef TargetID,
                                        llvm::StringRef OutputFilePrefix) const;
 
   /// \return opt output file name.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7410,11 +7410,12 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
         CurDep->getOffloadingArch()) {
       // clang-offload-bundler requires all 4 components in bundle entry ID.
       // Add an extra '-' to represent empty triple.environment.
-      Triples += '-';
+      Triples += "--";
       Triples += CurDep->getOffloadingArch();
     }
     if ((CurKind == Action::OFK_OpenMP || CurKind == Action::OFK_Cuda)) {
-      Triples += "-";
+      Triples += "--";
+      /*
       // Extract TargetID from TC argument list
       for (uint ArgIndex = 0; ArgIndex < TCArgs.size(); ArgIndex++) {
         StringRef ArchStr = StringRef(TCArgs.getArgString(ArgIndex));
@@ -7426,6 +7427,8 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
         }
       }
       Triples += TargetID.str();
+      */
+      Triples += CurTC->getTargetID();
     }
   }
   CmdArgs.push_back(TCArgs.MakeArgString(Triples));

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -336,7 +336,10 @@ void tools::AddTargetFeature(const ArgList &Args,
 /// Get the (LLVM) name of the AMDGPU gpu we are targeting.
 static std::string getAMDGPUTargetGPU(const llvm::Triple &T,
                                       const ArgList &Args) {
-  if (Arg *A = Args.getLastArg(options::OPT_mcpu_EQ)) {
+  Arg *A = Args.getLastArg(options::OPT_mcpu_EQ);
+  if (!A)
+    A = Args.getLastArg(options::OPT_march_EQ);
+  if (A) {
     auto GPUName = getProcessorFromTargetID(T, A->getValue());
     return llvm::StringSwitch<std::string>(GPUName)
         .Cases("rv630", "rv635", "r600")

--- a/clang/lib/Driver/ToolChains/CommonArgs.h
+++ b/clang/lib/Driver/ToolChains/CommonArgs.h
@@ -55,23 +55,23 @@ void AddStaticDeviceLibs(Compilation &C, const Tool &T, const JobAction &JA,
                          const InputInfoList &Inputs,
                          const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 void AddStaticDeviceLibs(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 void AddStaticDeviceLibs(Compilation *C, const Tool *T, const JobAction *JA,
                          const InputInfoList *Inputs,
                          const Driver &D, const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 
 bool SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                llvm::opt::ArgStringList &CmdArgs,
                SmallVector<std::string, 8> LibraryPaths, std::string libname,
-               StringRef ArchName, StringRef GpuArch, bool isBitCodeSDL,
+               StringRef ArchName, StringRef TargetID, bool isBitCodeSDL,
                bool postClangLink);
 
 bool GetSDLFromOffloadArchive(Compilation &C, const Driver &D, const Tool &T,
@@ -80,7 +80,7 @@ bool GetSDLFromOffloadArchive(Compilation &C, const Driver &D, const Tool &T,
                               llvm::opt::ArgStringList &CC1Args,
                               SmallVector<std::string, 8> LibraryPaths,
                               std::string libname, StringRef ArchName,
-                              StringRef GpuArch, bool isBitCodeSDL,
+                              StringRef TargetID, bool isBitCodeSDL,
                               bool postClangLink);
 
 const char *SplitDebugName(const JobAction &JA, const llvm::opt::ArgList &Args,

--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -10,6 +10,7 @@
 #include "CommonArgs.h"
 #include "InputInfo.h"
 #include "clang/Basic/Cuda.h"
+#include "clang/Basic/TargetID.h"
 #include "clang/Config/config.h"
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Distro.h"
@@ -403,7 +404,8 @@ void NVPTX::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
   // from the -march=arch option. This option may come from -Xopenmp-target
   // flag or the default value.
   if (JA.isDeviceOffloading(Action::OFK_OpenMP)) {
-    GPUArchName = Args.getLastArgValue(options::OPT_march_EQ);
+    //GPUArchName = Args.getLastArgValue(options::OPT_march_EQ);
+    GPUArchName = getProcessorFromTargetID(TC.getTriple(), TC.getTargetID());
     assert(!GPUArchName.empty() && "Must have an architecture passed in.");
   } else
     GPUArchName = JA.getOffloadingArch();
@@ -663,6 +665,22 @@ CudaToolChain::CudaToolChain(const Driver &D, const llvm::Triple &Triple,
   // Lookup binaries into the driver directory, this is used to
   // discover the clang-offload-bundler executable.
   getProgramPaths().push_back(getDriver().Dir);
+}
+
+CudaToolChain::CudaToolChain(const Driver &D, const llvm::Triple &Triple,
+                             const ToolChain &HostTC, const ArgList &Args,
+                             const Action::OffloadKind OK,
+                             const std::string TargetID)
+    : ToolChain(D, Triple, Args), HostTC(HostTC),
+      CudaInstallation(D, HostTC.getTriple(), Args), OK(OK) {
+  if (CudaInstallation.isValid()) {
+    CudaInstallation.WarnIfUnsupportedVersion();
+    getProgramPaths().push_back(std::string(CudaInstallation.getBinPath()));
+  }
+  // Lookup binaries into the driver directory, this is used to
+  // discover the clang-offload-bundler executable.
+  getProgramPaths().push_back(getDriver().Dir);
+  setTargetID(TargetID);
 }
 
 std::string CudaToolChain::getInputFilename(const InputInfo &Input) const {

--- a/clang/lib/Driver/ToolChains/Cuda.h
+++ b/clang/lib/Driver/ToolChains/Cuda.h
@@ -133,6 +133,10 @@ public:
   CudaToolChain(const Driver &D, const llvm::Triple &Triple,
                 const ToolChain &HostTC, const llvm::opt::ArgList &Args,
                 const Action::OffloadKind OK);
+  
+  CudaToolChain(const Driver &D, const llvm::Triple &Triple,
+                const ToolChain &HostTC, const llvm::opt::ArgList &Args,
+                const Action::OffloadKind OK, const std::string TargetID);
 
   const llvm::Triple *getAuxTriple() const override {
     return &HostTC.getTriple();

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3918,6 +3918,13 @@ bool CompilerInvocation::ParseLangArgsImpl(LangOptions &Opts, ArgList &Args,
 
     for (unsigned i = 0; i < A->getNumValues(); ++i) {
       llvm::Triple TT(A->getValue(i));
+      
+      if(StringRef(A->getValue(i)).startswith("gfx")) {
+        TT.setTriple("amdgcn-amd-amdhsa");
+      } else if(StringRef(A->getValue(i)).startswith("sm_")) {
+        T.isArch64Bit() ? TT.setTriple("nvptx64-nvidia-cuda") 
+                        : TT.setTriple("nvptx-nvidia-cuda");
+      }
 
       if (TT.getArch() == llvm::Triple::UnknownArch ||
           !(TT.getArch() == llvm::Triple::aarch64 || TT.isPPC() ||

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3525,8 +3525,10 @@ void CompilerInvocation::GenerateLangArgs(const LangOptions &Opts,
     if (!Opts.OpenMPUseTLS)
       GenerateArg(Args, OPT_fnoopenmp_use_tls, SA);
 
-    if (Opts.OpenMPIsDevice)
+    if (Opts.OpenMPIsDevice) {
+      printf("    COMPILER INVOKE GENERATING FLAG openmp_is_device \n");
       GenerateArg(Args, OPT_fopenmp_is_device, SA);
+    }
 
     if (Opts.OpenMPIRBuilder)
       GenerateArg(Args, OPT_fopenmp_enable_irbuilder, SA);

--- a/clang/tools/active-offload-target/active-offload-target
+++ b/clang/tools/active-offload-target/active-offload-target
@@ -3612,7 +3612,7 @@ function get_amd_features()
    if [[ ! -z $kfd_version ]] ; then
       vc=$(version_compare $kfd_version 5.9.15)
       if [[ $vc == "=" ]] || [[ "$vc" == ">" ]] ; then
-         features=":CodeObjVer4"
+         features="__CodeObjVer4"
       fi
       # TODO add features for xnack and sramecc
    fi

--- a/clang/tools/active-offload-target/active-offload-target
+++ b/clang/tools/active-offload-target/active-offload-target
@@ -58,7 +58,7 @@ function usage(){
     -h  Print this help message
     -n  Prints numeric pci id, useful to fix tables if getting unknown targetid
     -c  Prints the codename instead of targetid
-    -nofeatures Do not print the current active features in the targetid. 
+    -r  Print compiler required runtime options
 
    active-offload-target uses two internal tables that need regular maintenance
    to support new GPUs. The internal tables can be overridden with environment 
@@ -3605,7 +3605,7 @@ function version_compare {
    echo "="; return 0
 }
 
-function get_amd_features()
+function get_required_runtime_features()
 {
    features=""
    kfd_version=`modinfo -F version amdgpu`
@@ -3614,8 +3614,8 @@ function get_amd_features()
       if [[ $vc == "=" ]] || [[ "$vc" == ">" ]] ; then
          features="__CodeObjVer4"
       fi
-      # TODO add features for xnack and sramecc
    fi
+   # TODO add feature for cuda required runtime version
    echo $features
 }
 
@@ -3635,7 +3635,7 @@ while [ $# -gt 0 ] ; do
       --version) 	version ;;
       -c) 	        PRINT_CODENAME=1;;
       -n) 	        PRINT_NUMERIC=1;;
-      -nofeatures) 	NOFEATURES=1;;
+      -r) 	        REQUIRED_RUNTIME=1;;
       --) 		shift ; break;;
       *) 		break;echo $1 ignored;
    esac
@@ -3652,8 +3652,8 @@ if [ "$PRINT_CODENAME" == 1 ] ; then
 else
    targetid=$(get_targetid_from_codename $codename)
 fi
-if [[ "$aot_arch" == "amdgcn" ]] && [[ "$NOFEATURES" != 1 ]] ; then
-   features=$(get_amd_features $targetid)
+if [[ "$aot_arch" == "amdgcn" ]] && [[ "$REQUIRED_RUNTIME" == 1 ]] ; then
+   features=$(get_required_runtime_features $targetid)
    targetid="$targetid$features"
 fi
 

--- a/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
+++ b/clang/tools/clang-offload-bundler/ClangOffloadBundler.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "clang/Basic/TargetID.h"
 #include "clang/Basic/Version.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
@@ -28,11 +29,12 @@
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorOr.h"
-#include "llvm/Support/Host.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Program.h"
@@ -124,36 +126,50 @@ static unsigned HostInputIndex = ~0u;
 /// Path to the current binary.
 static std::string BundlerExecutable;
 
-/// Obtain the offload kind and real machine triple out of the target
-/// information specified by the user.
-static void getOffloadKindAndTriple(StringRef Target, StringRef &OffloadKind,
-                                    StringRef &Triple) {
-  auto KindTriplePair = Target.split('-');
-  OffloadKind = KindTriplePair.first;
-  Triple = KindTriplePair.second;
-}
-static bool hasHostKind(StringRef Target) {
+/// Obtain the offload kind, real machine triple, and an optional TARGETID
+/// out of the target information specified by the user.
+/// Bundle Entry ID (or, Offload Target String) has following components:
+///  * Offload Kind - Host, OpenMP, or HIP
+///  * Triple - Standard LLVM Triple
+///  * Target ID (Optional) - Processor name followed by set of ON/OFF features
+/// In presence of TARGETID, the TRIPLE should contain separator "-" for all
+/// standard four components, even if they are empty.
+struct OffloadTargetInfo {
   StringRef OffloadKind;
-  StringRef Triple;
-  getOffloadKindAndTriple(Target, OffloadKind, Triple);
-  return OffloadKind == "host";
-}
+  llvm::Triple Triple;
+  StringRef TargetID;
 
-static StringRef getTriple(StringRef Target) {
-  StringRef OffloadKind;
-  StringRef Triple;
-  getOffloadKindAndTriple(Target, OffloadKind, Triple);
-  return Triple;
-}
-
-static StringRef getDevice(StringRef Triple) {
-  if (Triple.contains("-")) {
-    auto Split = Triple.rsplit('-');
-    return Split.second;
-  } else {
-    return Triple;
+  OffloadTargetInfo(const StringRef Target) {
+    SmallVector<StringRef, 6> Components;
+    Target.split(Components, '-', 5);
+    Components.resize(6);
+    this->OffloadKind = Components[0];
+    this->Triple = llvm::Triple(Components[1], Components[2], Components[3],
+                                Components[4]);
+    this->TargetID = Components[5];
   }
-}
+
+  bool hasHostKind() const { return this->OffloadKind == "host"; }
+
+  bool isOffloadKindValid() const {
+    return OffloadKind == "host" || OffloadKind == "openmp" ||
+           OffloadKind == "hip";
+  }
+
+  bool isTripleValid() const {
+    return !Triple.str().empty() && Triple.getArch() != Triple::UnknownArch;
+  }
+
+  bool operator==(const OffloadTargetInfo &Target) const {
+    return OffloadKind == Target.OffloadKind &&
+           Triple.isCompatibleWith(Target.Triple) &&
+           TargetID == Target.TargetID;
+  }
+
+  std::string str() {
+    return Twine(OffloadKind + "-" + Triple.str() + "-" + TargetID).str();
+  }
+};
 
 /// Generic file handler interface.
 class FileHandler {
@@ -217,18 +233,18 @@ public:
   Error forEachBundle(MemoryBuffer &Input,
                       std::function<Error(const BundleInfo &)> Func) {
     while (true) {
-      Expected<Optional<StringRef>> CurTripleOrErr = ReadBundleStart(Input);
-      if (!CurTripleOrErr)
-        return CurTripleOrErr.takeError();
+      Expected<Optional<StringRef>> BundleEntryOrErr = ReadBundleStart(Input);
+      if (!BundleEntryOrErr)
+        return BundleEntryOrErr.takeError();
 
       // No more bundles.
-      if (!*CurTripleOrErr)
+      if (!*BundleEntryOrErr)
         break;
 
-      StringRef CurTriple = **CurTripleOrErr;
-      assert(!CurTriple.empty());
+      StringRef BundleEntry = **BundleEntryOrErr;
+      assert(!BundleEntry.empty());
 
-      BundleInfo Info{CurTriple};
+      BundleInfo Info{BundleEntry};
       if (Error Err = Func(Info))
         return Err;
     }
@@ -963,18 +979,18 @@ static Error UnbundleFiles() {
   // assume the file is meant for the host target.
   bool FoundHostBundle = false;
   while (!Worklist.empty()) {
-    Expected<Optional<StringRef>> CurTripleOrErr = FH->ReadBundleStart(Input);
-    if (!CurTripleOrErr)
-      return CurTripleOrErr.takeError();
+    Expected<Optional<StringRef>> BundleEntryOrErr = FH->ReadBundleStart(Input);
+    if (!BundleEntryOrErr)
+      return BundleEntryOrErr.takeError();
 
     // We don't have more bundles.
-    if (!*CurTripleOrErr)
+    if (!*BundleEntryOrErr)
       break;
 
-    StringRef CurTriple = **CurTripleOrErr;
-    assert(!CurTriple.empty());
+    StringRef BundleEntry = **BundleEntryOrErr;
+    assert(!BundleEntry.empty());
 
-    auto Output = Worklist.find(CurTriple);
+    auto Output = Worklist.find(BundleEntry);
     // The file may have more bundles for other targets, that we don't care
     // about. Therefore, move on to the next triple
     if (Output == Worklist.end())
@@ -992,7 +1008,8 @@ static Error UnbundleFiles() {
     Worklist.erase(Output);
 
     // Record if we found the host bundle.
-    if (hasHostKind(CurTriple))
+    auto OffloadInfo = OffloadTargetInfo(BundleEntry);
+    if (OffloadInfo.hasHostKind())
       FoundHostBundle = true;
   }
 
@@ -1025,7 +1042,8 @@ static Error UnbundleFiles() {
         return createFileError(E.second, EC);
 
       // If this entry has a host kind, copy the input file to the output file.
-      if (hasHostKind(E.first()))
+      auto OffloadInfo = OffloadTargetInfo(E.getKey());
+      if (OffloadInfo.hasHostKind())
         OutputFile.write(Input.getBufferStart(), Input.getBufferSize());
     }
     return Error::success();
@@ -1049,59 +1067,146 @@ static Error UnbundleFiles() {
 }
 
 static Archive::Kind getDefaultArchiveKindForHost() {
-  return Triple(sys::getDefaultTargetTriple()).isOSDarwin()
-             ? Archive::K_DARWIN
-             : Archive::K_GNU;
+  return Triple(sys::getDefaultTargetTriple()).isOSDarwin() ? Archive::K_DARWIN
+                                                            : Archive::K_GNU;
 }
 
-static StringRef getDeviceFileExtension(StringRef Device) {
-  if (Device.contains("gfx"))
-    return ".bc";
-  if (Device.contains("sm_"))
-    return ".cubin";
-  else {
-    WithColor::warning() << "Could not determine extension for archive"
-                            "members, using \".o\"\n";
-    return ".o";
+/// @brief Checks if a code object \p CodeObjectInfo is compatible with a given
+/// target \p TargetInfo.
+/// @link https://clang.llvm.org/docs/ClangOffloadBundler.html#bundle-entry-id
+bool isCodeObjectCompatible(OffloadTargetInfo &CodeObjectInfo,
+                            OffloadTargetInfo &TargetInfo) {
+
+  // Compatible in case of exact match.
+  if (CodeObjectInfo == TargetInfo) {
+    DEBUG_WITH_TYPE(
+        "CodeObjectCompatibility",
+        dbgs() << "Compatible: Exact match: " << CodeObjectInfo.str() << "\n");
+    return true;
   }
+
+  // Incompatible if Kinds or Triples mismatch.
+  if (CodeObjectInfo.OffloadKind != TargetInfo.OffloadKind ||
+      !CodeObjectInfo.Triple.isCompatibleWith(TargetInfo.Triple)) {
+    DEBUG_WITH_TYPE(
+        "CodeObjectCompatibility",
+        dbgs() << "Incompatible: Kind/Triple mismatch \t[CodeObject: "
+               << CodeObjectInfo.str() << "]\t:\t[Target: " << TargetInfo.str()
+               << "]\n");
+    return false;
+  }
+
+  // Incompatible if Processors mismatch.
+  llvm::StringMap<bool> CodeObjectFeatureMap, TargetFeatureMap;
+  llvm::Optional<StringRef> CodeObjectProc = clang::parseTargetID(
+      CodeObjectInfo.Triple, CodeObjectInfo.TargetID, &CodeObjectFeatureMap);
+  llvm::Optional<StringRef> TargetProc = clang::parseTargetID(
+      TargetInfo.Triple, TargetInfo.TargetID, &TargetFeatureMap);
+
+  // Both TargetProc and CodeObjectProc can't be empty here.
+  if (!TargetProc || !CodeObjectProc ||
+      CodeObjectProc.getValue() != TargetProc.getValue()) {
+    DEBUG_WITH_TYPE("CodeObjectCompatibility",
+                    dbgs() << "Incompatible: Processor mismatch \t[CodeObject: "
+                           << CodeObjectInfo.str()
+                           << "]\t:\t[Target: " << TargetInfo.str() << "]\n");
+    return false;
+  }
+
+  // Incompatible if CodeObject has more features than Target, irrespective of
+  // type or sign of features.
+  if (CodeObjectFeatureMap.getNumItems() > TargetFeatureMap.getNumItems()) {
+    DEBUG_WITH_TYPE("CodeObjectCompatibility",
+                    dbgs() << "Incompatible: CodeObject has more features "
+                              "than target \t[CodeObject: "
+                           << CodeObjectInfo.str()
+                           << "]\t:\t[Target: " << TargetInfo.str() << "]\n");
+    return false;
+  }
+
+  // Compatible if each target feature specified by target is compatible with
+  // target feature of code object. The target feature is compatible if the
+  // code object does not specify it (meaning Any), or if it specifies it
+  // with the same value (meaning On or Off).
+  for (const auto &CodeObjectFeature : CodeObjectFeatureMap) {
+    auto TargetFeature = TargetFeatureMap.find(CodeObjectFeature.getKey());
+    if (TargetFeature == TargetFeatureMap.end()) {
+      DEBUG_WITH_TYPE(
+          "CodeObjectCompatibility",
+          dbgs()
+              << "Incompatible: Value of CodeObject's non-ANY feature is "
+                 "not matching with Target feature's ANY value \t[CodeObject: "
+              << CodeObjectInfo.str() << "]\t:\t[Target: " << TargetInfo.str()
+              << "]\n");
+      return false;
+    } else if (TargetFeature->getValue() != CodeObjectFeature.getValue()) {
+      DEBUG_WITH_TYPE(
+          "CodeObjectCompatibility",
+          dbgs() << "Incompatible: Value of CodeObject's non-ANY feature is "
+                    "not matching with Target feature's non-ANY value "
+                    "\t[CodeObject: "
+                 << CodeObjectInfo.str()
+                 << "]\t:\t[Target: " << TargetInfo.str() << "]\n");
+      return false;
+    }
+  }
+
+  // CodeObject is compatible if all features of Target are:
+  //   - either, present in the Code Object's features map with the same sign,
+  //   - or, the feature is missing from CodeObjects's features map i.e. it is
+  //   set to ANY
+  DEBUG_WITH_TYPE(
+      "CodeObjectCompatibility",
+      dbgs() << "Compatible: Target IDs are compatible \t[CodeObject: "
+             << CodeObjectInfo.str() << "]\t:\t[Target: " << TargetInfo.str()
+             << "]\n");
+  return true;
 }
 
-static StringRef removeExtension(StringRef FileName) {
-  StringRef NoExtFileName;
-  if (FileName.contains("."))
-    NoExtFileName = FileName.rsplit('.').first;
-  else
-    NoExtFileName = FileName;
-
-  return NoExtFileName;
+/// @brief Computes a list of targets among all given targets which are
+/// compatible with this code object
+/// @param [in] Code Object \p CodeObject
+/// @param [out] List of all compatible targets \p CompatibleTargets among all
+/// given targets
+/// @return false, if no compatible target is found.
+static bool
+getCompatibleOffloadTargets(OffloadTargetInfo &CodeObjectInfo,
+                            SmallVectorImpl<StringRef> &CompatibleTargets) {
+  if (!CompatibleTargets.empty()) {
+    DEBUG_WITH_TYPE("CodeObjectCompatibility",
+                    dbgs() << "CompatibleTargets list should be empty\n");
+    return false;
+  }
+  for (auto &Target : TargetNames) {
+    auto TargetInfo = OffloadTargetInfo(Target);
+    if (isCodeObjectCompatible(CodeObjectInfo, TargetInfo))
+      CompatibleTargets.push_back(Target);
+  }
+  return !CompatibleTargets.empty();
 }
 
-static std::string getDeviceLibraryFileName(StringRef BundleFileName,
-                                            StringRef Device) {
-  StringRef LibName = removeExtension(BundleFileName);
-  StringRef Extension = getDeviceFileExtension(Device);
-
-  std::string Result;
-  Result += LibName;
-  Result += Extension;
-  return Result;
-}
-
-static bool checkDeviceOptions(StringRef Device, std::string OffloadArch) {
-  return !OffloadArch.empty() && OffloadArch == Device;
-}
-
-
-// UnbundleArchive takes an archive file (".a") as input containing bundled
-// object files, and an offload target (not host), and extracts the device code
-// into a new archive file. The resulting archive file contains the same number
-// of files, with the same names, except the file extension have been modified
-// depending on the target (either ".cubin" or ".bc") The created archive file
-// does not contain an index of the symbols.
+/// UnbundleArchive takes an archive file (".a") as input containing bundled
+/// code object files, and a list of offload targets (not host), and extracts
+/// the code objects into a new archive file for each offload target. Each
+/// resulting archive file contains all code object files corresponding to that
+/// particular offload target. The created archive file does not
+/// contain an index of the symbols and code object files are named as
+/// <<Parent Bundle Name>-<CodeObject's TargetID>>, with ':' replaced with '_'.
 static Error UnbundleArchive() {
   std::vector<std::unique_ptr<MemoryBuffer>> ArchiveBuffers;
-  std::string OffloadArch = getDevice(TargetNames.front()).str();
-  std::vector<NewArchiveMember> ArchiveMembers;
+
+  /// Map of target names with list of object files that will form the device
+  /// specific archive for that target
+  StringMap<std::vector<NewArchiveMember>> OutputArchivesMap;
+
+  // Map of target names and output archive filenames
+  StringMap<StringRef> TargetOutputFileNameMap;
+
+  auto Output = OutputFileNames.begin();
+  for (auto &Target : TargetNames) {
+    TargetOutputFileNameMap[Target] = *Output;
+    ++Output;
+  }
 
   StringRef IFName = InputFileNames.front();
   ErrorOr<std::unique_ptr<MemoryBuffer>> BufOrErr =
@@ -1110,7 +1215,7 @@ static Error UnbundleArchive() {
     return createFileError(InputFileNames.front(), EC);
 
   ArchiveBuffers.push_back(std::move(*BufOrErr));
-  auto LibOrErr =
+  Expected<std::unique_ptr<llvm::object::Archive>> LibOrErr =
       Archive::create(ArchiveBuffers.back()->getMemBufferRef());
   if (!LibOrErr)
     return LibOrErr.takeError();
@@ -1119,82 +1224,128 @@ static Error UnbundleArchive() {
 
   Error ArchiveErr = Error::success();
   auto ChildEnd = Archive->child_end();
-  for (auto ChildIter = Archive->child_begin(ArchiveErr);
-       ChildIter != ChildEnd; ++ChildIter) {
+
+  /// Iterate over all bundled code object files in the input archive.
+  for (auto ArchiveIter = Archive->child_begin(ArchiveErr);
+       ArchiveIter != ChildEnd; ++ArchiveIter) {
     if (ArchiveErr)
       return ArchiveErr;
-    auto ChildNameOrErr = (*ChildIter).getName();
-    if (!ChildNameOrErr)
-      return ChildNameOrErr.takeError();
+    auto ArchiveChildNameOrErr = (*ArchiveIter).getName();
+    if (!ArchiveChildNameOrErr)
+      return ArchiveChildNameOrErr.takeError();
 
-    StringRef ChildName = sys::path::filename(*ChildNameOrErr);
+    StringRef BundledObjectFile = sys::path::filename(*ArchiveChildNameOrErr);
 
-    auto ChildBufferRefOrErr = (*ChildIter).getMemoryBufferRef();
-    if (!ChildBufferRefOrErr)
-      return ChildBufferRefOrErr.takeError();
+    auto CodeObjectBufferRefOrErr = (*ArchiveIter).getMemoryBufferRef();
+    if (!CodeObjectBufferRefOrErr)
+      return CodeObjectBufferRefOrErr.takeError();
 
-    auto ChildBuffer =
-        MemoryBuffer::getMemBuffer(*ChildBufferRefOrErr, false);
+    auto CodeObjectBuffer =
+        MemoryBuffer::getMemBuffer(*CodeObjectBufferRefOrErr, false);
 
     Expected<std::unique_ptr<FileHandler>> FileHandlerOrErr =
-      CreateFileHandler(*ChildBuffer);
+        CreateFileHandler(*CodeObjectBuffer);
     if (!FileHandlerOrErr)
       return FileHandlerOrErr.takeError();
 
     std::unique_ptr<FileHandler> &FileHandler = *FileHandlerOrErr;
     assert(FileHandler);
 
-    if (Error ReadErr = FileHandler.get()->ReadHeader(*ChildBuffer))
+    if (Error ReadErr = FileHandler.get()->ReadHeader(*CodeObjectBuffer))
       return ReadErr;
 
-    Expected<Optional<StringRef>> CurTripleOrErr =
-      FileHandler->ReadBundleStart(*ChildBuffer);
-    if (!CurTripleOrErr)
-      return  CurTripleOrErr.takeError();
+    Expected<Optional<StringRef>> CurBundleIDOrErr =
+        FileHandler->ReadBundleStart(*CodeObjectBuffer);
+    if (!CurBundleIDOrErr)
+      return CurBundleIDOrErr.takeError();
 
-    Optional<StringRef> OptionalCurKindTriple = *CurTripleOrErr;
-    // No device code in this child, skip
-    if(!OptionalCurKindTriple.hasValue())
+    Optional<StringRef> OptionalCurBundleID = *CurBundleIDOrErr;
+    // No device code in this child, skip.
+    if (!OptionalCurBundleID.hasValue())
       continue;
-    StringRef CurKindTriple = *OptionalCurKindTriple;
-    assert(!CurKindTriple.empty());
+    StringRef CodeObject = *OptionalCurBundleID;
 
-    while (!CurKindTriple.empty()) {
-      if (hasHostKind(CurKindTriple)) {
-        // Do nothing, we don't extract host code yet
-      } else if (checkDeviceOptions(getDevice(getTriple(CurKindTriple)),
-                                    OffloadArch)) {
+    // Process all bundle entries (CodeObjects) found in this child of input
+    // archive.
+    while (!CodeObject.empty()) {
+      SmallVector<StringRef> CompatibleTargets;
+      auto CodeObjectInfo = OffloadTargetInfo(CodeObject);
+      if (CodeObjectInfo.hasHostKind()) {
+        // Do nothing, we don't extract host code yet.
+      } else if (getCompatibleOffloadTargets(CodeObjectInfo,
+                                             CompatibleTargets)) {
         std::string BundleData;
         raw_string_ostream DataStream(BundleData);
-        if (Error Err = FileHandler.get()->ReadBundle(DataStream, *ChildBuffer))
+        if (Error Err =
+                FileHandler.get()->ReadBundle(DataStream, *CodeObjectBuffer))
           return Err;
 
-        std::string *LibraryName =
-            new std::string(getDeviceLibraryFileName(ChildName, OffloadArch));
-        auto MemBuf =
-            MemoryBuffer::getMemBufferCopy(DataStream.str(), *LibraryName);
-        ArchiveBuffers.push_back(std::move(MemBuf));
-        auto MemBufRef = MemoryBufferRef(*(ArchiveBuffers.back()));
-        ArchiveMembers.push_back(NewArchiveMember(MemBufRef));
+        for (auto &CompatibleTarget : CompatibleTargets) {
+          SmallString<128> BundledObjectFileName;
+          BundledObjectFileName.assign(BundledObjectFile);
+          auto OutputBundleName =
+              Twine(llvm::sys::path::stem(BundledObjectFileName) + "-" +
+                    CodeObject)
+                  .str();
+          // Replace ':' in optional target feature list with '_' to ensure
+          // cross-platform validity.
+          std::replace(OutputBundleName.begin(), OutputBundleName.end(), ':',
+                       '_');
+
+          std::unique_ptr<MemoryBuffer> MemBuf = MemoryBuffer::getMemBufferCopy(
+              DataStream.str(), OutputBundleName);
+          ArchiveBuffers.push_back(std::move(MemBuf));
+          llvm::MemoryBufferRef MemBufRef =
+              MemoryBufferRef(*(ArchiveBuffers.back()));
+
+          // For inserting <CompatibleTarget, list<CodeObject>> entry in
+          // OutputArchivesMap.
+          if (OutputArchivesMap.find(CompatibleTarget) ==
+              OutputArchivesMap.end()) {
+
+            std::vector<NewArchiveMember> ArchiveMembers;
+            ArchiveMembers.push_back(NewArchiveMember(MemBufRef));
+            OutputArchivesMap.insert_or_assign(CompatibleTarget,
+                                               std::move(ArchiveMembers));
+          } else {
+            OutputArchivesMap[CompatibleTarget].push_back(
+                NewArchiveMember(MemBufRef));
+          }
+        }
       }
-      if (Error Err = FileHandler.get()->ReadBundleEnd(*ChildBuffer))
+
+      if (Error Err = FileHandler.get()->ReadBundleEnd(*CodeObjectBuffer))
         return Err;
 
       Expected<Optional<StringRef>> NextTripleOrErr =
-        FileHandler->ReadBundleStart(*ChildBuffer);
+          FileHandler->ReadBundleStart(*CodeObjectBuffer);
       if (!NextTripleOrErr)
         return NextTripleOrErr.takeError();
 
-      CurKindTriple = ((*NextTripleOrErr).hasValue()) ? **NextTripleOrErr : "";
-    }
-  }
+      CodeObject = ((*NextTripleOrErr).hasValue()) ? **NextTripleOrErr : "";
+    } // End of processing of all bundle entries of this child of input archive.
+  }   // End of while over children of input archive.
+
   assert(!ArchiveErr);
 
-    std::string FileName = OutputFileNames.front();
-  if (Error WriteErr =
-      writeArchive(FileName, ArchiveMembers, true,
-                   getDefaultArchiveKindForHost(), true, false, nullptr))
-    return WriteErr;
+  /// Write out an archive for each target
+  for (auto &Target : TargetNames) {
+    StringRef FileName = TargetOutputFileNameMap[Target];
+    StringMapIterator<std::vector<llvm::NewArchiveMember>> CurArchiveMembers =
+        OutputArchivesMap.find(Target);
+    if (CurArchiveMembers != OutputArchivesMap.end()) {
+      if (Error WriteErr = writeArchive(FileName, CurArchiveMembers->getValue(),
+                                        true, getDefaultArchiveKindForHost(),
+                                        true, false, nullptr))
+        return WriteErr;
+    } else if (!AllowMissingBundles) {
+      std::string ErrMsg =
+          Twine("no compatible code object found for the target '" + Target +
+                "' in heterogenous archive library: " + IFName)
+              .str();
+      return createStringError(inconvertibleErrorCode(), ErrMsg);
+    }
+  }
 
   return Error::success();
 }
@@ -1277,12 +1428,7 @@ int main(int argc, const char **argv) {
           errc::invalid_argument,
           "only one input file supported in unbundling mode"));
     }
-    if (FilesType == "a" && (OutputFileNames.size() != 1 ||
-                             TargetNames.size() != 1)) {
-      reportError(createStringError(errc::invalid_argument,
-                                    "number of output files and targets should "
-                                    "be 1 when unbundling an archive"));
-    } else if (OutputFileNames.size() != TargetNames.size()) {
+    if (OutputFileNames.size() != TargetNames.size()) {
       reportError(createStringError(errc::invalid_argument,
                                     "number of output files and targets should "
                                     "match in unbundling mode"));
@@ -1317,33 +1463,22 @@ int main(int argc, const char **argv) {
     }
     ParsedTargets.insert(Target);
 
-    StringRef Kind;
-    StringRef Triple;
-    getOffloadKindAndTriple(Target, Kind, Triple);
-
-    bool KindIsValid = !Kind.empty();
-    KindIsValid = KindIsValid && StringSwitch<bool>(Kind)
-                                     .Case("host", true)
-                                     .Case("openmp", true)
-                                     .Case("hip", true)
-                                     .Default(false);
-
-    bool TripleIsValid = !Triple.empty();
-    llvm::Triple T(Triple);
-    TripleIsValid &= T.getArch() != Triple::UnknownArch;
+    auto OffloadInfo = OffloadTargetInfo(Target);
+    bool KindIsValid = OffloadInfo.isOffloadKindValid();
+    bool TripleIsValid = OffloadInfo.isTripleValid();
 
     if (!KindIsValid || !TripleIsValid) {
       SmallVector<char, 128u> Buf;
       raw_svector_ostream Msg(Buf);
       Msg << "invalid target '" << Target << "'";
       if (!KindIsValid)
-        Msg << ", unknown offloading kind '" << Kind << "'";
+        Msg << ", unknown offloading kind '" << OffloadInfo.OffloadKind << "'";
       if (!TripleIsValid)
-        Msg << ", unknown target triple '" << Triple << "'";
+        Msg << ", unknown target triple '" << OffloadInfo.Triple.str() << "'";
       reportError(createStringError(errc::invalid_argument, Msg.str()));
     }
 
-    if (KindIsValid && Kind == "host") {
+    if (KindIsValid && OffloadInfo.hasHostKind()) {
       ++HostTargetNum;
       // Save the index of the input that refers to the host.
       HostInputIndex = Index;
@@ -1364,5 +1499,6 @@ int main(int argc, const char **argv) {
 		  ?  UnbundleArchive()
                   : (Unbundle) ? UnbundleFiles()
                                : BundleFiles(); });
+
   return 0;
 }

--- a/openmp/libomptarget/include/omptarget.h
+++ b/openmp/libomptarget/include/omptarget.h
@@ -93,7 +93,7 @@ struct __tgt_offload_entry {
   int32_t reserved; // Reserved, to be used by the runtime library.
 };
 
-/// This struct is a record of the device image information
+/// This struct is a record of a device image
 struct __tgt_device_image {
   void *ImageStart;                  // Pointer to the target code start
   void *ImageEnd;                    // Pointer to the target code end
@@ -108,6 +108,45 @@ struct __tgt_bin_desc {
   __tgt_device_image *DeviceImages;  // Array of device images (1 per dev. type)
   __tgt_offload_entry *HostEntriesBegin; // Begin of table with all host entries
   __tgt_offload_entry *HostEntriesEnd;   // End of table (non inclusive)
+};
+
+/// __tgt_image_info:
+///
+/// The information in this struct is provided in clang-offload-wrapper
+/// as a call to __tgt_register_image_info for each image in the library
+/// of images also created created by clang-offload-wrapper.
+/// __tgt_register_image_info is called for each image BEFORE the single
+/// call to __tgt_register_lib so that image information is available
+/// before they are loaded.  clang-offload-wrapper gets this image information
+/// from command line arguments provided by the clang driver when it creates
+/// the call to the __clang-offload-wrapper command.
+/// This architecture allows the binary image (pointed to by ImageStart and
+/// ImageEnd in __tgt_device_image) to remain architecture indenendent.
+/// That is, the architecture independent part of the libomptarget runtime
+/// does not need to peer inside the image to determine if it is loadable
+/// even though in most cases the image is an elf object.
+/// There is one __tgt_image_info for each __tgt_device_image. For backward
+/// compabibility, no changes are allowed to either __tgt_device_image or
+/// __tgt_bin_desc. The absense of __tgt_image_info is the indication that
+/// the runtime is being used on a binary created by an old version of
+/// the compiler.
+///
+struct __tgt_image_info {
+  int32_t version;           // The version of this struct
+  int32_t image_number;      // Image number in image library starting from 0
+  int32_t number_images;     // Number of images, used for initial allocation
+  char *targetid;            // e.g. sm_30, sm_70, gfx906, includes features
+  char *target_compile_opts; // reserved for future use
+};
+
+/// __tgt_active_offload_env
+///
+/// This structure is created by __tgt_get_active_offload_env and is used
+/// to determine compatibility of the images with the current environment
+/// that is "in play".  This information combined with the list of all
+/// __tgt_image_info's can also determine which plugins to load.
+struct __tgt_active_offload_env {
+  char *active_target; // string returned by active-offload-target
 };
 
 /// This struct contains the offload entries identified by the target runtime
@@ -157,6 +196,13 @@ void __tgt_register_requires(int64_t flags);
 
 /// adds a target shared library to the target execution image
 void __tgt_register_lib(__tgt_bin_desc *desc);
+
+/// adds an image information struct, called for each image
+void __tgt_register_image_info(__tgt_image_info *imageInfo);
+
+/// gets pointer to image information for specified image number
+/// Returns nullptr for apps built with old version of compiler
+__tgt_image_info *__tgt_get_image_info(uint32_t image_num);
 
 /// removes a target shared library from the target execution image
 void __tgt_unregister_lib(__tgt_bin_desc *desc);

--- a/openmp/libomptarget/src/exports
+++ b/openmp/libomptarget/src/exports
@@ -2,6 +2,7 @@ VERS1.0 {
   global:
     __tgt_register_requires;
     __tgt_register_lib;
+    __tgt_register_image_info;
     __tgt_unregister_lib;
     __tgt_target_data_begin;
     __tgt_target_data_end;

--- a/openmp/libomptarget/src/interface.cpp
+++ b/openmp/libomptarget/src/interface.cpp
@@ -105,6 +105,33 @@ EXTERN void __tgt_register_lib(__tgt_bin_desc *desc) {
   PM->RTLs.RegisterLib(desc);
 }
 
+// FIXME: malloc these with first call to register_image_info that now
+//        contains number of images.
+#define __TGT_MAX_IMAGES 16
+static __tgt_image_info *__tgt_AllImageInfos[__TGT_MAX_IMAGES];
+static bool __tgt_ImageInfoIsValid[__TGT_MAX_IMAGES] = {false};
+
+////////////////////////////////////////////////////////////////////////////////
+/// adds a target shared library to the target execution image
+EXTERN void __tgt_register_image_info(__tgt_image_info *imageInfo) {
+  DP(" register_image_info image %d of %d  targetid %s VERSION:%d\n",
+     imageInfo->image_number, imageInfo->number_images, imageInfo->targetid,
+     imageInfo->version);
+  if ((imageInfo->image_number + 1) > __TGT_MAX_IMAGES)
+    printf("ERROR: Too many images\n"); // FIXME: use malloc
+  __tgt_AllImageInfos[imageInfo->image_number] = imageInfo;
+  __tgt_ImageInfoIsValid[imageInfo->image_number] = true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return image information if it was registered
+EXTERN __tgt_image_info *__tgt_get_image_info(unsigned image_number) {
+  if (__tgt_ImageInfoIsValid[image_number])
+    return __tgt_AllImageInfos[image_number];
+  else
+    return nullptr;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// unloads a target shared library
 EXTERN void __tgt_unregister_lib(__tgt_bin_desc *desc) {

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -355,10 +355,12 @@ static void __tgt_get_active_offload_env(__tgt_active_offload_env *active_env,
   char *libomptarget_dir_name = new char[PATH_MAX];
   if (dlinfo(handle, RTLD_DI_ORIGIN, libomptarget_dir_name) == -1)
     DP("RTLD_DI_ORIGIN failed: %s\n", dlerror());
-  std::string cmd;
-  cmd.assign(libomptarget_dir_name).append("/../bin/active-offload-target");
+  std::string cmd_bin;
+  cmd_bin.assign(libomptarget_dir_name).append("/../bin/active-offload-target");
   struct stat stat_buffer;
-  if (stat(cmd.c_str(), &stat_buffer) == 0) {
+  if (stat(cmd_bin.c_str(), &stat_buffer) == 0) {
+    // Add flag to print required runtime features
+    std::string cmd = cmd_bin.append(" -r");
     FILE *stream = popen(cmd.c_str(), "r");
     while (fgets(env_buffer, env_buffer_size, stream) != NULL)
       ;
@@ -368,7 +370,7 @@ static void __tgt_get_active_offload_env(__tgt_active_offload_env *active_env,
     env_buffer[slen - 1] = '\0'; // terminate string before line feed
     env_buffer += slen;          // To store next value in env_buffer
   } else {
-    DP("Missing active-offload-target command at %s \n", cmd.c_str());
+    DP("Missing active-offload-target command at %s \n", cmd_bin.c_str());
   }
   delete[] libomptarget_dir_name;
 }

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -383,12 +383,14 @@ static bool _ImageIsCompatibleWithEnv(__tgt_image_info *img_info,
   if (!img_info)
     return true;
 
-  //  Currently, this strcmp forces only codeobjV4 images to work
+  //  Currently, these strcmp's forces only codeobjV4 or gnu images to work
   //             when active supports codeobjV4
   //  FIXME: If active image has codobjV4 then any image is acceptable
   //         MUST Still fail if image is codeobjV4 and active has
   //         no value.
-  if (strcmp(img_info->targetid, active_env->active_target))
+  // if target not the active env AND the target is not gnu, then no match
+  if (strcmp(img_info->targetid, active_env->active_target) &&
+      strcmp(img_info->targetid, "gnu"))
     return false;
 
   // FIXME: add feature comparisons here
@@ -417,7 +419,6 @@ void RTLsTy::RegisterLib(__tgt_bin_desc *desc) {
     // Scan the RTLs that have associated images until we find one that supports
     // the current image.
     for (auto &R : AllRTLs) {
-
       if (!_ImageIsCompatibleWithEnv(img_info, &offload_env)) {
         DP("Image w/targetid %s NOT compatible to active %s,\n		skip "
            "check of RTL %s ...\n",


### PR DESCRIPTION
…es for multiple GPU compilation which is a merge of upstream architecture for multiple GPUs with OpenMP.   That architecture uses one INSTANCE of a toolchain for each GPU.  This PR also includes end-to-end fixes for the active-offload-target utility and the openmp runtime to check active target with target info stored in the image info datastructures now created by clang-offload-wrapper.