### PR TITLE
fix always on __AMDGCN_OPENMP__

### DIFF
--- a/clang/lib/Headers/openmp_wrappers/math.h
+++ b/clang/lib/Headers/openmp_wrappers/math.h
@@ -58,8 +58,10 @@
 #pragma omp begin declare variant match(                                       \
     device = {arch(amdgcn)}, implementation = {extension(match_any)})
 
+#ifdef  __AMDGCN__
 #ifndef __OPENMP_AMDGCN__
 #define __OPENMP_AMDGCN__
+#endif
 #endif
 
 #ifndef __HIP__


### PR DESCRIPTION
This fixes where targets NVida and PowerPC were seeing __AMDGCN_OPENMP__ defined.
This should only be fore AMDGCN.