### PR TITLE
TargetID Support in AOMP - Part 2

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -712,7 +712,6 @@ void GetTargetInfoFromMArch(Compilation &C,
 
 void GetTargetInfoFromOffloadArchOpts(Compilation &C,
                                       std::set<std::string> &OffloadArchs) {
-  bool Error = false;
   for (Arg *A : C.getInputArgs()) {
     if (!(A->getOption().matches(options::OPT_offload_arch_EQ) ||
           A->getOption().matches(options::OPT_no_offload_arch_EQ))) {
@@ -727,9 +726,9 @@ void GetTargetInfoFromOffloadArchOpts(Compilation &C,
       OffloadArchs.clear();
       continue;
     }
-    if (ArchStr.empty()) {
-      Error = true;
-    } else if (A->getOption().matches(options::OPT_offload_arch_EQ))
+    if (ArchStr.empty()) 
+      continue;
+    else if (A->getOption().matches(options::OPT_offload_arch_EQ))
       GetTargetInfoFromOpenMPTargets(C, ArchStr.str().c_str(), OffloadArchs);
     else if (A->getOption().matches(options::OPT_no_offload_arch_EQ))
       GetTargetInfoFromOpenMPTargets(C, ArchStr.str().c_str(), OffloadArchs,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3179,8 +3179,8 @@ class OffloadingActionBuilder final {
         // Linking all inputs for the current GPU arch.
         // LI contains all the inputs for the linker.
         OffloadAction::DeviceDependences DeviceLinkDeps;
-        DeviceLinkDeps.add(*DeviceLinkAction, *ToolChains[0],
-            GpuArchList[I], AssociatedOffloadKind);
+        DeviceLinkDeps.add(*DeviceLinkAction, *ToolChains[0], GpuArchList[I].ID,
+                           AssociatedOffloadKind);
         AL.push_back(C.MakeAction<OffloadAction>(DeviceLinkDeps,
             DeviceLinkAction->getType()));
         ++I;
@@ -3210,11 +3210,10 @@ class OffloadingActionBuilder final {
     /// The OpenMP actions for the current input.
     ActionList OpenMPDeviceActions;
 
-    bool CompileHostOnly = false;
     bool CompileDeviceOnly = false;
 
     /// List of GPU architectures to use in this compilation.
-    SmallVector<CudaArch, 4> GpuArchList;
+    SmallVector<TargetID, 4> GpuArchList;
 
     /// The linker inputs obtained for each toolchain.
     SmallVector<ActionList, 8> DeviceLinkerInputs;
@@ -3235,20 +3234,12 @@ class OffloadingActionBuilder final {
       assert(OpenMPDeviceActions.size() == ToolChains.size() &&
              "Number of OpenMP actions and toolchains do not match.");
 
-      const ToolChain *OpenMPTC =
-          C.getSingleOffloadToolChain<Action::OFK_OpenMP>();
-
-      // amdgcn does not support linking of object files, therefore we skip
-      // backend and assemble phases to output LLVM IR.
-      if (OpenMPTC->getTriple().isAMDGCN() &&
-          (CurPhase == phases::Backend || CurPhase == phases::Assemble))
-        return CompileDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;
-
       // The host only depends on device action in the linking phase, when all
       // the device images have to be embedded in the host image.
       if (CurPhase == phases::Link) {
         assert(ToolChains.size() == DeviceLinkerInputs.size() &&
                "Toolchains and linker inputs sizes do not match.");
+
         auto LI = DeviceLinkerInputs.begin();
         for (auto *A : OpenMPDeviceActions) {
           LI->push_back(A);
@@ -3258,9 +3249,10 @@ class OffloadingActionBuilder final {
         // We passed the device action as a host dependence, so we don't need to
         // do anything else with them.
         OpenMPDeviceActions.clear();
-        return ABRT_Success;
+        return CompileDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;
       }
 
+      bool LastActionIsCompile = false;
       // By default, we produce an action for each device arch.
       for (unsigned I = 0; I < ToolChains.size(); ++I) {
         Action *&A = OpenMPDeviceActions[I];
@@ -3269,11 +3261,13 @@ class OffloadingActionBuilder final {
         if (ToolChains[I]->getTriple().isAMDGCN() &&
             (CurPhase == phases::Assemble || CurPhase == phases::Backend))
           continue;
-
-        A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A);
+        A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A,
+                                               Action::OFK_OpenMP);
+        LastActionIsCompile =
+            (A->getKind() == Action::ActionClass::CompileJobClass);
       }
-
-      return ABRT_Success;
+      return (CompileDeviceOnly && LastActionIsCompile) ? ABRT_Ignore_Host
+                                                        : ABRT_Success;
     }
 
     ActionBuilderReturnCode addDeviceDepences(Action *HostAction) override {
@@ -3281,9 +3275,15 @@ class OffloadingActionBuilder final {
       // If this is an input action replicate it for each OpenMP toolchain.
       if (auto *IA = dyn_cast<InputAction>(HostAction)) {
         OpenMPDeviceActions.clear();
-        for (unsigned I = 0; I < ToolChains.size(); ++I)
-          OpenMPDeviceActions.push_back(
-              C.MakeAction<InputAction>(IA->getInputArg(), IA->getType()));
+        // Only process input actions for files that have extensions
+        std::string FileName = IA->getInputArg().getAsString(Args);
+        if (!llvm::sys::path::has_extension(FileName)) {
+          return ABRT_Inactive;
+        }
+        for (unsigned I = 0; I < ToolChains.size(); ++I) {
+          OpenMPDeviceActions.push_back(C.MakeAction<InputAction>(
+              IA->getInputArg(), IA->getType(), GpuArchList[I].ID));
+        }
         return ABRT_Success;
       }
 
@@ -3317,15 +3317,8 @@ class OffloadingActionBuilder final {
 
         for (unsigned I = 0; I < ToolChains.size(); ++I) {
           OpenMPDeviceActions.push_back(UA);
-          if (GpuArchList.size())
-            for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I) {
-              UA->registerDependentActionInfo(ToolChains[I],
-                                              CudaArchToString(GpuArchList[I]),
-                                              Action::OFK_OpenMP);
-            }
-          else
-            UA->registerDependentActionInfo(
-                ToolChains[I], /*BoundArch=*/StringRef(), Action::OFK_OpenMP);
+          UA->registerDependentActionInfo(
+              ToolChains[I], /*BoundArch=*/StringRef(), Action::OFK_OpenMP);
         }
         return ABRT_Success;
       }
@@ -3342,15 +3335,11 @@ class OffloadingActionBuilder final {
             *HostAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
             /*BoundArch=*/nullptr, Action::OFK_OpenMP);
         auto TC = ToolChains.begin();
+        unsigned arch_count = 0;
         for (Action *&A : OpenMPDeviceActions) {
           assert(isa<CompileJobAction>(A));
           OffloadAction::DeviceDependences DDep;
-          if (GpuArchList.size())
-            for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I)
-              DDep.add(*A, **TC, CudaArchToString(GpuArchList[I]),
-                       Action::OFK_OpenMP);
-          else
-            DDep.add(*A, **TC, /*BoundArch=*/nullptr, Action::OFK_OpenMP);
+          DDep.add(*A, **TC, GpuArchList[arch_count++].ID, Action::OFK_OpenMP);
           A = C.MakeAction<OffloadAction>(HDep, DDep);
           ++TC;
         }
@@ -3370,46 +3359,29 @@ class OffloadingActionBuilder final {
       auto TI = ToolChains.begin();
       for (auto *A : OpenMPDeviceActions) {
         OffloadAction::DeviceDependences Dep;
-        if (GpuArchList.size())
-          for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I)
-            Dep.add(*A, **TI, CudaArchToString(GpuArchList[I]),
-                    Action::OFK_OpenMP);
-        else
-          Dep.add(*A, **TI, /*BoundArch=*/nullptr, Action::OFK_OpenMP);
+        Dep.add(*A, **TI, /*BoundArch=*/nullptr, Action::OFK_OpenMP);
         AL.push_back(C.MakeAction<OffloadAction>(Dep, A->getType()));
         ++TI;
       }
       // We no longer need the action stored in this builder.
       OpenMPDeviceActions.clear();
+      return;
     }
 
     void appendLinkDeviceActions(ActionList &AL) override {
       assert(ToolChains.size() == DeviceLinkerInputs.size() &&
              "Toolchains and linker inputs sizes do not match.");
-
       // Append a new link action for each device.
       auto TC = ToolChains.begin();
+      unsigned arch_count = 0;
       for (auto &LI : DeviceLinkerInputs) {
-        if (GpuArchList.size()) {
-          for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I) {
-            auto *DeviceLinkAction =
-                C.MakeAction<LinkJobAction>(LI, types::TY_Image);
-            OffloadAction::DeviceDependences DeviceLinkDeps;
-            DeviceLinkDeps.add(*DeviceLinkAction, **TC,
-                               CudaArchToString(GpuArchList[I]),
-                               Action::OFK_OpenMP);
-            AL.push_back(C.MakeAction<OffloadAction>(
-                DeviceLinkDeps, DeviceLinkAction->getType()));
-          }
-        } else {
-          auto *DeviceLinkAction =
-              C.MakeAction<LinkJobAction>(LI, types::TY_Image);
-          OffloadAction::DeviceDependences DeviceLinkDeps;
-          DeviceLinkDeps.add(*DeviceLinkAction, **TC, /*BoundArch=*/nullptr,
-                             Action::OFK_OpenMP);
-          AL.push_back(C.MakeAction<OffloadAction>(
-              DeviceLinkDeps, DeviceLinkAction->getType()));
-        }
+        auto *DeviceLinkAction =
+            C.MakeAction<LinkJobAction>(LI, types::TY_Image);
+        OffloadAction::DeviceDependences DeviceLinkDeps;
+        DeviceLinkDeps.add(*DeviceLinkAction, **TC,
+                           GpuArchList[arch_count++].ID, Action::OFK_OpenMP);
+        AL.push_back(C.MakeAction<OffloadAction>(DeviceLinkDeps,
+                                                 DeviceLinkAction->getType()));
         ++TC;
       }
       DeviceLinkerInputs.clear();
@@ -3426,82 +3398,24 @@ class OffloadingActionBuilder final {
     void appendLinkDependences(OffloadAction::DeviceDependences &DA) override {}
 
     bool initialize() override {
+      if (Arg *cu_dev_only =
+              C.getInputArgs().getLastArg(options::OPT_cuda_device_only)) {
+        cu_dev_only->claim();
+        CompileDeviceOnly = true;
+        // TODO: Check emitting IR for OpenMP when cuda-device-only is set
+      }
       // Get the OpenMP toolchains. If we don't get any, the action builder will
       // know there is nothing to do related to OpenMP offloading.
       auto OpenMPTCRange = C.getOffloadToolChains<Action::OFK_OpenMP>();
       for (auto TI = OpenMPTCRange.first, TE = OpenMPTCRange.second; TI != TE;
-           ++TI)
+           ++TI) {
+        GpuArchList.push_back(
+            TI->second->getTriple().getEnvironmentName().data());
         ToolChains.push_back(TI->second);
+      }
 
       DeviceLinkerInputs.resize(ToolChains.size());
-
-      // Collect all cuda_gpu_arch parameters, removing duplicates.
-      std::set<CudaArch> GpuArchs;
-      bool Error = false;
-
-      Arg *PartialCompilationArg = Args.getLastArg(
-          options::OPT_cuda_host_only, options::OPT_cuda_device_only,
-          options::OPT_cuda_compile_host_device);
-      CompileHostOnly =
-          PartialCompilationArg && PartialCompilationArg->getOption().matches(
-                                       options::OPT_cuda_host_only);
-      CompileDeviceOnly =
-          PartialCompilationArg && PartialCompilationArg->getOption().matches(
-                                       options::OPT_cuda_device_only);
-
-      // Add each -march from -Xopenmp before processing offload-arch flags
-      for (Arg *A : Args) {
-        if (A->getOption().matches(options::OPT_Xopenmp_target_EQ)) {
-          for (auto *V : A->getValues()) {
-            StringRef VStr = StringRef(V);
-            if (VStr.startswith("-march=")) {
-              CudaArch Arch = StringToCudaArch(StringRef(VStr.str().substr(7)));
-              if (Arch == CudaArch::UNKNOWN) {
-                C.getDriver().Diag(clang::diag::err_drv_cuda_bad_gpu_arch)
-                    << VStr;
-                Error = true;
-              }
-              GpuArchs.insert(Arch);
-            }
-          }
-          A->claim();
-        }
-      }
-
-      for (Arg *A : Args) {
-        if (!(A->getOption().matches(options::OPT_cuda_gpu_arch_EQ) ||
-              A->getOption().matches(options::OPT_no_cuda_gpu_arch_EQ)))
-          continue;
-        A->claim();
-
-        const StringRef ArchStr = A->getValue();
-        if (A->getOption().matches(options::OPT_no_cuda_gpu_arch_EQ) &&
-            ArchStr == "all") {
-          GpuArchs.clear();
-          continue;
-        }
-        CudaArch Arch = StringToCudaArch(ArchStr);
-        if (Arch == CudaArch::UNKNOWN) {
-          C.getDriver().Diag(clang::diag::err_drv_cuda_bad_gpu_arch) << ArchStr;
-          Error = true;
-        } else if (A->getOption().matches(options::OPT_cuda_gpu_arch_EQ))
-          GpuArchs.insert(Arch);
-        else if (A->getOption().matches(options::OPT_no_cuda_gpu_arch_EQ))
-          GpuArchs.erase(Arch);
-        else
-          llvm_unreachable("Unexpected option.");
-      }
-
-      // Collect list of GPUs remaining in the set.
-      for (CudaArch Arch : GpuArchs)
-        GpuArchList.push_back(Arch);
-
-      // Default to sm_20 which is the lowest common denominator for
-      // supported GPUs.  sm_20 code should work correctly, if
-      // suboptimally, on all newer GPUs.
-      if (GpuArchList.empty())
-        GpuArchList.push_back(CudaArch::SM_20);
-      return Error;
+      return false;
     }
 
     bool canUseBundlerUnbundler() const override {
@@ -3509,7 +3423,6 @@ class OffloadingActionBuilder final {
       return true;
     }
   };
-
   ///
   /// TODO: Add the implementation for other specialized builders here.
   ///
@@ -4824,6 +4737,7 @@ InputInfo Driver::BuildJobsForActionNoCache(
     OA->doOnEachDependence(
         /*IsHostDependence=*/BuildingForOffloadDevice,
         [&](Action *DepA, const ToolChain *DepTC, const char *DepBoundArch) {
+
           OffloadDependencesInputInfo.push_back(BuildJobsForAction(
               C, DepA, DepTC, DepBoundArch, /*AtTopLevel=*/false,
               /*MultipleArchs*/ !!DepBoundArch, LinkingOutput, CachedResults,
@@ -4952,18 +4866,17 @@ InputInfo Driver::BuildJobsForActionNoCache(
           UI.DependentOffloadKind,
           UI.DependentToolChain->getTriple().normalize(),
           /*CreatePrefixForHost=*/true);
-      auto CurI =
-	(UI.DependentOffloadKind == Action::OFK_Host &&
-	 llvm::sys::path::extension(InputInfos[0].getFilename()) == ".a")
-              ? InputInfos[0]
-              : InputInfo(UA,
-                          GetNamedOutputPath(
-                              C, *UA, BaseInput, UI.DependentBoundArch,
-                              /*AtTopLevel=*/false,
-                              MultipleArchs ||
-                                  UI.DependentOffloadKind == Action::OFK_HIP,
-                              OffloadingPrefix),
-                          BaseInput);
+      auto CurI = InputInfo(
+          UA,
+          GetNamedOutputPath(C, *UA, BaseInput, UI.DependentBoundArch,
+                             /*AtTopLevel=*/false,
+                             MultipleArchs ||
+                                 UI.DependentOffloadKind == Action::OFK_HIP,
+                             OffloadingPrefix),
+          BaseInput);
+      if (UI.DependentOffloadKind == Action::OFK_Host &&
+          llvm::sys::path::extension(InputInfos[0].getFilename()) == ".a")
+        CurI = InputInfos[0];
       // Save the unbundling result.
       UnbundlingResults.push_back(CurI);
 
@@ -5000,21 +4913,12 @@ InputInfo Driver::BuildJobsForActionNoCache(
         /*CreatePrefixForHost=*/!!A->getOffloadingHostActiveKinds() &&
             !AtTopLevel);
     if (isa<OffloadWrapperJobAction>(JA)) {
-      // Openmp offloading needs a name prepended for -save-temps.
-      // See examples/hip-openmp/aomp_hip_launch_test and smoke flags.
-      OffloadingPrefix += "-wrapper";
-      if (Args.getLastArg(options::OPT_fopenmp_targets_EQ)) {
-        if (Arg *FinalOutput = C.getArgs().getLastArg(options::OPT_o))
-          NewBI += FinalOutput->getValue();
-        else
-          NewBI += getDefaultImageName();
-        BaseInput = C.getArgs().MakeArgString(NewBI.c_str());
-      } else {
-        if (Arg *FinalOutput = C.getArgs().getLastArg(options::OPT_o))
-          BaseInput = FinalOutput->getValue();
-        else
-          BaseInput = getDefaultImageName();
-      }
+      if (Arg *FinalOutput = C.getArgs().getLastArg(options::OPT_o))
+        BaseInput = FinalOutput->getValue();
+      else
+        BaseInput = getDefaultImageName();
+      BaseInput =
+          C.getArgs().MakeArgString(std::string(BaseInput) + "-wrapper");
     }
     Result = InputInfo(A, GetNamedOutputPath(C, *JA, BaseInput, BoundArch,
                                              AtTopLevel, MultipleArchs,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7721,15 +7721,8 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
 
-  // Get the Code Object Version used by all offload-archs in this compilation
-  unsigned CodeObjVer = 0;
   auto TCs = C.getOffloadToolChains<Action::OFK_OpenMP>();
-  for (auto II = TCs.first, IE = TCs.second; II != IE; ++II) {
-    auto TC = II->second;
-    if (TC->getArch() == llvm::Triple::amdgcn)
-      CodeObjVer = getOrCheckAMDGPUCodeObjectVersion(C.getDriver(), Args);
-  }
-
+  
   // Add runtime requirements on each image which includes the offload-arch
   auto II = TCs.first;
   for (const InputInfo &I : Inputs) {
@@ -7748,9 +7741,6 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         requirements.replace(start_pos, 1, "__");
         start_pos += 2;
       }
-      if (CodeObjVer > 3) // Add implied CodeObjVer feature.
-        requirements.append(
-            Args.MakeArgString(Twine("__CodeObjVer") + Twine(CodeObjVer)));
 
       // FIXME: Add other architecture requirements here
       CmdArgs.push_back(Args.MakeArgString(requirements.c_str()));

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7673,7 +7673,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
          Dep.DependentOffloadKind == Action::OFK_OpenMP ||
          Dep.DependentOffloadKind == Action::OFK_Cuda) &&
         !Dep.DependentBoundArch.empty()) {
-      Triples += '-';
+      Triples += "--";
       Triples += Dep.DependentBoundArch;
     }
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7513,15 +7513,14 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
     Triples += Action::GetOffloadKindName(CurKind);
     Triples += '-';
     Triples += CurTC->getTriple().normalize();
-    if ((CurKind == Action::OFK_HIP || CurKind == Action::OFK_OpenMP ||
-         CurKind == Action::OFK_Cuda) &&
+    if ((CurKind == Action::OFK_HIP || CurKind == Action::OFK_Cuda) &&
         CurDep->getOffloadingArch()) {
       // clang-offload-bundler requires all 4 components in bundle entry ID.
       // Add an extra '-' to represent empty triple.environment.
       Triples += "--";
       Triples += CurDep->getOffloadingArch();
     }
-    if ((CurKind == Action::OFK_OpenMP || CurKind == Action::OFK_Cuda)) {
+    if (CurKind == Action::OFK_OpenMP && !CurTC->getTargetID().empty()) {
       Triples += "--";
       Triples += CurTC->getTargetID();
     }
@@ -7564,7 +7563,6 @@ static bool isArchiveOfBundlesFileName(StringRef FilePath) {
   if (!FileName.endswith(".a"))
     return false;
 
-
   if (FileName.startswith("lib")) {
     if (FileName.contains("amdgcn") && FileName.contains("gfx"))
       return false;
@@ -7602,11 +7600,20 @@ static void createUnbundleArchiveCommand(Compilation &C,
       ArgStringList CmdArgs;
 
       SmallString<128> DeviceTriple;
-      DeviceTriple += Action::GetOffloadKindName(Dep.DependentOffloadKind);
+      auto OffloadKind = Dep.DependentOffloadKind;
+      DeviceTriple += Action::GetOffloadKindName(OffloadKind);
       DeviceTriple += '-';
       DeviceTriple += Triple.normalize();
-      DeviceTriple += '-';
-      DeviceTriple += Dep.DependentBoundArch;
+
+      if ((OffloadKind == Action::OFK_HIP || OffloadKind == Action::OFK_Cuda) &&
+          !Dep.DependentBoundArch.empty()) {
+        DeviceTriple += "--";
+        DeviceTriple += Dep.DependentBoundArch;
+      }
+      if (OffloadKind == Action::OFK_OpenMP && !Dep.DependentToolChain->getTargetID().empty()) {
+        DeviceTriple += "--";
+        DeviceTriple += Dep.DependentToolChain->getTargetID();
+      }
 
       std::string UnbundleArg("-unbundle");
       std::string TypeArg("-type=a");
@@ -7621,6 +7628,12 @@ static void createUnbundleArchiveCommand(Compilation &C,
       UBArgs.push_back(C.getArgs().MakeArgString(InputArg.c_str()));
       UBArgs.push_back(C.getArgs().MakeArgString(OffloadArg.c_str()));
       UBArgs.push_back(C.getArgs().MakeArgString(OutputArg.c_str()));
+      
+      // Add this flag to not exit from clang-offload-bundler if no compatible
+      // code object is found in heterogenous archive library.
+      std::string AdditionalArgs("-allow-missing-bundles");
+      UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
+
       C.addCommand(std::make_unique<Command>(
           UA, T, ResponseFileSupport::AtFileCurCP(), UBProgram, UBArgs, Inputs,
           InputInfo(&UA, C.getArgs().MakeArgString(OutputLib))));
@@ -7666,18 +7679,21 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       Triples += ',';
 
     auto &Dep = DepInfo[I];
-    Triples += Action::GetOffloadKindName(Dep.DependentOffloadKind);
+    auto OffloadKind = Dep.DependentOffloadKind;
+    Triples += Action::GetOffloadKindName(OffloadKind);
     Triples += '-';
     Triples += Dep.DependentToolChain->getTriple().normalize();
-    if ((Dep.DependentOffloadKind == Action::OFK_HIP ||
-         Dep.DependentOffloadKind == Action::OFK_OpenMP ||
-         Dep.DependentOffloadKind == Action::OFK_Cuda) &&
+    if ((OffloadKind == Action::OFK_HIP || OffloadKind == Action::OFK_Cuda) &&
         !Dep.DependentBoundArch.empty()) {
       Triples += "--";
       Triples += Dep.DependentBoundArch;
     }
+    if (OffloadKind == Action::OFK_OpenMP && !Dep.DependentToolChain->getTargetID().empty()) {
+      Triples += "--";
+      Triples += Dep.DependentToolChain->getTargetID();
+    }
   }
-
+  
   CmdArgs.push_back(TCArgs.MakeArgString(Triples));
 
   // Get bundled file command.

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1788,8 +1788,8 @@ bool tools::GetSDLFromOffloadArchive(
 
       // Add this flag to not exit from clang-offload-bundler if no compatible
       // code object is found in heterogenous archive library.
-      // std::string AdditionalArgs("-allow-missing-bundles");
-      // UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
+      std::string AdditionalArgs("-allow-missing-bundles");
+      UBArgs.push_back(C.getArgs().MakeArgString(AdditionalArgs.c_str()));
 
       C.addCommand(std::make_unique<Command>(
           JA, T, ResponseFileSupport::AtFileCurCP(), UBProgram, UBArgs, Inputs,

--- a/clang/test/Driver/amdgcn-toolchain-openmp-duplicate-arguments.c
+++ b/clang/test/Driver/amdgcn-toolchain-openmp-duplicate-arguments.c
@@ -22,7 +22,7 @@
 // DUP-NOT:  "-mllvm" "-amdgpu-dump-hsa-metadata" "-mllvm" "-amdgpu-dump-hsa-metadata"
 // CHECK-SAME: "-fopenmp-is-device"
 
-// CHECK: [[OPT:".*llc.*"]] {{".*-gfx906-linked.*bc"}} "-mtriple=amdgcn-amd-amdhsa"
+// CHECK: [[OPT:".*llc.*"]] {{".*-gfx906-optimized.*bc"}} "-mtriple=amdgcn-amd-amdhsa"
 // CHECK-SAME: "-mcpu=gfx906"
 // CHECK-SAME: "-amdgpu-dump-hsa-metadata"
 // DUP-NOT: "-amdgpu-dump-hsa-metadata" "-amdgpu-dump-hsa-metadata"

--- a/clang/test/Driver/hip-toolchain-rdc-separate.hip
+++ b/clang/test/Driver/hip-toolchain-rdc-separate.hip
@@ -44,7 +44,7 @@
 // CHECK-SAME: {{.*}} [[A_SRC]]
 
 // CHECK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900,host-x86_64-unknown-linux-gnu"
+// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900,host-x86_64-unknown-linux-gnu"
 // CHECK-SAME: "-outputs=[[A_O:.*a.o]]" "-inputs=[[A_BC1]],[[A_BC2]],[[A_OBJ_HOST]]"
 
 // CHECK: [[CLANG]] "-cc1" "-mllvm" "--amdhsa-code-object-version={{[0-9]+}}" "-triple" "amdgcn-amd-amdhsa"
@@ -79,7 +79,7 @@
 // CHECK-SAME: {{.*}} [[B_SRC]]
 
 // CHECK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900,host-x86_64-unknown-linux-gnu"
+// CHECK-SAME: "-targets=hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900,host-x86_64-unknown-linux-gnu"
 // CHECK-SAME: "-outputs=[[B_O:.*b.o]]" "-inputs=[[B_BC1]],[[B_BC2]],[[B_OBJ_HOST]]"
 
 // RUN: touch %T/a.o
@@ -91,22 +91,22 @@
 // RUN: 2>&1 | FileCheck -check-prefix=LINK %s
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[A_O:.*a.o]]" "-outputs=[[A_OBJ_HOST:.*o]],{{.*o}},{{.*o}}"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[B_O:.*b.o]]" "-outputs=[[B_OBJ_HOST:.*o]],{{.*o}},{{.*o}}"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[A_O]]" "-outputs={{.*o}},[[A_BC1:.*o]],[[A_BC2:.*o]]"
 // LINK: "-unbundle" "-allow-missing-bundles"
 
 // LINK: [[BUNDLER:".*clang-offload-bundler"]] "-type=o"
-// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-gfx803,hip-amdgcn-amd-amdhsa-gfx900"
+// LINK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx803,hip-amdgcn-amd-amdhsa--gfx900"
 // LINK-SAME: "-inputs=[[B_O]]" "-outputs={{.*o}},[[B_BC1:.*o]],[[B_BC2:.*o]]"
 // LINK: "-unbundle" "-allow-missing-bundles"
 

--- a/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
+++ b/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
@@ -74,34 +74,6 @@ static cl::opt<bool> BuiltinCode("mlink-builtin-bitcode", cl::desc("Ignore optio
 
 static ExitOnError ExitOnErr;
 
-/// ---------------------------------------------
-// Show the error message and exit.
-LLVM_ATTRIBUTE_NORETURN static void fail(Twine Error) {
-  errs() << ": " << Error << ".\n";
-  exit(1);
-}
-
-static void failIfError(std::error_code EC, Twine Context = "") {
-  if (!EC)
-    return;
-  std::string ContextStr = Context.str();
-  if (ContextStr == "")
-    fail(EC.message());
-  fail(Context + ": " + EC.message());
-}
-
-static void failIfError(Error E, Twine Context = "") {
-  if (!E)
-    return;
-
-  handleAllErrors(std::move(E), [&](const llvm::ErrorInfoBase &EIB) {
-    std::string ContextStr = Context.str();
-    if (ContextStr == "")
-      fail(EIB.message());
-    fail(Context + ": " + EIB.message());
-  });
-}
-
 static bool loadArFile(const char *argv0, const std::string ArchiveName,
                        LLVMContext &Context, Linker &L, unsigned OrigFlags,
                        unsigned ApplicableFlags) {
@@ -111,14 +83,19 @@ static bool loadArFile(const char *argv0, const std::string ArchiveName,
   ErrorOr<std::unique_ptr<MemoryBuffer>> Buf =
       MemoryBuffer::getFile(ArchiveName, -1, false);
   if (std::error_code EC = Buf.getError()) {
-    failIfError(EC, Twine("error loading archive'") + ArchiveName + "'");
+    if (Verbose)
+      errs() << "Skipping archive : File not found " << ArchiveName << "\n";
+    return false;
   } else {
     Error Err = Error::success();
     object::Archive Archive(Buf.get()->getMemBufferRef(), Err);
     object::Archive *ArchivePtr = &Archive;
     EC = errorToErrorCode(std::move(Err));
-    failIfError(EC,
-                "error loading '" + ArchiveName + "': " + EC.message() + "!");
+    if(Err) {
+      if (Verbose)
+        errs() << "Skipping archive : Empty file found " << ArchiveName << "\n";
+      return false;
+    }
     for (auto &C : ArchivePtr->children(Err)) {
       Expected<StringRef> ename = C.getName();
       if (Error E = ename.takeError()) {
@@ -159,7 +136,11 @@ static bool loadArFile(const char *argv0, const std::string ArchiveName,
       }
       ApplicableFlags = OrigFlags;
     } // end for each child
-    failIfError(std::move(Err));
+    if(Err) {
+      if (Verbose)
+        errs() << "Skipping archive : Linking Error " << ArchiveName << "\n";
+      return false;
+    }
   }
   return true;
 }
@@ -196,8 +177,9 @@ static bool linkFiles(const char *argv0, LLVMContext &Context, Linker &L,
         errs() << "Loading library archive file'" << File << "'\n";
       bool loadArSuccess =
           loadArFile(argv0, File, Context, L, Flags, ApplicableFlags);
-      if (!loadArSuccess)
-        return false;
+      if (!loadArSuccess) {
+        continue;
+      }
     } else {
       if (Verbose)
         errs() << "Loading bc file'" << File << "'\n";

--- a/clang/tools/offload-arch/amdgpu/vendor_specific_capabilities.cpp
+++ b/clang/tools/offload-arch/amdgpu/vendor_specific_capabilities.cpp
@@ -189,16 +189,7 @@ void *_aot_dynload_hsa_runtime() {
 std::string _aot_amdgpu_capabilities(uint16_t vid, uint16_t devid,
                                      std::string oa) {
   std::string amdgpu_capabilities;
-  std::string file_contents =
-      _aot_get_file_contents(std::string("/sys/module/amdgpu/version"));
-  if (!file_contents.empty()) {
-    int ver, rel, mod;
-    sscanf(file_contents.c_str(), "%d.%d.%d\n", &ver, &rel, &mod);
-    if ((ver > 5) || ((ver == 5) && (rel > 9)) ||
-        ((ver == 5) && (rel == 9) && (mod >= 15)))
-      amdgpu_capabilities.append("CodeObjVer4");
-  }
-
+  
   void *dlhandle = _aot_dynload_hsa_runtime();
   if (!dlhandle) {
     amdgpu_capabilities.append(" HSAERROR-LOADING");


### PR DESCRIPTION
Left over Driver changes to support multi-arch compilation
using TargetID and --offload-arch option.