### PR TITLE
Support sm_30 which does not have a long long atomicAdd, so we implem…

### DIFF
--- a/openmp/libomptarget/deviceRTLs/nvptx/CMakeLists.txt
+++ b/openmp/libomptarget/deviceRTLs/nvptx/CMakeLists.txt
@@ -73,7 +73,7 @@ set(devicertl_common_directory
 set(devicertl_nvptx_directory
   ${devicertl_base_directory}/nvptx)
 
-set(all_capabilities 35 37 50 52 53 60 61 62 70 72 75 80)
+set(all_capabilities 30 35 37 50 52 53 60 61 62 70 72 75 80)
 
 set(LIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES ${all_capabilities} CACHE STRING
   "List of CUDA Compute Capabilities to be used to compile the NVPTX device RTL.")


### PR DESCRIPTION
…ent CAS loop only for old cuda archs

I am not giving up on my k4200 which is sm_30.  These fix the Cmake to add sm_30 and DeviceRLTs/nvptx to use a CAS loop for long long atomicAdd. 