### PR TITLE
[OpenMP][Clang] Fix legacy mechanism of specifying offloading target

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -57,7 +57,7 @@ private:
   const char *constructOptCommand(Compilation &C, const JobAction &JA,
                                   const InputInfoList &Inputs,
                                   const llvm::opt::ArgList &Args,
-                                  llvm::StringRef SubArchName,
+                                  llvm::StringRef TargetID,
                                   llvm::StringRef OutputFilePrefix,
                                   const char *InputFileName) const;
 
@@ -65,7 +65,7 @@ private:
   const char *constructLlcCommand(Compilation &C, const JobAction &JA,
                                   const InputInfoList &Inputs,
                                   const llvm::opt::ArgList &Args,
-                                  llvm::StringRef SubArchName,
+                                  llvm::StringRef TargetID,
                                   llvm::StringRef OutputFilePrefix,
                                   const char *InputFileName,
                                   bool OutputIsAsm = false) const;

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1662,18 +1662,18 @@ bool tools::SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                       llvm::opt::ArgStringList &CC1Args,
                       SmallVector<std::string, 8> LibraryPaths,
                       std::string libname, StringRef ArchName,
-                      StringRef GpuArch, bool isBitCodeSDL,
+                      StringRef TargetID, bool isBitCodeSDL,
                       bool postClangLink) {
   std::string archname = ArchName.str();
-  std::string gpuname = GpuArch.str();
+  std::string Target = TargetID.str();
 
   SmallVector<std::string, 12> SDL_FileNames;
   if (isBitCodeSDL) {
     // For bitcode SDL, search for these 12 relative SDL filenames
     SDL_FileNames.push_back(std::string("/libdevice/libbc-" + libname + "-" +
-                                        archname + "-" + gpuname + ".a"));
+                                        archname + "-" + Target + ".a"));
     SDL_FileNames.push_back(std::string("/libbc-" + libname + "-" + archname +
-                                        "-" + gpuname + ".a"));
+                                        "-" + Target + ".a"));
     SDL_FileNames.push_back(
         std::string("/libdevice/libbc-" + libname + "-" + archname + ".a"));
     SDL_FileNames.push_back(
@@ -1681,9 +1681,9 @@ bool tools::SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
     SDL_FileNames.push_back(std::string("/libdevice/libbc-" + libname + ".a"));
     SDL_FileNames.push_back(std::string("/libbc-" + libname + ".a"));
     SDL_FileNames.push_back(std::string("/libdevice/lib" + libname + "-" +
-                                        archname + "-" + gpuname + ".bc"));
+                                        archname + "-" + Target + ".bc"));
     SDL_FileNames.push_back(
-        std::string("/lib" + libname + "-" + archname + "-" + gpuname + ".bc"));
+        std::string("/lib" + libname + "-" + archname + "-" + Target + ".bc"));
     SDL_FileNames.push_back(
         std::string("/libdevice/lib" + libname + "-" + archname + ".bc"));
     SDL_FileNames.push_back(
@@ -1693,9 +1693,9 @@ bool tools::SDLSearch(const Driver &D, const llvm::opt::ArgList &DriverArgs,
   } else {
     // Otherwise only 4 names to search for machine-code SDL
     SDL_FileNames.push_back(std::string("/libdevice/lib" + libname + "-" +
-                                        archname + "-" + gpuname + ".a"));
+                                        archname + "-" + Target + ".a"));
     SDL_FileNames.push_back(
-        std::string("/lib" + libname + "-" + archname + "-" + gpuname + ".a"));
+        std::string("/lib" + libname + "-" + archname + "-" + Target + ".a"));
     SDL_FileNames.push_back(
         std::string("/libdevice/lib" + libname + "-" + archname + ".a"));
     SDL_FileNames.push_back(
@@ -1871,15 +1871,10 @@ void tools::AddStaticDeviceLibs(Compilation *C, const Tool *T,
     }
   }
 
