### PR TITLE
Revert amd-stg-open fix for reduction_shared_array

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -696,14 +696,7 @@ static void EmitOMPAggregateInit(CodeGenFunction &CGF, Address DestAddr,
   if (DRD)
     SrcBegin = SrcAddr.getPointer();
   llvm::Value *DestBegin = DestAddr.getPointer();
-  // Cast from pointer to array type to pointer to single element.
-  llvm::Value *DestEnd;
-  if (CGF.getTarget().getTriple().isAMDGCN())
-    // addrspace resolution in InstructionSimplify does not work
-    // correctly when using normal GEP during the simplification of icmp
-    DestEnd = CGF.Builder.CreateInBoundsGEP(DestBegin, NumElements);
-  else
-    DestEnd = CGF.Builder.CreateGEP(DestBegin, NumElements);
+  llvm::Value *DestEnd = CGF.Builder.CreateGEP(DestBegin, NumElements);
   // The basic structure here is a while-do loop.
   llvm::BasicBlock *BodyBB = CGF.createBasicBlock("omp.arrayinit.body");
   llvm::BasicBlock *DoneBB = CGF.createBasicBlock("omp.arrayinit.done");


### PR DESCRIPTION
Fix for reduction_shared_array and reduction_array_section was different in amd-stg-open than in aomp-dev. Merge from amd-stg-open brought the fix into aomp-dev causing conflicts. I have reverted the amd-stg-open fix from aomp-dev.