### PR TITLE
[clang-offload-bundler] Add TargetID support and update SDL handling

### DIFF
--- a/openmp/libomptarget/hostrpc/CMakeLists.txt
+++ b/openmp/libomptarget/hostrpc/CMakeLists.txt
@@ -116,7 +116,7 @@ macro(add_openmp_library libname archname dir)
     # Extract the bitcode file to make aarch specific bitcode archive
     add_custom_command(
       OUTPUT ${bc_filename}
-      COMMAND ${LLVM_INSTALL_PREFIX}/bin/clang-offload-bundler -type=o -targets=openmp-${triple}-${GPU} -inputs=${obj_filename} -outputs=${bc_filename} -unbundle
+      COMMAND ${LLVM_INSTALL_PREFIX}/bin/clang-offload-bundler -type=o -targets=openmp-${triple}--${GPU} -inputs=${obj_filename} -outputs=${bc_filename} -unbundle
       DEPENDS ${obj_filename} )
 
     list(APPEND obj_files ${obj_filename})


### PR DESCRIPTION
 * Add support for TargetID in Bundle Entry ID
 * Add test cases for archive unbundling
 * Define compatibility between code objects
 * Support multiple targets for archive unbundling
 * Code cleanup

Note - This is first patch in the series of patches to support
targetID and multi-arch compilation in AOMP.