### PR TITLE
[OpenMP][Clang] Simplify command line options for OpenMP device offlo…

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1788,8 +1788,8 @@ bool tools::GetSDLFromOffloadArchive(
 
       // Add this flag to not exit from clang-offload-bundler if no compatible
       // code object is found in heterogenous archive library.
-      // std::string AdditionalArgs("-allow-missing-bundles");
-      // UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
+      std::string AdditionalArgs("-allow-missing-bundles");
+      UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
 
       C.addCommand(std::make_unique<Command>(
           JA, T, ResponseFileSupport::AtFileCurCP(), UBProgram, UBArgs, Inputs,

--- a/clang/test/Driver/amdgcn-toolchain-openmp-duplicate-arguments.c
+++ b/clang/test/Driver/amdgcn-toolchain-openmp-duplicate-arguments.c
@@ -22,7 +22,7 @@
 // DUP-NOT:  "-mllvm" "-amdgpu-dump-hsa-metadata" "-mllvm" "-amdgpu-dump-hsa-metadata"
 // CHECK-SAME: "-fopenmp-is-device"
 
-// CHECK: [[OPT:".*llc.*"]] {{".*-gfx906-linked.*bc"}} "-mtriple=amdgcn-amd-amdhsa"
+// CHECK: [[OPT:".*llc.*"]] {{".*-gfx906-optimized.*bc"}} "-mtriple=amdgcn-amd-amdhsa"
 // CHECK-SAME: "-mcpu=gfx906"
 // CHECK-SAME: "-amdgpu-dump-hsa-metadata"
 // DUP-NOT: "-amdgpu-dump-hsa-metadata" "-amdgpu-dump-hsa-metadata"

--- a/clang/test/Driver/hip-toolchain-rdc-separate.hip
+++ b/clang/test/Driver/hip-toolchain-rdc-separate.hip
@@ -44,7 +44,7 @@
 // CHECK-SAME: {{.*}} [[A_SRC]]
 
 // CHECK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900,host-x86_64-unknown-linux-gnu"
+// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900,host-x86_64-unknown-linux-gnu"
 // CHECK-SAME: "-outputs=[[A_O:.*a.o]]" "-inputs=[[A_BC1]],[[A_BC2]],[[A_OBJ_HOST]]"
 
 // CHECK: [[CLANG]] "-cc1" "-mllvm" "--amdhsa-code-object-version={{[0-9]+}}" "-triple" "amdgcn-amd-amdhsa"
@@ -79,7 +79,7 @@
 // CHECK-SAME: {{.*}} [[B_SRC]]
 
 // CHECK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900,host-x86_64-unknown-linux-gnu"
+// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900,host-x86_64-unknown-linux-gnu"
 // CHECK-SAME: "-outputs=[[B_O:.*b.o]]" "-inputs=[[B_BC1]],[[B_BC2]],[[B_OBJ_HOST]]"
 
 // RUN: touch %T/a.o
@@ -91,22 +91,22 @@
 // RUN: 2>&1 | FileCheck -check-prefix=LINK %s
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[A_O:.*a.o]]" "-outputs=[[A_OBJ_HOST:.*o]],{{.*o}},{{.*o}}"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[B_O:.*b.o]]" "-outputs=[[B_OBJ_HOST:.*o]],{{.*o}},{{.*o}}"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[A_O]]" "-outputs={{.*o}},[[A_BC1:.*o]],[[A_BC2:.*o]]"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[B_O]]" "-outputs={{.*o}},[[B_BC1:.*o]],[[B_BC2:.*o]]"
 // LINK: "-unbundle" "-allow-missing-bundles"
 

--- a/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
+++ b/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
@@ -74,34 +74,6 @@ static cl::opt<bool> BuiltinCode("mlink-builtin-bitcode", cl::desc("Ignore optio
 
 static ExitOnError ExitOnErr;
 
-/// ---------------------------------------------
-// Show the error message and exit.
-LLVM_ATTRIBUTE_NORETURN static void fail(Twine Error) {
-  errs() << ": " << Error << ".\n";
-  exit(1);
-}
-
-static void failIfError(std::error_code EC, Twine Context = "") {
-  if (!EC)
-    return;
-  std::string ContextStr = Context.str();
-  if (ContextStr == "")
-    fail(EC.message());
-  fail(Context + ": " + EC.message());
-}
-
-static void failIfError(Error E, Twine Context = "") {
-  if (!E)
-    return;
-
-  handleAllErrors(std::move(E), [&](const llvm::ErrorInfoBase &EIB) {
-    std::string ContextStr = Context.str();
-    if (ContextStr == "")
-      fail(EIB.message());
-    fail(Context + ": " + EIB.message());
-  });
-}
-
 static bool loadArFile(const char *argv0, const std::string ArchiveName,
                        LLVMContext &Context, Linker &L, unsigned OrigFlags,
                        unsigned ApplicableFlags) {
@@ -111,14 +83,19 @@ static bool loadArFile(const char *argv0, const std::string ArchiveName,
   ErrorOr<std::unique_ptr<MemoryBuffer>> Buf =
       MemoryBuffer::getFile(ArchiveName, -1, false);
   if (std::error_code EC = Buf.getError()) {
-    failIfError(EC, Twine("error loading archive'") + ArchiveName + "'");
+    if (Verbose)
+      errs() << "Skipping archive : File not found " << ArchiveName << "\n";
+    return false;
   } else {
     Error Err = Error::success();
     object::Archive Archive(Buf.get()->getMemBufferRef(), Err);
     object::Archive *ArchivePtr = &Archive;
     EC = errorToErrorCode(std::move(Err));
-    failIfError(EC,
-                "error loading '" + ArchiveName + "': " + EC.message() + "!");
+    if(Err) {
+      if (Verbose)
+        errs() << "Skipping archive : Empty file found " << ArchiveName << "\n";
+      return false;
+    }
     for (auto &C : ArchivePtr->children(Err)) {
       Expected<StringRef> ename = C.getName();
       if (Error E = ename.takeError()) {
@@ -159,7 +136,11 @@ static bool loadArFile(const char *argv0, const std::string ArchiveName,
       }
       ApplicableFlags = OrigFlags;
     } // end for each child
-    failIfError(std::move(Err));
+    if(Err) {
+      if (Verbose)
+        errs() << "Skipping archive : Linking Error " << ArchiveName << "\n";
+      return false;
+    }
   }
   return true;
 }
@@ -196,8 +177,9 @@ static bool linkFiles(const char *argv0, LLVMContext &Context, Linker &L,
         errs() << "Loading library archive file'" << File << "'\n";
       bool loadArSuccess =
           loadArFile(argv0, File, Context, L, Flags, ApplicableFlags);
-      if (!loadArSuccess)
-        return false;
+      if (!loadArSuccess) {
+        continue;
+      }
     } else {
       if (Verbose)
         errs() << "Loading bc file'" << File << "'\n";

--- a/clang/tools/offload-arch/amdgpu/vendor_specific_capabilities.cpp
+++ b/clang/tools/offload-arch/amdgpu/vendor_specific_capabilities.cpp
@@ -189,16 +189,7 @@ void *_aot_dynload_hsa_runtime() {
 std::string _aot_amdgpu_capabilities(uint16_t vid, uint16_t devid,
                                      std::string oa) {
   std::string amdgpu_capabilities;
-  std::string file_contents =
-      _aot_get_file_contents(std::string("/sys/module/amdgpu/version"));
-  if (!file_contents.empty()) {
-    int ver, rel, mod;
-    sscanf(file_contents.c_str(), "%d.%d.%d\n", &ver, &rel, &mod);
-    if ((ver > 5) || ((ver == 5) && (rel > 9)) ||
-        ((ver == 5) && (rel == 9) && (mod >= 15)))
-      amdgpu_capabilities.append("CodeObjVer4");
-  }
-
+  
   void *dlhandle = _aot_dynload_hsa_runtime();
   if (!dlhandle) {
     amdgpu_capabilities.append(" HSAERROR-LOADING");


### PR DESCRIPTION
…ading

OpenMP Offloading is active when -offload-arch, -offload-archs, or
legacy options (-fopenmp-targets= with -march=) are specified. We
first build a list of OffloadArchs from command line options.

Required llvm triple is automatically generated based on the
TargetID given in --offload-arch option.