### PR TITLE
[OpenMP][clang] Backward compatibility with legacy fopenmp-targets format

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
@@ -393,8 +393,10 @@ void AMDGCN::OpenMPLinker::ConstructJob(Compilation &C, const JobAction &JA,
     return constructHIPFatbinCommand(C, JA, Output.getFilename(), Inputs, Args, *this);
 
   assert(getToolChain().getTriple().isAMDGCN() && "Unsupported target");
-
-  StringRef GPUArch = getProcessorFromTargetID(getToolChain().getTriple(),
+  
+  StringRef GPUArch = Args.getLastArgValue(options::OPT_march_EQ);
+  if(GPUArch.empty())
+    GPUArch = getProcessorFromTargetID(getToolChain().getTriple(),
                                                getToolChain().getTargetID());
   assert(GPUArch.startswith("gfx") && "Unsupported sub arch");
 
@@ -450,8 +452,11 @@ void AMDGPUOpenMPToolChain::addClangTargetOptions(
     Action::OffloadKind DeviceOffloadingKind) const {
   HostTC.addClangTargetOptions(DriverArgs, CC1Args, DeviceOffloadingKind);
 
-  StringRef GpuArch =
+  StringRef GpuArch = DriverArgs.getLastArgValue(options::OPT_march_EQ);
+  if(GpuArch.empty())
+    GpuArch =
       getProcessorFromTargetID(this->getTriple(), this->getTargetID());
+  
   assert(!GpuArch.empty() && "Must have an explicit GPU arch.");
   (void) GpuArch;
   assert((DeviceOffloadingKind == Action::OFK_HIP ||

--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -404,7 +404,9 @@ void NVPTX::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
   // from the -march=arch option. This option may come from -Xopenmp-target
   // flag or the default value.
   if (JA.isDeviceOffloading(Action::OFK_OpenMP)) {
-    GPUArchName = getProcessorFromTargetID(TC.getTriple(), TC.getTargetID());
+    GPUArchName = Args.getLastArgValue(options::OPT_march_EQ);
+    if(GPUArchName.empty())
+      GPUArchName = getProcessorFromTargetID(TC.getTriple(), TC.getTargetID());
     assert(!GPUArchName.empty() && "Must have an architecture passed in.");
   } else
     GPUArchName = JA.getOffloadingArch();


### PR DESCRIPTION
Recently introduced --offload-arch flag was distrupting legacy
target offload support which uses -fopenmp-targets, -xopenmp-target,
and -march.
Also, fixes issue with host offloading.