### PR TITLE
Libomp.so Link Path

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -553,7 +553,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Make sure openmp finds it libomp.so before all others.
-  if (Args.hasArg(options::OPT_fopenmp)){
+  if (Args.hasArg(options::OPT_fopenmp) || JA.isHostOffloading(Action::OFK_OpenMP)){
     addDirectoryList(Args, CmdArgs, "-L", "LIBRARY_PATH");
     CmdArgs.push_back(Args.MakeArgString("-L" + D.Dir + "/../lib"));
   }

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -553,7 +553,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Make sure openmp finds it libomp.so before all others.
-  if (JA.isHostOffloading(Action::OFK_OpenMP)) {
+  if (Args.hasArg(options::OPT_fopenmp)){
     addDirectoryList(Args, CmdArgs, "-L", "LIBRARY_PATH");
     CmdArgs.push_back(Args.MakeArgString("-L" + D.Dir + "/../lib"));
   }


### PR DESCRIPTION
This fixes host compilation picking up libomp.so.5 by ensuring our path is ahead of system paths. KOKKOS did not like the condition just being the fopenmp option, so I added back the openmp offload type as well. I saw no adverse effects in testing.