### PR TITLE
TargetID Support in AOMP - Part 1

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -174,6 +174,11 @@ private:
   mutable llvm::Optional<RuntimeLibType> runtimeLibType;
   mutable llvm::Optional<UnwindLibType> unwindLibType;
 
+  // OpenMP creates a toolchain for each target, which is uniquely
+  // defined as (Target Triple, TargetID).
+  // TargetID example "gfx908:sramecc+:xnack-".
+  std::string TargetID;
+
 protected:
   MultilibSet Multilibs;
   Multilib SelectedMultilib;
@@ -248,6 +253,12 @@ public:
   const llvm::Triple &getEffectiveTriple() const {
     assert(!EffectiveTriple.getTriple().empty() && "No effective triple");
     return EffectiveTriple;
+  }
+
+  const std::string getTargetID() const { return TargetID; }
+
+  void setTargetID(std::string TargetID) {
+    this->TargetID = std::move(TargetID);
   }
 
   path_list &getLibraryPaths() { return LibraryPaths; }

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -54,13 +54,8 @@ const char *Action::getClassName(ActionClass AC) {
 
 void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch) {
   // Offload action set its own kinds on their dependences.
-  // But we still need to preserve OffloadingDeviceKind and OffloadingArch
-  // where toplevel action is an unbundle.
-  if (Kind == OffloadClass) {
-    OffloadingDeviceKind = OKind;
-    OffloadingArch = OArch;
+  if (Kind == OffloadClass)
     return;
-  }
   // Unbundling actions use the host kinds.
   if (Kind == OffloadUnbundlingJobClass)
     return;
@@ -213,11 +208,23 @@ OffloadAction::OffloadAction(const HostDependence &HDep,
                              const DeviceDependences &DDeps)
     : Action(OffloadClass, HDep.getAction()), HostTC(HDep.getToolChain()),
       DevToolChains(DDeps.getToolChains()) {
-  // We use the kinds of the host dependence for this action.
-  OffloadingArch = HDep.getBoundArch();
+  auto &OKinds = DDeps.getOffloadKinds();
+  auto &BArchs = DDeps.getBoundArchs();
+
+  // If all inputs agree on the same kind, use it also for this action.
+  if (llvm::all_of(OKinds, [&](OffloadKind K) { return K == OKinds.front(); }))
+    OffloadingDeviceKind = OKinds.front();
+
+  // If we have a single dependency, inherit the architecture from it.
+  if (OKinds.size() == 1)
+    OffloadingArch = BArchs.front();
+  else
+    // We use the kinds of the host dependence for this action.
+    OffloadingArch = HDep.getBoundArch();
+
   ActiveOffloadKindMask = HDep.getOffloadKinds();
   HDep.getAction()->propagateHostOffloadInfo(HDep.getOffloadKinds(),
-                                             HDep.getBoundArch());
+                                             OffloadingArch);
 
   // Add device inputs and propagate info to the device actions. Do work only if
   // we have dependencies.

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -527,10 +527,15 @@ void amdgpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                                      const llvm::Triple &Triple,
                                      const llvm::opt::ArgList &Args,
-                                     std::vector<StringRef> &Features) {
+                                     std::vector<StringRef> &Features,
+                                     std::string TcTargetID) {
   // Add target ID features to -target-feature options. No diagnostics should
   // be emitted here since invalid target ID is diagnosed at other places.
   StringRef TargetID = Args.getLastArgValue(options::OPT_mcpu_EQ);
+
+  // Use this toolchain's TargetID if mcpu is not defined
+  if (TargetID.empty() && !TcTargetID.empty())
+    TargetID = TcTargetID;
   if (!TargetID.empty()) {
     llvm::StringMap<bool> FeatureMap;
     auto OptionalGpuArch = parseTargetID(Triple, TargetID, &FeatureMap);

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -39,7 +39,8 @@ public:
 
 void getAMDGPUTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                              const llvm::opt::ArgList &Args,
-                             std::vector<StringRef> &Features);
+                             std::vector<StringRef> &Features,
+                             std::string TcTargetID = std::string());
 
 } // end namespace amdgpu
 } // end namespace tools