-  // SDL name only contains the processor name, while TargetID is required
-  // to extract compatible code objects.
-  StringRef GpuArch = !T ? TargetID :
-    getProcessorFromTargetID(T->getToolChain().getTriple(),TargetID);
-
   for (std::string SDL_Name : SDL_Names) {
     //  THIS IS THE ONLY CALL TO SDLSearch
     if (!(SDLSearch(D, DriverArgs, CC1Args, LibraryPaths, SDL_Name, ArchName,
-                    GpuArch, isBitCodeSDL, postClangLink))) {
+                    TargetID, isBitCodeSDL, postClangLink))) {
       GetSDLFromOffloadArchive(*C, D, *T, *JA, *Inputs, DriverArgs, CC1Args,
                                LibraryPaths, SDL_Name, ArchName, TargetID,
                                isBitCodeSDL, postClangLink);

--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -600,7 +600,9 @@ void NVPTX::OpenMPLinker::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_v))
     CmdArgs.push_back("-v");
 
-  StringRef GPUArch = getProcessorFromTargetID(getToolChain().getTriple(),
+  StringRef GPUArch = Args.getLastArgValue(options::OPT_march_EQ);
+  if(GPUArch.empty())
+    GPUArch = getProcessorFromTargetID(getToolChain().getTriple(),
                                                getToolChain().getTargetID());
 
   assert(!GPUArch.empty() && "At least one GPU Arch required for ptxas.");
@@ -704,7 +706,9 @@ void CudaToolChain::addClangTargetOptions(
     Action::OffloadKind DeviceOffloadingKind) const {
   HostTC.addClangTargetOptions(DriverArgs, CC1Args, DeviceOffloadingKind);
 
-  StringRef GpuArch = getProcessorFromTargetID(this->getTriple(),
+  StringRef GpuArch = DriverArgs.getLastArgValue(options::OPT_march_EQ);
+  if(GpuArch.empty())
+    GpuArch = getProcessorFromTargetID(this->getTriple(),
                                                this->getTargetID());
 
   assert(!GpuArch.empty() && "Must have an explicit GPU arch.");

--- a/clang/test/Driver/openmp-invalid-target-id.c
+++ b/clang/test/Driver/openmp-invalid-target-id.c
@@ -29,7 +29,7 @@
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900+xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=UNK-L %s
 
-// UNK-L: error: Invalid offload arch combinations: gfx908 and gfx908:unknown+
+// UNK-L: error: Invalid target ID: gfx908:unknown+
 
 // RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
@@ -38,7 +38,7 @@
 // RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900+xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=MIXED-L %s
 
-// MIXED-L: error: Invalid offload arch combinations: gfx908 and gfx908:sramecc+:unknown+
+// MIXED-L: error: Invalid target ID: gfx908:sramecc+:unknown+
 
 // RUN: not %clang -### -target x86_64-linux-gnu -fopenmp\
 // RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
@@ -96,7 +96,7 @@
 // RUN:   --offload-arch=gfx900+xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=UNK %s
 
-// UNK: error: Invalid offload arch combinations: gfx908 and gfx908:unknown+
+// UNK: error: Invalid target ID: gfx908:unknown+
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
 // RUN:   -fopenmp --offload-arch=gfx908 \
@@ -104,7 +104,7 @@
 // RUN:   --offload-arch=gfx900+xnack \
 // RUN:   %s 2>&1 | FileCheck -check-prefix=MIXED %s
 
-// MIXED: error: Invalid offload arch combinations: gfx908 and gfx908:sramecc+:unknown+
+// MIXED: error: Invalid target ID: gfx908:sramecc+:unknown+
 
 // RUN: not %clang -### -target x86_64-linux-gnu \
 // RUN:   -fopenmp --offload-arch=gfx908 \

--- a/clang/test/Driver/openmp-target-id.c
+++ b/clang/test/Driver/openmp-target-id.c
@@ -1,0 +1,77 @@
+// REQUIRES: clang-driver
+// REQUIRES: x86-registered-target
+// REQUIRES: amdgpu-registered-target
+
+//
+// Legacy mode (-fopenmp-targets,-Xopenmp-target,-march) tests for TargetID
+//
+// RUN:   %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:sramecc+ \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:sramecc- \
+// RUN:   %s 2>&1 | FileCheck %s
+
+// RUN:   %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:sramecc+ \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:sramecc- \
+// RUN:   -save-temps \
+// RUN:   %s 2>&1 | FileCheck %s
+
+// RUN:   %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa,amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:sramecc+ \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack+:sramecc- \
+// RUN:   -fgpu-rdc \
+// RUN:   %s 2>&1 | FileCheck %s
+
+//
+// Offload-arch mode (--offload-arch) tests for TargetID
+//
+// RUN:   %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   --offload-arch=gfx908:xnack+:sramecc+ \
+// RUN:   --offload-arch=gfx908:xnack+:sramecc- \
+// RUN:   %s 2>&1 | FileCheck %s
+
+// RUN:   %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   --offload-arch=gfx908:xnack+:sramecc+ \
+// RUN:   --offload-arch=gfx908:xnack+:sramecc- \
+// RUN:   -save-temps \
+// RUN:   %s 2>&1 | FileCheck %s
+
+// RUN:   %clang -### -target x86_64-linux-gnu -fopenmp\
+// RUN:   --offload-arch=gfx908:xnack+:sramecc+ \
+// RUN:   --offload-arch=gfx908:xnack+:sramecc- \
+// RUN:   -fgpu-rdc \
+// RUN:   %s 2>&1 | FileCheck %s
+
+// CHECK: [[CLANG:"[^"]*clang[^"]*"]] "-cc1" "-mllvm" "--amdhsa-code-object-version={{[0-9]+}}" "-triple" "amdgcn-amd-amdhsa"
+// CHECK-SAME: "-target-cpu" "gfx908"
+// CHECK-SAME: "-target-feature" "+sramecc"
+// CHECK-SAME: "-target-feature" "+xnack"
+
+// CHECK: [[OPT:"[^"]*opt[^"]*"]] {{.*}}  "-mcpu=gfx908"
+// CHECK-SAME: "-mattr=+sramecc,+xnack"
+
+// CHECK: [[LLC:"[^"]*llc[^"]*"]] {{.*}}  "-mcpu=gfx908"
+// CHECK-SAME: "-mattr=+sramecc,+xnack
+
+// CHECK: [[LLD:"[^"]*lld[^"]*"]] {{.*}} "-plugin-opt=mcpu=gfx908"
+// CHECK-SAME: "-plugin-opt=-mattr=+sramecc,+xnack"
+
+// CHECK: [[CLANG]] "-cc1" "-mllvm" "--amdhsa-code-object-version={{[0-9]+}}" "-triple" "amdgcn-amd-amdhsa"
+// CHECK-SAME: "-target-cpu" "gfx908"
+// CHECK-SAME: "-target-feature" "-sramecc"
+// CHECK-SAME: "-target-feature" "+xnack"
+
+// CHECK: [[OPT:"[^"]*opt[^"]*"]] {{.*}}  "-mcpu=gfx908"
+// CHECK-SAME: "-mattr=-sramecc,+xnack"
+
+// CHECK: [[LLC:"[^"]*llc[^"]*"]] {{.*}}  "-mcpu=gfx908"
+// CHECK-SAME: "-mattr=-sramecc,+xnack
+
+// CHECK: [[LLD]] {{.*}} "-plugin-opt=mcpu=gfx908"
+// CHECK-SAME: "-plugin-opt=-mattr=-sramecc,+xnack"
+
+// CHECK: {{"[^"]*clang-offload-wrapper[^"]*"}}
+// CHECK-SAME: "-target" "x86_64-unknown-linux-gnu" {{.*}} "--requirements=gfx908__sramecc+__xnack+" {{.*}} "--requirements=gfx908__sramecc-__xnack+"


### PR DESCRIPTION
1. Fix legacy mechanism (fopenmp-target+march) of specifying
offloading target.
2. Propagate target features as options in different phases of
the toolchain. Target Feature, if any, specified using --offload-arch or
-fopenmp-target options should be passed to clang frontend (using
-target-feature option), opt, llc, and lld (as -mattr option).
3. Add clang lit tests for TargetID support for legacy as well as
offload-arch mechanism.
4. Update parameters in LLD command to be same as HIP.
5. Miscellaneous TargetID fixes.