### PR TITLE
[OpenMP][Clang] Ensure TargetID compatibility of Offloading Archs

### DIFF
--- a/clang/lib/Basic/TargetID.cpp
+++ b/clang/lib/Basic/TargetID.cpp
@@ -150,8 +150,10 @@ getConflictTargetIDCombination(const std::set<llvm::StringRef> &TargetIDs) {
   llvm::StringMap<Info> FeatureMap;
   for (auto &&ID : TargetIDs) {
     llvm::StringMap<bool> Features;
-    llvm::StringRef Proc =
-        parseTargetIDWithFormatCheckingOnly(ID, &Features).getValue();
+    auto ParsedTargetID = parseTargetIDWithFormatCheckingOnly(ID, &Features);
+    if (!ParsedTargetID)
+      continue;
+    llvm::StringRef Proc = ParsedTargetID.getValue();
     auto Loc = FeatureMap.find(Proc);
     if (Loc == FeatureMap.end())
       FeatureMap[Proc] = Info{ID, Features};

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -848,7 +848,32 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     }
 
     GetTargetInfoFromOffloadArchOpts(C, OffloadArchs);
+
     if (!OffloadArchs.empty()) {
+
+      // Extract targetIDs from all OffloadArchs and see if there
+      // is a conflict i.e. For a specific processor, a feature either shows
+      // up in all target IDs, or does not show up in any target IDs. Otherwise
+      // the target ID combination is invalid.
+      if (OffloadArchs.size() > 1) {
+        std::set<StringRef> OffloadArchsRef;
+        for (std::set<std::string>::iterator Arch = OffloadArchs.begin();
+             Arch != OffloadArchs.end(); Arch++) {
+          auto Loc = Arch->find('^') + 1;
+          OffloadArchsRef.insert(
+              StringRef(Arch->data() + Loc, Arch->size() - Loc));
+        }
+
+        auto &&ConflictingArchs =
+            getConflictTargetIDCombination(OffloadArchsRef);
+        if (ConflictingArchs) {
+          C.getDriver().Diag(clang::diag::err_drv_bad_offload_arch_combo)
+              << ConflictingArchs.getValue().first
+              << ConflictingArchs.getValue().second;
+          C.setContainsError();
+          return;
+        }
+      }
 
       // We expect that an offload target is always used in conjunction with
       // option -fopenmp specifying a valid runtime with offloading support,
@@ -878,6 +903,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
         if (!ArchStr) {
           C.getDriver().Diag(clang::diag::err_drv_bad_target_id) << IdStr;
           C.setContainsError();
+          return;
         } else
           TargetID = getCanonicalTargetID(ArchStr.getValue(), Features);
 

--- a/clang/test/Driver/openmp-invalid-target-id.c
+++ b/clang/test/Driver/openmp-invalid-target-id.c
@@ -1,0 +1,135 @@
+// REQUIRES: clang-driver
+// REQUIRES: x86-registered-target
+// REQUIRES: amdgpu-registered-target
+
+//
+// Legacy mode (-fopenmp-targets,-Xopenmp-target,-march) tests for TargetID
+//
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOPLUS-L %s
+
+// NOPLUS-L: error: Invalid target ID: gfx908xnack
+
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:xnack+ \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=ORDER-L %s
+
+// ORDER-L: error: Invalid target ID: gfx908:xnack+:xnack+
+
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa,amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:unknown+ \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908+sramecc+unknown \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900+xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=UNK-L %s
+
+// UNK-L: error: Invalid offload arch combinations: gfx908 and gfx908:unknown+
+
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:sramecc+:unknown+ \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900+xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=MIXED-L %s
+
+// MIXED-L: error: Invalid offload arch combinations: gfx908 and gfx908:sramecc+:unknown+
+
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900:sramecc+ \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=UNSUP-L %s
+
+// UNSUP-L: error: Invalid target ID: gfx900:sramecc+
+
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900:xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOSIGN-L %s
+
+// NOSIGN-L: error: Invalid target ID: gfx900:xnack
+
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900+xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOCOLON-L %s
+
+// NOCOLON-L: error: Invalid target ID: gfx900+xnack
+
+// RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908 \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+ \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=COMBO-L %s
+
+// COMBO-L: error: Invalid offload arch combinations: gfx908 and gfx908:xnack+
+
+//
+// Offload-arch mode (--offload-arch) tests for TargetID
+//
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   --offload-arch=gfx908xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOPLUS %s
+
+// NOPLUS: error: Invalid target ID: gfx908xnack
+
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx900 \
+// RUN:   --offload-arch=gfx908:xnack+:xnack+ \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=ORDER %s
+
+// ORDER: error: Invalid target ID: gfx908:xnack+:xnack+
+
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   --offload-arch=gfx908:unknown+ \
+// RUN:   --offload-arch=gfx908+sramecc+unknown \
+// RUN:   --offload-arch=gfx900+xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=UNK %s
+
+// UNK: error: Invalid offload arch combinations: gfx908 and gfx908:unknown+
+
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   --offload-arch=gfx908:sramecc+:unknown+ \
+// RUN:   --offload-arch=gfx900+xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=MIXED %s
+
+// MIXED: error: Invalid offload arch combinations: gfx908 and gfx908:sramecc+:unknown+
+
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   --offload-arch=gfx900:sramecc+ \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=UNSUP %s
+
+// UNSUP: error: Invalid target ID: gfx900:sramecc+
+
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   --offload-arch=gfx900:xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOSIGN %s
+
+// NOSIGN: error: Invalid target ID: gfx900:xnack
+
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   --offload-arch=gfx900+xnack \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=NOCOLON %s
+
+// NOCOLON: error: Invalid target ID: gfx900+xnack
+
+// RUN: not %clang -### -target x86_64-linux-gnu \
+// RUN:   -fopenmp --offload-arch=gfx908 \
+// RUN:   --offload-arch=gfx908:xnack+ \
+// RUN:   %s 2>&1 | FileCheck -check-prefix=COMBO %s
+
+// COMBO: error: Invalid offload arch combinations: gfx908 and gfx908:xnack+


### PR DESCRIPTION
1. Added negative tests for TargetID support
2. Fixed missing compatibility testing of given multiple TargetIDs
for example, TargetIDs gfx908 and gfx908:xnack+ are not compatible
with each other so their images for same source should not be packed
together in a binary.