--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -43,14 +43,14 @@ private:
   const char *constructOmpExtraCmds(Compilation &C, const JobAction &JA,
                                     const InputInfoList &Inputs,
                                     const llvm::opt::ArgList &Args,
-                                    llvm::StringRef SubArchName,
+                                    llvm::StringRef TargetID,
                                     llvm::StringRef OutputFilePrefix) const;
 
   /// \return llvm-link output file name.
   const char *constructLLVMLinkCommand(Compilation &C, const JobAction &JA,
                                        const InputInfoList &Inputs,
                                        const llvm::opt::ArgList &Args,
-                                       llvm::StringRef SubArchName,
+                                       llvm::StringRef TargetID,
                                        llvm::StringRef OutputFilePrefix) const;
 
   /// \return opt output file name.
@@ -87,6 +87,11 @@ public:
                         const ToolChain &HostTC,
                         const llvm::opt::ArgList &Args,
                         const Action::OffloadKind OK);
+
+  AMDGPUOpenMPToolChain(const Driver &D, const llvm::Triple &Triple,
+                        const ToolChain &HostTC, const llvm::opt::ArgList &Args,
+                        const Action::OffloadKind OK,
+                        const std::string TargetID);
 
   const llvm::Triple *getAuxTriple() const override {
     return &HostTC.getTriple();

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -338,7 +338,12 @@ void tools::AddTargetFeature(const ArgList &Args,
 /// Get the (LLVM) name of the AMDGPU gpu we are targeting.
 static std::string getAMDGPUTargetGPU(const llvm::Triple &T,
                                       const ArgList &Args) {
-  if (Arg *A = Args.getLastArg(options::OPT_mcpu_EQ)) {
+  Arg *A = Args.getLastArg(options::OPT_mcpu_EQ);
+  if (!A)
+    A = Args.getLastArg(options::OPT_march_EQ);
+  if (!A)
+    A = Args.getLastArg(options::OPT_offload_arch_EQ);
+  if (A) {
     auto GPUName = getProcessorFromTargetID(T, A->getValue());
     return llvm::StringSwitch<std::string>(GPUName)
         .Cases("rv630", "rv635", "r600")
@@ -1717,17 +1722,15 @@ bool tools::SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
   return FoundSDL;
 }
 
-bool tools::GetSDLFromOffloadArchive(Compilation &C, const Driver &D,
-                                     const Tool &T, const JobAction &JA,
-                                     const InputInfoList &Inputs,
-                                     const llvm::opt::ArgList &DriverArgs,
-                                     llvm::opt::ArgStringList &CC1Args,
-                                     SmallVector<std::string, 8> LibraryPaths,
-                                     std::string libname, StringRef ArchName,
-                                     StringRef GpuArch, bool isBitCodeSDL,
-                                     bool postClangLink) {
+bool tools::GetSDLFromOffloadArchive(
+    Compilation &C, const Driver &D, const Tool &T, const JobAction &JA,
+    const InputInfoList &Inputs, const llvm::opt::ArgList &DriverArgs,
+    llvm::opt::ArgStringList &CC1Args, SmallVector<std::string, 8> LibraryPaths,
+    std::string libname, StringRef ArchName, StringRef TargetID,
+    bool isBitCodeSDL, bool postClangLink) {
   std::string archname = ArchName.str();
-  std::string gpuname = GpuArch.str();
+  std::string gpuname =
+      getProcessorFromTargetID(T.getToolChain().getTriple(), TargetID).str();
 
   // We don't support bitcode archive bundles for nvptx
   if (isBitCodeSDL && archname == "nvptx")
@@ -1762,10 +1765,10 @@ bool tools::GetSDLFromOffloadArchive(Compilation &C, const Driver &D,
       ArgStringList CmdArgs;
       SmallString<128> DeviceTriple;
       DeviceTriple += Action::GetOffloadKindName(JA.getOffloadingDeviceKind());
-      DeviceTriple += '-';
+      DeviceTriple += "-";
       DeviceTriple += T.getToolChain().getTriple().normalize();
-      DeviceTriple += '-';
-      DeviceTriple += gpuname;
+      DeviceTriple += "--";
+      DeviceTriple += TargetID;
 
       std::string UnbundleArg("-unbundle");
       std::string TypeArg("-type=a");
@@ -1782,6 +1785,12 @@ bool tools::GetSDLFromOffloadArchive(Compilation &C, const Driver &D,
       UBArgs.push_back(C.getArgs().MakeArgString(InputArg.c_str()));
       UBArgs.push_back(C.getArgs().MakeArgString(OffloadArg.c_str()));
       UBArgs.push_back(C.getArgs().MakeArgString(OutputArg.c_str()));
+
+      // Add this flag to not exit from clang-offload-bundler if no compatible
+      // code object is found in heterogenous archive library.
+      // std::string AdditionalArgs("-allow-missing-bundles");
+      // UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
+
       C.addCommand(std::make_unique<Command>(
           JA, T, ResponseFileSupport::AtFileCurCP(), UBProgram, UBArgs, Inputs,
           InputInfo(&JA, C.getArgs().MakeArgString(OutputLib.c_str()))));
@@ -1801,19 +1810,19 @@ void tools::AddStaticDeviceLibs(Compilation &C, const Tool &T,
                                 const InputInfoList &Inputs,
                                 const llvm::opt::ArgList &DriverArgs,
                                 llvm::opt::ArgStringList &CC1Args,
-                                StringRef ArchName, StringRef GpuArch,
+                                StringRef ArchName, StringRef TargetID,
                                 bool isBitCodeSDL, bool postClangLink) {
   AddStaticDeviceLibs(&C, &T, &JA, &Inputs, C.getDriver(), DriverArgs, CC1Args,
-                      ArchName, GpuArch, isBitCodeSDL, postClangLink);
+                      ArchName, TargetID, isBitCodeSDL, postClangLink);
 }
 
 void tools::AddStaticDeviceLibs(const Driver &D,
                                 const llvm::opt::ArgList &DriverArgs,
                                 llvm::opt::ArgStringList &CC1Args,
-                                StringRef ArchName, StringRef GpuArch,
+                                StringRef ArchName, StringRef TargetID,
                                 bool isBitCodeSDL, bool postClangLink) {
   AddStaticDeviceLibs(nullptr, nullptr, nullptr, nullptr, D, DriverArgs,
-                      CC1Args, ArchName, GpuArch, isBitCodeSDL, postClangLink);
+                      CC1Args, ArchName, TargetID, isBitCodeSDL, postClangLink);
 }
 
 void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
@@ -1821,7 +1830,7 @@ void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
                                 const InputInfoList *Inputs, const Driver &D,
                                 const llvm::opt::ArgList &DriverArgs,
                                 llvm::opt::ArgStringList &CC1Args,
-                                StringRef ArchName, StringRef GpuArch,
+                                StringRef ArchName, StringRef TargetID,
                                 bool isBitCodeSDL, bool postClangLink) {
 
   SmallVector<std::string, 8> LibraryPaths;
@@ -1862,12 +1871,16 @@ void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
     }
   }
 
+  // SDL name only contains the processor name, while TargetID is required
+  // to extract compatible code objects.
+  StringRef GpuArch =
+      getProcessorFromTargetID(T->getToolChain().getTriple(), TargetID);
   for (std::string SDL_Name : SDL_Names) {
     //  THIS IS THE ONLY CALL TO SDLSearch
     if (!(SDLSearch(D, DriverArgs, CC1Args, LibraryPaths, SDL_Name, ArchName,
                     GpuArch, isBitCodeSDL, postClangLink))) {
       GetSDLFromOffloadArchive(*C, D, *T, *JA, *Inputs, DriverArgs, CC1Args,
-                               LibraryPaths, SDL_Name, ArchName, GpuArch,
+                               LibraryPaths, SDL_Name, ArchName, TargetID,
                                isBitCodeSDL, postClangLink);
     }
   }

--- a/clang/lib/Driver/ToolChains/CommonArgs.h
+++ b/clang/lib/Driver/ToolChains/CommonArgs.h
@@ -56,23 +56,23 @@ void AddStaticDeviceLibs(Compilation &C, const Tool &T, const JobAction &JA,
                          const InputInfoList &Inputs,
                          const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 void AddStaticDeviceLibs(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 void AddStaticDeviceLibs(Compilation *C, const Tool *T, const JobAction *JA,
-                         const InputInfoList *Inputs,
-                         const Driver &D, const llvm::opt::ArgList &DriverArgs,
+                         const InputInfoList *Inputs, const Driver &D,
+                         const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 
 bool SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                llvm::opt::ArgStringList &CmdArgs,
                SmallVector<std::string, 8> LibraryPaths, std::string libname,
-               StringRef ArchName, StringRef GpuArch, bool isBitCodeSDL,
+               StringRef ArchName, StringRef TargetID, bool isBitCodeSDL,
                bool postClangLink);
 
 bool GetSDLFromOffloadArchive(Compilation &C, const Driver &D, const Tool &T,
@@ -81,7 +81,7 @@ bool GetSDLFromOffloadArchive(Compilation &C, const Driver &D, const Tool &T,
                               llvm::opt::ArgStringList &CC1Args,
                               SmallVector<std::string, 8> LibraryPaths,
                               std::string libname, StringRef ArchName,
-                              StringRef GpuArch, bool isBitCodeSDL,
+                              StringRef TargetID, bool isBitCodeSDL,
                               bool postClangLink);
 
 const char *SplitDebugName(const JobAction &JA, const llvm::opt::ArgList &Args,

--- a/clang/lib/Driver/ToolChains/Cuda.h
+++ b/clang/lib/Driver/ToolChains/Cuda.h
@@ -134,6 +134,10 @@ public:
                 const ToolChain &HostTC, const llvm::opt::ArgList &Args,
                 const Action::OffloadKind OK);
 
+  CudaToolChain(const Driver &D, const llvm::Triple &Triple,
+                const ToolChain &HostTC, const llvm::opt::ArgList &Args,
+                const Action::OffloadKind OK, const std::string TargetID);
+
   const llvm::Triple *getAuxTriple() const override {
     return &HostTC.getTriple();
   }

--- a/openmp/libomptarget/hostrpc/CMakeLists.txt
+++ b/openmp/libomptarget/hostrpc/CMakeLists.txt
@@ -116,7 +116,7 @@ macro(add_openmp_library libname archname dir)
     # Extract the bitcode file to make aarch specific bitcode archive
     add_custom_command(
       OUTPUT ${bc_filename}
-      COMMAND ${LLVM_INSTALL_PREFIX}/bin/clang-offload-bundler -type=o -targets=openmp-${triple}-${GPU} -inputs=${obj_filename} -outputs=${bc_filename} -unbundle
+      COMMAND ${LLVM_INSTALL_PREFIX}/bin/clang-offload-bundler -type=o -targets=openmp-${triple}--${GPU} -inputs=${obj_filename} -outputs=${bc_filename} -unbundle
       DEPENDS ${obj_filename} )
 
     list(APPEND obj_files ${obj_filename})


### PR DESCRIPTION
This patch introduces TargetID as a target specific specialized
string in clang frontend, without changing the Driver. It is
first patch to lay ground work for subsequent changes in Driver.
  * For each offloading target, an instance of toolchain is created
     with TargetID being one of the fields.
  * User specifies TargetID as argument of "--offload-arch" command
     line flag.

This patch is based on saiislam/llvm-project's target-id-0 branch.
So, after review and merge of PR #123, this PR should automatically
base itself on aomp-dev.