### PR TITLE
TargetID Support in AOMP - Part 1

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -174,6 +174,11 @@ private:
   mutable llvm::Optional<RuntimeLibType> runtimeLibType;
   mutable llvm::Optional<UnwindLibType> unwindLibType;
 
+  // OpenMP creates a toolchain for each target, which is uniquely
+  // defined as (Target Triple, TargetID).
+  // TargetID example "gfx908:sramecc+:xnack-".
+  std::string TargetID;
+
 protected:
   MultilibSet Multilibs;
   Multilib SelectedMultilib;
@@ -248,6 +253,12 @@ public:
   const llvm::Triple &getEffectiveTriple() const {
     assert(!EffectiveTriple.getTriple().empty() && "No effective triple");
     return EffectiveTriple;
+  }
+
+  const std::string getTargetID() const { return TargetID; }
+
+  void setTargetID(std::string TargetID) {
+    this->TargetID = std::move(TargetID);
   }
 
   path_list &getLibraryPaths() { return LibraryPaths; }

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -54,13 +54,8 @@ const char *Action::getClassName(ActionClass AC) {
 
 void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch) {
   // Offload action set its own kinds on their dependences.
-  // But we still need to preserve OffloadingDeviceKind and OffloadingArch
-  // where toplevel action is an unbundle.
-  if (Kind == OffloadClass) {
-    OffloadingDeviceKind = OKind;
-    OffloadingArch = OArch;
+  if (Kind == OffloadClass)
     return;
-  }
   // Unbundling actions use the host kinds.
   if (Kind == OffloadUnbundlingJobClass)
     return;
@@ -213,11 +208,23 @@ OffloadAction::OffloadAction(const HostDependence &HDep,
                              const DeviceDependences &DDeps)
     : Action(OffloadClass, HDep.getAction()), HostTC(HDep.getToolChain()),
       DevToolChains(DDeps.getToolChains()) {
-  // We use the kinds of the host dependence for this action.
-  OffloadingArch = HDep.getBoundArch();
+  auto &OKinds = DDeps.getOffloadKinds();
+  auto &BArchs = DDeps.getBoundArchs();
+
+  // If all inputs agree on the same kind, use it also for this action.
+  if (llvm::all_of(OKinds, [&](OffloadKind K) { return K == OKinds.front(); }))
+    OffloadingDeviceKind = OKinds.front();
+
+  // If we have a single dependency, inherit the architecture from it.
+  if (OKinds.size() == 1)
+    OffloadingArch = BArchs.front();
+  else
+    // We use the kinds of the host dependence for this action.
+    OffloadingArch = HDep.getBoundArch();
+
   ActiveOffloadKindMask = HDep.getOffloadKinds();
   HDep.getAction()->propagateHostOffloadInfo(HDep.getOffloadKinds(),
-                                             HDep.getBoundArch());
+                                             OffloadingArch);
 
   // Add device inputs and propagate info to the device actions. Do work only if
   // we have dependencies.

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -527,10 +527,15 @@ void amdgpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                                      const llvm::Triple &Triple,
                                      const llvm::opt::ArgList &Args,
-                                     std::vector<StringRef> &Features) {
+                                     std::vector<StringRef> &Features,
+                                     std::string TcTargetID) {
   // Add target ID features to -target-feature options. No diagnostics should
   // be emitted here since invalid target ID is diagnosed at other places.
   StringRef TargetID = Args.getLastArgValue(options::OPT_mcpu_EQ);
+
+  // Use this toolchain's TargetID if mcpu is not defined
+  if (TargetID.empty() && !TcTargetID.empty())
+    TargetID = TcTargetID;
   if (!TargetID.empty()) {
     llvm::StringMap<bool> FeatureMap;
     auto OptionalGpuArch = parseTargetID(Triple, TargetID, &FeatureMap);

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -39,7 +39,8 @@ public:
 
 void getAMDGPUTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                              const llvm::opt::ArgList &Args,
-                             std::vector<StringRef> &Features);
+                             std::vector<StringRef> &Features,
+                             std::string TcTargetID = std::string());
 
 } // end namespace amdgpu
 } // end namespace tools

