### PR TITLE
these are the stubs for _ockl_sanitizer_report and __ockl_devmem_requ…

### DIFF
--- a/openmp/libomptarget/hostrpc/services/hostrpc_execute_service.c
+++ b/openmp/libomptarget/hostrpc/services/hostrpc_execute_service.c
@@ -344,6 +344,12 @@ extern void hostrpc_execute_service(uint32_t service, uint32_t device_id,
   case HOSTRPC_SERVICE_DEMO:
     hostrpc_handler_SERVICE_DEMO(device_id, payload);
     break;
+  case HOSTRPC_SERVICE_DEVMEM:
+    fprintf(stderr, "NO HOSTRPC_SERVICE_DEVMEM handler \n");
+    break;
+  case HOSTRPC_SERVICE_SANITIZER:
+    fprintf(stderr, "NO HOSTRPC_SERVICE_SANITIZER handler \n");
+    break;
   default:
     hostrpc_abort(HOSTRPC_INVALIDSERVICE_ERROR);
     printf("ERROR: hostrpc got a bad service id:%d\n", service);

--- a/openmp/libomptarget/hostrpc/src/hostrpc.cpp
+++ b/openmp/libomptarget/hostrpc/src/hostrpc.cpp
@@ -143,6 +143,22 @@ EXTERN double hostrpc_varfn_double_execute(char *print_buffer, uint32_t bufsz) {
   return unionarg.dval;
 }
 
+EXTERN void __ockl_sanitizer_report(uint64_t addr, uint64_t pc, uint64_t wgidx,
+                                    uint64_t wgidy, uint64_t wgidz,
+                                    uint64_t wave_id, uint64_t is_read,
+                                    uint64_t access_size) {
+  hostrpc_result_t value =
+      hostrpc_invoke(PACK_VERS(HOSTRPC_SERVICE_SANITIZER), addr, pc, wgidx,
+                     wgidy, wgidz, wave_id, is_read, access_size);
+  return (void)value.arg0;
+}
+
+EXTERN uint64_t __ockl_devmem_request(uint64_t addr, uint64_t size) {
+  hostrpc_result_t result = hostrpc_invoke(PACK_VERS(HOSTRPC_SERVICE_DEVMEM),
+                                           addr, size, 0, 0, 0, 0, 0, 0);
+  return (uint64_t)result.arg0;
+}
+
 // -----------------------------------------------------------------------------
 //
 // vector_product_zeros: Example stub to demonstrate hostrpc services

--- a/openmp/libomptarget/hostrpc/src/hostrpc.h
+++ b/openmp/libomptarget/hostrpc/src/hostrpc.h
@@ -110,6 +110,8 @@ enum hostcall_service_id {
   HOSTRPC_SERVICE_VARFNUINT64,
   HOSTRPC_SERVICE_VARFNDOUBLE,
   HOSTRPC_SERVICE_FPRINTF,
+  HOSTRPC_SERVICE_DEVMEM,
+  HOSTRPC_SERVICE_SANITIZER,
 };
 typedef enum hostcall_service_id hostcall_service_id_t;
 


### PR DESCRIPTION
…est to use hostrpc.  The host service routines still need to added when we find where in rocclr they are defined.

Do not merge this till we get build the hostrpc service handlers.
