### PR TITLE
to support --offload-arch we need to get targetid from TC.  Also, O0 …

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1873,8 +1873,9 @@ void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
 
   // SDL name only contains the processor name, while TargetID is required
   // to extract compatible code objects.
-  StringRef GpuArch =
-      getProcessorFromTargetID(T->getToolChain().getTriple(), TargetID);
+  StringRef GpuArch = !T ? TargetID :
+    getProcessorFromTargetID(T->getToolChain().getTriple(),TargetID);
+
   for (std::string SDL_Name : SDL_Names) {
     //  THIS IS THE ONLY CALL TO SDLSearch
     if (!(SDLSearch(D, DriverArgs, CC1Args, LibraryPaths, SDL_Name, ArchName,


### PR DESCRIPTION
…does not work for ptxas, it should default to O3 for cuda, Another fix is that the tool could be null and not able to provide ToolChain when called from Cuda TC with the AddTargetOptions

This is a fix so this PR will not last long before merging. 