### PR TITLE
Changes to libomptarget runtime to register image info requirements a…

### DIFF
--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -59,6 +59,12 @@ static cl::opt<std::string>
            cl::desc("Target triple for the output module"),
            cl::value_desc("triple"), cl::cat(ClangOffloadWrapperCategory));
 
+static cl::list<std::string> OffloadArchs(
+    "requirements",
+    cl::desc(
+        "requirements contains offload-arch + target offload-arch features"),
+    cl::value_desc("requirements"), cl::cat(ClangOffloadWrapperCategory));
+
 namespace {
 
 class BinaryWrapper {
@@ -68,6 +74,7 @@ class BinaryWrapper {
   StructType *EntryTy = nullptr;
   StructType *ImageTy = nullptr;
   StructType *DescTy = nullptr;
+  StructType *ImageInfoTy = nullptr;
 
 private:
   IntegerType *getSizeTTy() {
@@ -133,6 +140,27 @@ private:
     return PointerType::getUnqual(getBinDescTy());
   }
 
+  // This matches the runtime struct definition of __tgt_image_info
+  // declared in openmp/libomptarget/include/omptarget.h /
+  // struct __tgt_image_info {
+  //   int32_t version;
+  //   int32_t image_number;
+  //   int32_t number_images;
+  //   char* requirements;
+  //   char* target_compile_opts;
+  // };
+  StructType *getImageInfoTy() {
+    if (!ImageInfoTy)
+      ImageInfoTy = StructType::create(
+          "__tgt_image_info", Type::getInt32Ty(C), Type::getInt32Ty(C),
+          Type::getInt32Ty(C), Type::getInt8PtrTy(C), Type::getInt8PtrTy(C));
+    return ImageInfoTy;
+  }
+
+  PointerType *getImageInfoPtrTy() {
+    return PointerType::getUnqual(getImageInfoTy());
+  }
+
   /// Creates binary descriptor for the given device images. Binary descriptor
   /// is an object that is passed to the offloading runtime at program startup
   /// and it describes all device images available in the executable or shared
@@ -191,9 +219,8 @@ private:
         ConstantAggregateZero::get(ArrayType::get(getEntryTy(), 0u));
     auto *DummyEntry = new GlobalVariable(
         M, DummyInit->getType(), true,
-        Triple(Target).isAMDGCN() ?
-          GlobalVariable::WeakAnyLinkage :
-          GlobalVariable::ExternalLinkage,
+        Triple(Target).isAMDGCN() ? GlobalVariable::WeakAnyLinkage
+                                  : GlobalVariable::ExternalLinkage,
         DummyInit, "__dummy.omp_offloading.entry");
     DummyEntry->setSection("omp_offloading_entries");
     DummyEntry->setVisibility(GlobalValue::HiddenVisibility);
@@ -247,7 +274,9 @@ private:
                               ".omp_offloading.descriptor");
   }
 
-  void createRegisterFunction(GlobalVariable *BinDesc) {
+  void createRegisterFunction(GlobalVariable *BinDesc,
+                              ArrayRef<ArrayRef<char>> Requirements) {
+
     auto *FuncTy = FunctionType::get(Type::getVoidTy(C), /*isVarArg*/ false);
     auto *Func = Function::Create(FuncTy, GlobalValue::InternalLinkage,
                                   ".omp_offloading.descriptor_reg", &M);
@@ -261,6 +290,41 @@ private:
 
     // Construct function body
     IRBuilder<> Builder(BasicBlock::Create(C, "entry", Func));
+
+    // Create calls to __tgt_register_image_info for each image
+    auto *NullPtr = llvm::ConstantPointerNull::get(Builder.getInt8PtrTy());
+    auto *Zero = ConstantInt::get(getSizeTTy(), 0u);
+    auto *RegInfoFuncTy =
+        FunctionType::get(Type::getVoidTy(C), getImageInfoPtrTy(), false);
+    FunctionCallee RegInfoFuncC =
+        M.getOrInsertFunction("__tgt_register_image_info", RegInfoFuncTy);
+    unsigned int img_count = 0;
+    for (ArrayRef<char> Requirement : Requirements) {
+      Constant *RequirementV = ConstantDataArray::get(C, Requirement);
+      auto *GV =
+          new GlobalVariable(M, RequirementV->getType(), /*isConstant*/ true,
+                             GlobalValue::InternalLinkage, RequirementV,
+                             Twine("offload_arch_" + Twine(img_count)));
+      GV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+      auto *RequirementVPtr =
+          ConstantExpr::getGetElementPtr(GV->getValueType(), GV, Zero);
+      RequirementVPtr =
+          ConstantExpr::getBitCast(RequirementVPtr, Type::getInt8PtrTy(C));
+      auto *InfoInit = ConstantStruct::get(
+          getImageInfoTy(), ConstantInt::get(Type::getInt32Ty(C), 1),
+          ConstantInt::get(Type::getInt32Ty(C), img_count),
+          ConstantInt::get(Type::getInt32Ty(C), (uint32_t)Requirements.size()),
+          RequirementVPtr,
+          NullPtr // TODO: capture target-compile-opts from clang driver
+      );
+      auto *ImageInfoGV = new GlobalVariable(
+          M, InfoInit->getType(),
+          /*isConstant*/ true, GlobalValue::InternalLinkage, InfoInit,
+          Twine(".offload_image_info_" + Twine(img_count++)));
+      ImageInfoGV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+      Builder.CreateCall(RegInfoFuncC, ImageInfoGV);
+    }
+
     Builder.CreateCall(RegFuncC, BinDesc);
     Builder.CreateRetVoid();
 
@@ -300,10 +364,11 @@ public:
     M.setTargetTriple(Target);
   }
 
-  const Module &wrapBinaries(ArrayRef<ArrayRef<char>> Binaries) {
+  const Module &wrapBinaries(ArrayRef<ArrayRef<char>> Binaries,
+                             ArrayRef<ArrayRef<char>> Requirements) {
     GlobalVariable *Desc = createBinDesc(Binaries);
     assert(Desc && "no binary descriptor");
-    createRegisterFunction(Desc);
+    createRegisterFunction(Desc, Requirements);
     createUnregisterFunction(Desc);
     return M;
   }
@@ -365,10 +430,18 @@ int main(int argc, const char **argv) {
     return 1;
   }
 
+  SmallVector<ArrayRef<char>, 4u> Requirements;
+  Requirements.reserve(OffloadArchs.size());
+  for (unsigned i = 0; i != OffloadArchs.size(); ++i) {
+    Requirements.emplace_back(OffloadArchs[i].data(), OffloadArchs[i].size());
+  }
+
   // Create a wrapper for device binaries and write its bitcode to the file.
-  WriteBitcodeToFile(BinaryWrapper(Target).wrapBinaries(
-                         makeArrayRef(Images.data(), Images.size())),
-                     Out.os());
+  WriteBitcodeToFile(
+      BinaryWrapper(Target).wrapBinaries(
+          makeArrayRef(Images.data(), Images.size()),
+          makeArrayRef(Requirements.data(), Requirements.size())),
+      Out.os());
   if (Out.os().has_error()) {
     reportError(createFileError(Output, Out.os().error()));
     return 1;

--- a/openmp/libomptarget/include/omptarget.h
+++ b/openmp/libomptarget/include/omptarget.h
@@ -105,7 +105,7 @@ struct __tgt_offload_entry {
   int32_t reserved; // Reserved, to be used by the runtime library.
 };
 
-/// This struct is a record of the device image information
+/// This struct is a record of a device image
 struct __tgt_device_image {
   void *ImageStart;                  // Pointer to the target code start
   void *ImageEnd;                    // Pointer to the target code end
@@ -120,6 +120,44 @@ struct __tgt_bin_desc {
   __tgt_device_image *DeviceImages;  // Array of device images (1 per dev. type)
   __tgt_offload_entry *HostEntriesBegin; // Begin of table with all host entries
   __tgt_offload_entry *HostEntriesEnd;   // End of table (non inclusive)
+};
+
+/// __tgt_image_info:
+///
+/// The information in this struct is provided in clang-offload-wrapper
+/// as a call to __tgt_register_image_info for each image in the library
+/// of images also created created by clang-offload-wrapper.
+/// __tgt_register_image_info is called for each image BEFORE the single
+/// call to __tgt_register_lib so that image information is available
+/// before they are loaded.  clang-offload-wrapper gets this image information
+/// from command line arguments provided by the clang driver when it creates
+/// the call to the __clang-offload-wrapper command.
+/// This architecture allows the binary image (pointed to by ImageStart and
+/// ImageEnd in __tgt_device_image) to remain architecture indenendent.
+/// That is, the architecture independent part of the libomptarget runtime
+/// does not need to peer inside the image to determine if it is loadable
+/// even though in most cases the image is an elf object.
+/// There is one __tgt_image_info for each __tgt_device_image. For backward
+/// compabibility, no changes are allowed to either __tgt_device_image or
+/// __tgt_bin_desc. The absense of __tgt_image_info is the indication that
+/// the runtime is being used on a binary created by an old version of
+/// the compiler.
+///
+struct __tgt_image_info {
+  int32_t version;           // The version of this struct
+  int32_t image_number;      // Image number in image library starting from 0
+  int32_t number_images;     // Number of images, used for initial allocation
+  char *requirements;        // e.g. sm_30, sm_70, gfx906, includes features
+  char *compile_opts;        // reserved for future use
+};
+
+/// __tgt_active_offload_env
+///
+/// This structure is created by __tgt_get_active_offload_env and is used
+/// to determine compatibility of the images with the current environment
+/// that is "in play".
+struct __tgt_active_offload_env {
+  char *capabilities; // string returned by offload-arch -r
 };
 
 /// This struct contains the offload entries identified by the target runtime
@@ -210,6 +248,13 @@ void __tgt_register_requires(int64_t flags);
 
 /// adds a target shared library to the target execution image
 void __tgt_register_lib(__tgt_bin_desc *desc);
+
+/// adds an image information struct, called for each image
+void __tgt_register_image_info(__tgt_image_info *imageInfo);
+
+/// gets pointer to image information for specified image number
+/// Returns nullptr for apps built with old version of compiler
+__tgt_image_info *__tgt_get_image_info(uint32_t image_num);
 
 /// removes a target shared library from the target execution image
 void __tgt_unregister_lib(__tgt_bin_desc *desc);

--- a/openmp/libomptarget/src/exports
+++ b/openmp/libomptarget/src/exports
@@ -2,6 +2,7 @@ VERS1.0 {
   global:
     __tgt_register_requires;
     __tgt_register_lib;
+    __tgt_register_image_info;
     __tgt_unregister_lib;
     __tgt_target_data_begin;
     __tgt_target_data_end;

--- a/openmp/libomptarget/src/interface.cpp
+++ b/openmp/libomptarget/src/interface.cpp
@@ -43,6 +43,30 @@ EXTERN void __tgt_register_lib(__tgt_bin_desc *desc) {
   PM->RTLs.RegisterLib(desc);
 }
 
+static __tgt_image_info **__tgt_AllImageInfos;
+static int __tgt_num_registered_images = 0;
+EXTERN void __tgt_register_image_info(__tgt_image_info *imageInfo) {
+
+  DP(" register_image_info image %d of %d  requirements:%s VERSION:%d\n",
+     imageInfo->image_number, imageInfo->number_images, imageInfo->requirements,
+     imageInfo->version);
+
+  if (!__tgt_AllImageInfos)
+    __tgt_AllImageInfos = (__tgt_image_info **)malloc(
+        sizeof(__tgt_image_info *) * imageInfo->number_images);
+  __tgt_AllImageInfos[imageInfo->image_number] = imageInfo;
+  __tgt_num_registered_images = imageInfo->number_images;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return pointer to image information if it was registered
+EXTERN __tgt_image_info *__tgt_get_image_info(unsigned image_number) {
+  if (__tgt_num_registered_images)
+    return __tgt_AllImageInfos[image_number];
+  else
+    return nullptr;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// unloads a target shared library
 EXTERN void __tgt_unregister_lib(__tgt_bin_desc *desc) {
@@ -54,6 +78,10 @@ EXTERN void __tgt_unregister_lib(__tgt_bin_desc *desc) {
         DP("Could not register library with %s", RTL->RTLName.c_str());
       }
     }
+  }
+  if (__tgt_num_registered_images) {
+    free(__tgt_AllImageInfos);
+    __tgt_num_registered_images = 0;
   }
 }
 


### PR DESCRIPTION
…nd check against capabilities obtained with the offload-arch -r command

This is the changes to the libomptarget runtime and the clang-offload-wrapper tool .  The clang-offload-wrapper tool takes the value of the command line arg -requirements and writes them into a struct that gets processed with library registration.  The runtime runs the command offload-arch -r to pick up the current active runtime capabilities.  Then they are compared to see if the image can be run. 