--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -43,14 +43,14 @@ private:
   const char *constructOmpExtraCmds(Compilation &C, const JobAction &JA,
                                     const InputInfoList &Inputs,
                                     const llvm::opt::ArgList &Args,
-                                    llvm::StringRef SubArchName,
+                                    llvm::StringRef TargetID,
                                     llvm::StringRef OutputFilePrefix) const;
 
   /// \return llvm-link output file name.
   const char *constructLLVMLinkCommand(Compilation &C, const JobAction &JA,
                                        const InputInfoList &Inputs,
                                        const llvm::opt::ArgList &Args,
-                                       llvm::StringRef SubArchName,
+                                       llvm::StringRef TargetID,
                                        llvm::StringRef OutputFilePrefix) const;
 
   /// \return opt output file name.
@@ -87,6 +87,11 @@ public:
                         const ToolChain &HostTC,
                         const llvm::opt::ArgList &Args,
                         const Action::OffloadKind OK);
+
+  AMDGPUOpenMPToolChain(const Driver &D, const llvm::Triple &Triple,
+                        const ToolChain &HostTC, const llvm::opt::ArgList &Args,
+                        const Action::OffloadKind OK,
+                        const std::string TargetID);
 
   const llvm::Triple *getAuxTriple() const override {
     return &HostTC.getTriple();

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6508,20 +6508,19 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // For all the host OpenMP offloading compile jobs we need to pass the targets
-  // information using -fopenmp-targets= option.
+  // information using legacy -fopenmp-targets= option.
   if (JA.isHostOffloading(Action::OFK_OpenMP)) {
     SmallString<128> TargetInfo("-fopenmp-targets=");
 
-    Arg *Tgts = Args.getLastArg(options::OPT_fopenmp_targets_EQ);
-    assert(Tgts && Tgts->getNumValues() &&
-           "OpenMP offloading has to have targets specified.");
-    for (unsigned i = 0; i < Tgts->getNumValues(); ++i) {
-      if (i)
-        TargetInfo += ',';
-      // We need to get the string from the triple because it may be not exactly
-      // the same as the one we get directly from the arguments.
-      llvm::Triple T(Tgts->getValue(i));
-      TargetInfo += T.getTriple();
+    // Get list of device Toolchains
+    auto OpenMPTCRange = C.getOffloadToolChains<Action::OFK_OpenMP>();
+    assert(
+        (OpenMPTCRange.first != OpenMPTCRange.second) &&
+        "OpenMP offloading requires target devices , specify --offload-arch.");
+    for (auto TI = OpenMPTCRange.first, TE = OpenMPTCRange.second; TI != TE;
+         ++TI) {
+      auto *deviceTC = TI->second;
+      TargetInfo += deviceTC->getTriple().str();
     }
     CmdArgs.push_back(Args.MakeArgString(TargetInfo.str()));
   }
@@ -7482,6 +7481,7 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
   //   -inputs=unbundle_file_host,unbundle_file_tgt1,unbundle_file_tgt2"
 
   ArgStringList CmdArgs;
+  StringRef TargetID;
 
   // Get the type.
   CmdArgs.push_back(TCArgs.MakeArgString(
@@ -7516,8 +7516,14 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
     if ((CurKind == Action::OFK_HIP || CurKind == Action::OFK_OpenMP ||
          CurKind == Action::OFK_Cuda) &&
         CurDep->getOffloadingArch()) {
-      Triples += '-';
+      // clang-offload-bundler requires all 4 components in bundle entry ID.
+      // Add an extra '-' to represent empty triple.environment.
+      Triples += "--";
       Triples += CurDep->getOffloadingArch();
+    }
+    if ((CurKind == Action::OFK_OpenMP || CurKind == Action::OFK_Cuda)) {
+      Triples += "--";
+      Triples += CurTC->getTargetID();
     }
   }
   CmdArgs.push_back(TCArgs.MakeArgString(Triples));
@@ -7715,9 +7721,40 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
 
-  // Add inputs.
+  // Get the Code Object Version used by all offload-archs in this compilation
+  unsigned CodeObjVer = 0;
+  auto TCs = C.getOffloadToolChains<Action::OFK_OpenMP>();
+  for (auto II = TCs.first, IE = TCs.second; II != IE; ++II) {
+    auto TC = II->second;
+    if (TC->getArch() == llvm::Triple::amdgcn)
+      CodeObjVer = getOrCheckAMDGPUCodeObjectVersion(C.getDriver(), Args);
+  }
+
+  // Add runtime requirements on each image which includes the offload-arch
+  auto II = TCs.first;
   for (const InputInfo &I : Inputs) {
     assert(I.isFilename() && "Invalid input.");
+    if (I.getAction()) {
+      auto TC = II->second;
+      II++;
+      std::string requirements("--requirements=");
+      requirements.append(TC->getTargetID());
+      // targetid could have user specified features such as :xnack-:sramecc+
+      // so replace ":" with "__" in requirements used for
+      // clang-offload-wrapper.
+      size_t start_pos = 0;
+      while ((start_pos = requirements.find(":", start_pos)) !=
+             std::string::npos) {
+        requirements.replace(start_pos, 1, "__");
+        start_pos += 2;
+      }
+      if (CodeObjVer > 3) // Add implied CodeObjVer feature.
+        requirements.append(
+            Args.MakeArgString(Twine("__CodeObjVer") + Twine(CodeObjVer)));
+
+      // FIXME: Add other architecture requirements here
+      CmdArgs.push_back(Args.MakeArgString(requirements.c_str()));
+    }
     CmdArgs.push_back(I.getFilename());
   }
 

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1788,8 +1788,8 @@ bool tools::GetSDLFromOffloadArchive(
 
       // Add this flag to not exit from clang-offload-bundler if no compatible
       // code object is found in heterogenous archive library.
-      // std::string AdditionalArgs("-allow-missing-bundles");
-      // UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
+      std::string AdditionalArgs("-allow-missing-bundles");
+      UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
 
       C.addCommand(std::make_unique<Command>(
           JA, T, ResponseFileSupport::AtFileCurCP(), UBProgram, UBArgs, Inputs,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -338,7 +338,12 @@ void tools::AddTargetFeature(const ArgList &Args,
 /// Get the (LLVM) name of the AMDGPU gpu we are targeting.
 static std::string getAMDGPUTargetGPU(const llvm::Triple &T,
                                       const ArgList &Args) {
-  if (Arg *A = Args.getLastArg(options::OPT_mcpu_EQ)) {
+  Arg *A = Args.getLastArg(options::OPT_mcpu_EQ);
+  if (!A)
+    A = Args.getLastArg(options::OPT_march_EQ);
+  if (!A)
+    A = Args.getLastArg(options::OPT_offload_arch_EQ);
+  if (A) {
     auto GPUName = getProcessorFromTargetID(T, A->getValue());
     return llvm::StringSwitch<std::string>(GPUName)
         .Cases("rv630", "rv635", "r600")
@@ -1717,17 +1722,15 @@ bool tools::SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
   return FoundSDL;
 }
 
-bool tools::GetSDLFromOffloadArchive(Compilation &C, const Driver &D,
-                                     const Tool &T, const JobAction &JA,
-                                     const InputInfoList &Inputs,
-                                     const llvm::opt::ArgList &DriverArgs,
-                                     llvm::opt::ArgStringList &CC1Args,
-                                     SmallVector<std::string, 8> LibraryPaths,
-                                     std::string libname, StringRef ArchName,
-                                     StringRef GpuArch, bool isBitCodeSDL,
-                                     bool postClangLink) {
+bool tools::GetSDLFromOffloadArchive(
+    Compilation &C, const Driver &D, const Tool &T, const JobAction &JA,
+    const InputInfoList &Inputs, const llvm::opt::ArgList &DriverArgs,
+    llvm::opt::ArgStringList &CC1Args, SmallVector<std::string, 8> LibraryPaths,
+    std::string libname, StringRef ArchName, StringRef TargetID,
+    bool isBitCodeSDL, bool postClangLink) {
   std::string archname = ArchName.str();
-  std::string gpuname = GpuArch.str();
+  std::string gpuname =
+      getProcessorFromTargetID(T.getToolChain().getTriple(), TargetID).str();
 
   // We don't support bitcode archive bundles for nvptx
   if (isBitCodeSDL && archname == "nvptx")
@@ -1762,10 +1765,10 @@ bool tools::GetSDLFromOffloadArchive(Compilation &C, const Driver &D,
       ArgStringList CmdArgs;
       SmallString<128> DeviceTriple;
       DeviceTriple += Action::GetOffloadKindName(JA.getOffloadingDeviceKind());
-      DeviceTriple += '-';
+      DeviceTriple += "-";
       DeviceTriple += T.getToolChain().getTriple().normalize();
-      DeviceTriple += '-';
-      DeviceTriple += gpuname;
+      DeviceTriple += "--";
+      DeviceTriple += TargetID;
 
       std::string UnbundleArg("-unbundle");
       std::string TypeArg("-type=a");
@@ -1782,6 +1785,12 @@ bool tools::GetSDLFromOffloadArchive(Compilation &C, const Driver &D,
       UBArgs.push_back(C.getArgs().MakeArgString(InputArg.c_str()));
       UBArgs.push_back(C.getArgs().MakeArgString(OffloadArg.c_str()));
       UBArgs.push_back(C.getArgs().MakeArgString(OutputArg.c_str()));
+
+      // Add this flag to not exit from clang-offload-bundler if no compatible
+      // code object is found in heterogenous archive library.
+      // std::string AdditionalArgs("-allow-missing-bundles");
+      // UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
+
       C.addCommand(std::make_unique<Command>(
           JA, T, ResponseFileSupport::AtFileCurCP(), UBProgram, UBArgs, Inputs,
           InputInfo(&JA, C.getArgs().MakeArgString(OutputLib.c_str()))));
@@ -1801,19 +1810,19 @@ void tools::AddStaticDeviceLibs(Compilation &C, const Tool &T,
                                 const InputInfoList &Inputs,
                                 const llvm::opt::ArgList &DriverArgs,
                                 llvm::opt::ArgStringList &CC1Args,
-                                StringRef ArchName, StringRef GpuArch,
+                                StringRef ArchName, StringRef TargetID,
                                 bool isBitCodeSDL, bool postClangLink) {
   AddStaticDeviceLibs(&C, &T, &JA, &Inputs, C.getDriver(), DriverArgs, CC1Args,
-                      ArchName, GpuArch, isBitCodeSDL, postClangLink);
+                      ArchName, TargetID, isBitCodeSDL, postClangLink);
 }
 
 void tools::AddStaticDeviceLibs(const Driver &D,
                                 const llvm::opt::ArgList &DriverArgs,
                                 llvm::opt::ArgStringList &CC1Args,
-                                StringRef ArchName, StringRef GpuArch,
+                                StringRef ArchName, StringRef TargetID,
                                 bool isBitCodeSDL, bool postClangLink) {
   AddStaticDeviceLibs(nullptr, nullptr, nullptr, nullptr, D, DriverArgs,
-                      CC1Args, ArchName, GpuArch, isBitCodeSDL, postClangLink);
+                      CC1Args, ArchName, TargetID, isBitCodeSDL, postClangLink);
 }
 
 void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
@@ -1821,7 +1830,7 @@ void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
                                 const InputInfoList *Inputs, const Driver &D,
                                 const llvm::opt::ArgList &DriverArgs,
                                 llvm::opt::ArgStringList &CC1Args,
-                                StringRef ArchName, StringRef GpuArch,
+                                StringRef ArchName, StringRef TargetID,
                                 bool isBitCodeSDL, bool postClangLink) {
 
   SmallVector<std::string, 8> LibraryPaths;
@@ -1862,12 +1871,16 @@ void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
     }
   }
 
+  // SDL name only contains the processor name, while TargetID is required
+  // to extract compatible code objects.
+  StringRef GpuArch =
+      getProcessorFromTargetID(T->getToolChain().getTriple(), TargetID);
   for (std::string SDL_Name : SDL_Names) {
     //  THIS IS THE ONLY CALL TO SDLSearch
     if (!(SDLSearch(D, DriverArgs, CC1Args, LibraryPaths, SDL_Name, ArchName,
                     GpuArch, isBitCodeSDL, postClangLink))) {
       GetSDLFromOffloadArchive(*C, D, *T, *JA, *Inputs, DriverArgs, CC1Args,
-                               LibraryPaths, SDL_Name, ArchName, GpuArch,
+                               LibraryPaths, SDL_Name, ArchName, TargetID,
                                isBitCodeSDL, postClangLink);
     }
   }

--- a/clang/lib/Driver/ToolChains/CommonArgs.h
+++ b/clang/lib/Driver/ToolChains/CommonArgs.h
@@ -56,23 +56,23 @@ void AddStaticDeviceLibs(Compilation &C, const Tool &T, const JobAction &JA,
                          const InputInfoList &Inputs,
                          const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 void AddStaticDeviceLibs(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 void AddStaticDeviceLibs(Compilation *C, const Tool *T, const JobAction *JA,
-                         const InputInfoList *Inputs,
-                         const Driver &D, const llvm::opt::ArgList &DriverArgs,
+                         const InputInfoList *Inputs, const Driver &D,
+                         const llvm::opt::ArgList &DriverArgs,
                          llvm::opt::ArgStringList &CmdArgs, StringRef ArchName,
-                         StringRef GpuArch, bool isBitCodeSDL,
+                         StringRef TargetID, bool isBitCodeSDL,
                          bool postClangLink);
 
 bool SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                llvm::opt::ArgStringList &CmdArgs,
                SmallVector<std::string, 8> LibraryPaths, std::string libname,
-               StringRef ArchName, StringRef GpuArch, bool isBitCodeSDL,
+               StringRef ArchName, StringRef TargetID, bool isBitCodeSDL,
                bool postClangLink);
 
 bool GetSDLFromOffloadArchive(Compilation &C, const Driver &D, const Tool &T,
@@ -81,7 +81,7 @@ bool GetSDLFromOffloadArchive(Compilation &C, const Driver &D, const Tool &T,
                               llvm::opt::ArgStringList &CC1Args,
                               SmallVector<std::string, 8> LibraryPaths,
                               std::string libname, StringRef ArchName,
-                              StringRef GpuArch, bool isBitCodeSDL,
+                              StringRef TargetID, bool isBitCodeSDL,
                               bool postClangLink);
 
 const char *SplitDebugName(const JobAction &JA, const llvm::opt::ArgList &Args,

--- a/clang/lib/Driver/ToolChains/Cuda.h
+++ b/clang/lib/Driver/ToolChains/Cuda.h
@@ -134,6 +134,10 @@ public:
                 const ToolChain &HostTC, const llvm::opt::ArgList &Args,
                 const Action::OffloadKind OK);
 
+  CudaToolChain(const Driver &D, const llvm::Triple &Triple,
+                const ToolChain &HostTC, const llvm::opt::ArgList &Args,
+                const Action::OffloadKind OK, const std::string TargetID);
+
   const llvm::Triple *getAuxTriple() const override {
     return &HostTC.getTriple();
   }

--- a/clang/test/Driver/amdgcn-toolchain-openmp-duplicate-arguments.c
+++ b/clang/test/Driver/amdgcn-toolchain-openmp-duplicate-arguments.c
@@ -22,7 +22,7 @@
 // DUP-NOT:  "-mllvm" "-amdgpu-dump-hsa-metadata" "-mllvm" "-amdgpu-dump-hsa-metadata"
 // CHECK-SAME: "-fopenmp-is-device"
 
-// CHECK: [[OPT:".*llc.*"]] {{".*-gfx906-linked.*bc"}} "-mtriple=amdgcn-amd-amdhsa"
+// CHECK: [[OPT:".*llc.*"]] {{".*-gfx906-optimized.*bc"}} "-mtriple=amdgcn-amd-amdhsa"
 // CHECK-SAME: "-mcpu=gfx906"
 // CHECK-SAME: "-amdgpu-dump-hsa-metadata"
 // DUP-NOT: "-amdgpu-dump-hsa-metadata" "-amdgpu-dump-hsa-metadata"

--- a/clang/test/Driver/hip-toolchain-rdc-separate.hip
+++ b/clang/test/Driver/hip-toolchain-rdc-separate.hip
@@ -44,7 +44,7 @@
 // CHECK-SAME: {{.*}} [[A_SRC]]
 
 // CHECK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900,host-x86_64-unknown-linux-gnu"
+// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900,host-x86_64-unknown-linux-gnu"
 // CHECK-SAME: "-outputs=[[A_O:.*a.o]]" "-inputs=[[A_BC1]],[[A_BC2]],[[A_OBJ_HOST]]"
 
 // CHECK: [[CLANG]] "-cc1" "-mllvm" "--amdhsa-code-object-version={{[0-9]+}}" "-triple" "amdgcn-amd-amdhsa"
@@ -79,7 +79,7 @@
 // CHECK-SAME: {{.*}} [[B_SRC]]
 
 // CHECK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900,host-x86_64-unknown-linux-gnu"
+// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900,host-x86_64-unknown-linux-gnu"
 // CHECK-SAME: "-outputs=[[B_O:.*b.o]]" "-inputs=[[B_BC1]],[[B_BC2]],[[B_OBJ_HOST]]"
 
 // RUN: touch %T/a.o
@@ -91,22 +91,22 @@
 // RUN: 2>&1 | FileCheck -check-prefix=LINK %s
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[A_O:.*a.o]]" "-outputs=[[A_OBJ_HOST:.*o]],{{.*o}},{{.*o}}"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[B_O:.*b.o]]" "-outputs=[[B_OBJ_HOST:.*o]],{{.*o}},{{.*o}}"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[A_O]]" "-outputs={{.*o}},[[A_BC1:.*o]],[[A_BC2:.*o]]"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[B_O]]" "-outputs={{.*o}},[[B_BC1:.*o]],[[B_BC2:.*o]]"
 // LINK: "-unbundle" "-allow-missing-bundles"
 

--- a/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
+++ b/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
@@ -74,34 +74,6 @@ static cl::opt<bool> BuiltinCode("mlink-builtin-bitcode", cl::desc("Ignore optio
 
 static ExitOnError ExitOnErr;
 
-/// ---------------------------------------------
-// Show the error message and exit.
-LLVM_ATTRIBUTE_NORETURN static void fail(Twine Error) {
-  errs() << ": " << Error << ".\n";
-  exit(1);
-}
-
-static void failIfError(std::error_code EC, Twine Context = "") {
-  if (!EC)
-    return;
-  std::string ContextStr = Context.str();
-  if (ContextStr == "")
-    fail(EC.message());
-  fail(Context + ": " + EC.message());
-}
-
-static void failIfError(Error E, Twine Context = "") {
-  if (!E)
-    return;
-
-  handleAllErrors(std::move(E), [&](const llvm::ErrorInfoBase &EIB) {
-    std::string ContextStr = Context.str();
-    if (ContextStr == "")
-      fail(EIB.message());
-    fail(Context + ": " + EIB.message());
-  });
-}
-
 static bool loadArFile(const char *argv0, const std::string ArchiveName,
                        LLVMContext &Context, Linker &L, unsigned OrigFlags,
                        unsigned ApplicableFlags) {
@@ -111,14 +83,19 @@ static bool loadArFile(const char *argv0, const std::string ArchiveName,
   ErrorOr<std::unique_ptr<MemoryBuffer>> Buf =
       MemoryBuffer::getFile(ArchiveName, -1, false);
   if (std::error_code EC = Buf.getError()) {
-    failIfError(EC, Twine("error loading archive'") + ArchiveName + "'");
+    if (Verbose)
+      errs() << "Skipping archive : File not found " << ArchiveName << "\n";
+    return false;
   } else {
     Error Err = Error::success();
     object::Archive Archive(Buf.get()->getMemBufferRef(), Err);
     object::Archive *ArchivePtr = &Archive;
     EC = errorToErrorCode(std::move(Err));
-    failIfError(EC,
-                "error loading '" + ArchiveName + "': " + EC.message() + "!");
+    if(Err) {
+      if (Verbose)
+        errs() << "Skipping archive : Empty file found " << ArchiveName << "\n";
+      return false;
+    }
     for (auto &C : ArchivePtr->children(Err)) {
       Expected<StringRef> ename = C.getName();
       if (Error E = ename.takeError()) {
@@ -159,7 +136,11 @@ static bool loadArFile(const char *argv0, const std::string ArchiveName,
       }
       ApplicableFlags = OrigFlags;
     } // end for each child
-    failIfError(std::move(Err));
+    if(Err) {
+      if (Verbose)
+        errs() << "Skipping archive : Linking Error " << ArchiveName << "\n";
+      return false;
+    }
   }
   return true;
 }
@@ -196,8 +177,9 @@ static bool linkFiles(const char *argv0, LLVMContext &Context, Linker &L,
         errs() << "Loading library archive file'" << File << "'\n";
       bool loadArSuccess =
           loadArFile(argv0, File, Context, L, Flags, ApplicableFlags);
-      if (!loadArSuccess)
-        return false;
+      if (!loadArSuccess) {
+        continue;
+      }
     } else {
       if (Verbose)
         errs() << "Loading bc file'" << File << "'\n";

--- a/clang/tools/offload-arch/amdgpu/vendor_specific_capabilities.cpp
+++ b/clang/tools/offload-arch/amdgpu/vendor_specific_capabilities.cpp
@@ -189,16 +189,7 @@ void *_aot_dynload_hsa_runtime() {
 std::string _aot_amdgpu_capabilities(uint16_t vid, uint16_t devid,
                                      std::string oa) {
   std::string amdgpu_capabilities;
-  std::string file_contents =
-      _aot_get_file_contents(std::string("/sys/module/amdgpu/version"));
-  if (!file_contents.empty()) {
-    int ver, rel, mod;
-    sscanf(file_contents.c_str(), "%d.%d.%d\n", &ver, &rel, &mod);
-    if ((ver > 5) || ((ver == 5) && (rel > 9)) ||
-        ((ver == 5) && (rel == 9) && (mod >= 15)))
-      amdgpu_capabilities.append("CodeObjVer4");
-  }
-
+  
   void *dlhandle = _aot_dynload_hsa_runtime();
   if (!dlhandle) {
     amdgpu_capabilities.append(" HSAERROR-LOADING");


### PR DESCRIPTION
This patch introduces TargetID as a target specific specialized
string in clang frontend, without changing the Driver. It is
first patch to lay ground work for subsequent changes in Driver.

 * For each offloading target, an instance of toolchain is created
   with TargetID being one of the fields.
 * User specifies TargetID as argument of "--offload-arch" command
   line flag.