### PR TITLE
Move hostcall required test to rtl, fix minor race

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/impl/system.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/impl/system.cpp
@@ -148,7 +148,6 @@ std::vector<std::map<std::string, atl_kernel_info_t>> KernelInfoTable;
 std::vector<std::map<std::string, atl_symbol_info_t>> SymbolInfoTable;
 
 bool g_atmi_initialized = false;
-bool g_atmi_hostcall_required = false;
 
 struct timespec context_init_time;
 int context_init_time_init = 0;
@@ -1021,8 +1020,6 @@ static hsa_status_t populate_InfoTables(hsa_executable_t executable,
     register_allocation(reinterpret_cast<void *>(info.addr), (size_t)info.size,
                         place);
     SymbolInfoTable[gpu][std::string(name)] = info;
-    if (strcmp(name, "needs_hostcall_buffer") == 0)
-      g_atmi_hostcall_required = true;
     free(name);
   } else {
     DEBUG_PRINT("Symbol is an indirect function\n");

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -336,6 +336,8 @@ public:
   // Resource pools
   SignalPoolT FreeSignalPool;
 
+  bool hostcall_required = false;
+
   struct atmiFreePtrDeletor {
     void operator()(void *p) {
       atmi_free(p); // ignore failure to free
@@ -1138,6 +1140,12 @@ static atmi_status_t atmi_calloc(void **ret_ptr, size_t size,
   return ATMI_STATUS_SUCCESS;
 }
 
+static bool image_contains_symbol(void *data, size_t size, const char *sym) {
+  symbol_info si;
+  int rc = get_symbol_info_without_loading((char *)data, size, sym, &si);
+  return (rc == 0) && (si.addr != nullptr);
+}
+
 __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
                                                  __tgt_device_image *image) {
   // This function loads the device image onto gpu[device_id] and does other
@@ -1180,6 +1188,10 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
     atmi_status_t err = module_register_from_memory_to_place(
         (void *)image->ImageStart, img_size, get_gpu_place(device_id),
         [&](void *data, size_t size) {
+          if (image_contains_symbol(data, size, "needs_hostcall_buffer")) {
+            __atomic_store_n(&DeviceInfo.hostcall_required, true,
+                             __ATOMIC_RELEASE);
+          }
           return env.before_loading(data, size);
         });
 
@@ -1716,7 +1728,6 @@ static uint64_t acquire_available_packet_id(hsa_queue_t *queue) {
   return packet_id;
 }
 
-extern bool g_atmi_hostcall_required; // declared without header by atmi
 
 static int32_t __tgt_rtl_run_target_team_region_locked(
     int32_t device_id, void *tgt_entry_ptr, void **tgt_args,
@@ -1896,7 +1907,7 @@ int32_t __tgt_rtl_run_target_team_region_locked(
       impl_args->offset_z = 0;
 
       // assign a hostcall buffer for the selected Q
-      if (g_atmi_hostcall_required) {
+      if (__atomic_load_n(&DeviceInfo.hostcall_required, __ATOMIC_ACQUIRE)) {
         // hostrpc_assign_buffer is not thread safe, and this function is
         // under a multiple reader lock, not a writer lock.
         static pthread_mutex_t hostcall_init_lock = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
Check for variable in elf before loading. Replaces a global bool with a DeviceInfo member, access with atomics as uses are under shared lock. Step towards setting up hostcall on image load instead of kernel launch.
