### PR TITLE
cuda and hip define math functions that are not in libm.  For OpenMP,…

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -89,6 +89,7 @@ set(files
   nmmintrin.h
   opencl-c.h
   opencl-c-base.h
+  omp_libmextras.h
   offload_macros.h
   pkuintrin.h
   pmmintrin.h

--- a/clang/lib/Headers/omp_libmextras.h
+++ b/clang/lib/Headers/omp_libmextras.h
@@ -1,0 +1,30 @@
+/*===---- omp_libmextras.h -----host functions not defined in libm         -===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+// NVIDIA and AMD define device math functions that are not in libm.
+// They do this for CUDA and HIP respectively.   For OpenMP, we need a
+// fallback function for host execution. These functions are defined here.
+// c and c++ users must include these with #include <omp_libmextras.h>
+
+#ifndef __OMP_LIBMEXTRAS_H__
+#define __OMP_LIBMEXTRAS_H__
+
+#ifndef _OPENMP
+#error "This file is for OpenMP compilation only."
+#endif
+
+// Host definitions of functions not in libm.
+#if !defined(__NVPTX__) && !defined(__AMDGCN__)
+float sinpif(const float x) { return (sinf(x * M_PI)); }
+double sinpi(const double x) { return (sin(x * M_PI)); }
+float cospif(const float x) { return (cosf(x * M_PI)); }
+double cospi(const double x) { return (cos(x * M_PI)); }
+#endif
+
+#endif // __OMP_LIBMEXTRAS_H__


### PR DESCRIPTION
… we need host fallback functions or host-equivalent functions for testing.

There may be more math functions in CUDA and HIP that are not in libm.  We should add host equivalent versions of these functions here.   

OpenMP users must include these if they use them with 

#include <omp_libmextras.h>

This is done in the new smoke test found in aomp/test/smoke/omp_libmextras  