### PR TITLE
Remove hack for isnan/isinf centos-7.

### DIFF
--- a/clang/lib/Headers/__clang_hip_cmath.h
+++ b/clang/lib/Headers/__clang_hip_cmath.h
@@ -28,10 +28,8 @@
 #pragma push_macro("__DEVICE__")
 #ifdef __OPENMP_AMDGCN__
 #define __DEVICE__ static constexpr __attribute__((always_inline, nothrow))
-#define __DEVICE_isfn__ int constexpr __attribute__((always_inline, nothrow))
 #else
 #define __DEVICE__ static __device__ inline __attribute__((always_inline))
-#define __DEVICE_isfn__ bool __device__ inline __attribute__((always_inline))
 #endif
 
 // Start with functions that cannot be defined by DEF macros below.
@@ -58,8 +56,52 @@ __DEVICE__ int fpclassify(long double __x) {
 __DEVICE__ float frexp(float __arg, int *__exp) {
   return ::frexpf(__arg, __exp);
 }
+
+#if !defined(_MSC_VER) || defined(__OPENMP_AMDGCN__)
+
+// For OpenMP we work around some old system headers that have non-conforming
+// `isinf(float)` and `isnan(float)` implementations that return an `int`. We do
+// this by providing two versions of these functions, differing only in the
+// return type. To avoid conflicting definitions we disable implicit base
+// function generation. That means we will end up with two specializations, one
+// per type, but only one has a base function defined by the system header.
+#if defined(__OPENMP_AMDGCN__)
+#pragma omp begin declare variant match(                                       \
+    implementation = {extension(disable_implicit_base)})
+
+// FIXME: We lack an extension to customize the mangling of the variants, e.g.,
+//        add a suffix. This means we would clash with the names of the variants
+//        (note that we do not create implicit base functions here). To avoid
+//        this clash we add a new trait to some of them that is always true
+//        (this is LLVM after all ;)). It will only influence the mangled name
+//        of the variants inside the inner region and avoid the clash.
+#pragma omp begin declare variant match(implementation = {vendor(llvm)})
+
+__DEVICE__ int isinf(float __x) { return ::__isinff(__x); }
+__DEVICE__ int isinf(double __x) { return ::__isinf(__x); }
+__DEVICE__ int isfinite(float __x) { return ::__finitef(__x); }
+__DEVICE__ int isfinite(double __x) { return ::__finite(__x); }
+__DEVICE__ int isnan(float __x) { return ::__isnanf(__x); }
+__DEVICE__ int isnan(double __x) { return ::__isnan(__x); }
+
+#pragma omp end declare variant
+
+#endif
+
+__DEVICE__ bool isinf(float __x) { return ::__isinff(__x); }
+__DEVICE__ bool isinf(double __x) { return ::__isinf(__x); }
 __DEVICE__ bool isfinite(float __x) { return ::__finitef(__x); }
 __DEVICE__ bool isfinite(double __x) { return ::__finite(__x); }
+__DEVICE__ bool isnan(float __x) { return ::__isnanf(__x); }
+__DEVICE__ bool isnan(double __x) { return ::__isnan(__x); }
+
+#if defined(__OPENMP_AMDGCN__)
+#pragma omp end declare variant
+#endif
+
+#endif
+
+
 __DEVICE__ bool isgreater(float __x, float __y) {
   return __builtin_isgreater(__x, __y);
 }
@@ -72,8 +114,6 @@ __DEVICE__ bool isgreaterequal(float __x, float __y) {
 __DEVICE__ bool isgreaterequal(double __x, double __y) {
   return __builtin_isgreaterequal(__x, __y);
 }
-__DEVICE_isfn__ isinf(float __x) { return ::__isinff(__x); }
-__DEVICE_isfn__ isinf(double __x) { return ::__isinf(__x); }
 __DEVICE__ bool isless(float __x, float __y) {
   return __builtin_isless(__x, __y);
 }
@@ -92,8 +132,6 @@ __DEVICE__ bool islessgreater(float __x, float __y) {
 __DEVICE__ bool islessgreater(double __x, double __y) {
   return __builtin_islessgreater(__x, __y);
 }
-__DEVICE_isfn__ isnan(float __x) { return ::__isnanf(__x); }
-__DEVICE_isfn__ isnan(double __x) { return ::__isnan(__x); }
 __DEVICE__ bool isnormal(float __x) { return __builtin_isnormal(__x); }
 __DEVICE__ bool isnormal(double __x) { return __builtin_isnormal(__x); }
 __DEVICE__ bool isunordered(float __x, float __y) {
@@ -568,7 +606,7 @@ using ::trunc;
 // Well this is fun: We need to pull these symbols in for libc++, but we can't
 // pull them in with libstdc++, because its ::isinf and ::isnan are different
 // than its std::isinf and std::isnan.
-#if !defined(__GLIBCXX__) || defined(__OPENMP_AMDGCN__)
+#if !defined(__GLIBCXX__)
 using ::isinf;
 using ::isnan;
 #endif

--- a/clang/lib/Headers/openmp_wrappers/cmath
+++ b/clang/lib/Headers/openmp_wrappers/cmath
@@ -13,7 +13,6 @@
 #ifndef _OPENMP
 #error "This file is for OpenMP compilation only."
 #endif
-#define __CORRECT_ISO_CPP11_MATH_H_PROTO_FP
 #include_next <cmath>
 
 // Make sure we include our new and math.h overlays, it probably happened already


### PR DESCRIPTION
This removes a hack that would most likely not be accepted upstream and
fixes issues seen on centos-7 where these functions return
int instead of bool. This avoids collisions and is very close to the method
used in __clang_cuda_cmath.h but modified for AMDGCN, which leverages
declare variant.