### PR TITLE
[offload-arch] Fix option to query image requirements

### DIFF
--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -304,8 +304,14 @@ private:
       auto *GV =
           new GlobalVariable(M, RequirementV->getType(), /*isConstant*/ true,
                              GlobalValue::InternalLinkage, RequirementV,
-                             Twine("offload_arch_" + Twine(img_count)));
+                             Twine("__offload_arch_" + Twine(img_count)));
       GV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+
+      // store value of these variables (i.e. offload archs) into a custom
+      // section which will be used by "offload-arch -f". It won't be
+      // removed during binary stripping.
+      GV->setSection(".offload_arch_list");
+
       auto *RequirementVPtr =
           ConstantExpr::getGetElementPtr(GV->getValueType(), GV, Zero);
       RequirementVPtr =
@@ -433,7 +439,8 @@ int main(int argc, const char **argv) {
   SmallVector<ArrayRef<char>, 4u> Requirements;
   Requirements.reserve(OffloadArchs.size());
   for (unsigned i = 0; i != OffloadArchs.size(); ++i) {
-    Requirements.emplace_back(OffloadArchs[i].data(), OffloadArchs[i].size());
+    OffloadArchs[i].append("\0");
+    Requirements.emplace_back(OffloadArchs[i].data(), OffloadArchs[i].size() + 1);
   }
 
   // Create a wrapper for device binaries and write its bitcode to the file.

--- a/clang/tools/offload-arch/getRequirementsFromFile.cpp
+++ b/clang/tools/offload-arch/getRequirementsFromFile.cpp
@@ -1,16 +1,16 @@
-//===-- offload-arch/getRequirementsFromFile.cpp ----------*- C++ -*-===//
+//===------- offload-arch/getRequirementsFromFile.cpp ----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===---------------------------------------------------------------------===//
 ///
 /// \file clang/tools/offload-arch/getRequirementsFromFile.cpp
 /// Function used by offload-arch tool to get requirements from each image of
-/// an elf binary file.
-///
-//===----------------------------------------------------------------------===//
+/// an elf binary file. Requirements (like offload arch name, target features)
+/// are read from a custom section ".offload_arch_list" in elf binary.
+//===---------------------------------------------------------------------===//
 
 #include "OffloadArch.h"
 #include <fcntl.h>
@@ -21,9 +21,9 @@
 std::vector<std::string>
 _aot_get_requirements_from_file(const std::string &input_filename) {
   std::vector<std::string> results;
-  int ii, num_syms, fd;
+  int fd;
   elf_version(EV_CURRENT);
-  fd = open(input_filename.c_str(), O_LARGEFILE);
+  fd = open(input_filename.c_str(), O_RDONLY | O_LARGEFILE);
   if (!fd) {
     fprintf(stderr, "ERROR: Could not open file %s\n", input_filename.c_str());
     return results;
@@ -35,65 +35,67 @@ _aot_get_requirements_from_file(const std::string &input_filename) {
     return results;
   }
 
-  // Find symbol talble section
-  GElf_Shdr symtab;
+  GElf_Shdr offload_section;
   Elf_Scn *scn = NULL;
+  size_t section_idx;
+  uint status;
+  // Get section header index.
+  status = elf_getshdrstrndx(elf, &section_idx);
+  if (status) {
+    fprintf(stderr, "ERROR: No section header index found in %s\n",
+            input_filename.c_str());
+    return results;
+  }
+
+  // Iterate over sections of elf.
   while ((scn = elf_nextscn(elf, scn)) != NULL) {
-    gelf_getshdr(scn, &symtab);
-    if (symtab.sh_type == SHT_SYMTAB)
+
+    // Get pointer to section header.
+    if(gelf_getshdr(scn, &offload_section) != &offload_section) {
+      fprintf(stderr, "ERROR: No section header found in %s\n",
+            input_filename.c_str());
+      return results;
+    }
+
+    // Read section name from pointer to section header.
+    std::string sname(elf_strptr(elf, section_idx, offload_section.sh_name));
+    if(sname.empty()) {
+      fprintf(stderr, "ERROR: No section name found in %s\n",
+            input_filename.c_str());
+      return results;
+    }
+
+    // Check if this is the section being searched.
+    if (!sname.compare(".offload_arch_list"))
       break;
   }
   if (!scn) {
-    fprintf(stderr, "ERROR: No symbol table found in %s\n",
+    fprintf(stderr, "ERROR: .offload_arch_list section not found in %s\n",
             input_filename.c_str());
     return results;
   }
+  
+  Elf_Data *sec_data = NULL;
+  std::string arch;
 
-  // Get file offsets for requirements string of each offload image in
-  // application binary by looking for "offload_arch" in symtab
-  Elf_Data *sec_data = elf_getdata(scn, NULL);
-  num_syms = symtab.sh_size / symtab.sh_entsize;
-  std::string symname;
-  GElf_Sym sym;
-  size_t req_offset, req_strsz;
-  std::vector<size_t> req_offsets, req_strszs;
-  for (ii = 0; ii < num_syms; ++ii) {
-    gelf_getsym(sec_data, ii, &sym);
-    symname = std::string(elf_strptr(elf, symtab.sh_link, sym.st_name));
-    std::size_t found_loc = symname.find("offload_arch");
-    if (found_loc != std::string::npos) {
-      GElf_Shdr oshdr, *osh;
-      Elf_Scn *oscn;
-      oscn = elf_getscn(elf, sym.st_shndx);
-      osh = gelf_getshdr(oscn, &oshdr);
-      req_offset = (size_t)osh->sh_offset + (sym.st_value - osh->sh_addr);
-      req_strsz = sym.st_size;
-      req_offsets.push_back(req_offset);
-      req_strszs.push_back(req_strsz);
+  // Get a pointer to list of null terminated requirements.
+  sec_data = elf_getdata(scn, sec_data);
+  if(!sec_data) {
+    fprintf(stderr, "ERROR: list of offload archs not found in %s\n",
+            input_filename.c_str());
+    return results;
+  }
+  char *arch_list_ptr = (char *)sec_data->d_buf;
+
+  // Iterate over list of requirements to extract individual requirements.
+  for(uint i = 0; i < offload_section.sh_size; i++) {
+    for(uint j = i; arch_list_ptr[j] != '\0'; j++, i++) {
+      arch.push_back(arch_list_ptr[i]);
     }
+    results.push_back(arch);
+    arch.resize(0);
   }
   elf_end(elf);
-
-  if (req_strszs.size() == 0) {
-    fprintf(stderr, "ERROR: No requirements found for any images in %s\n",
-            input_filename.c_str());
-    return results;
-  }
-
-#define REQ_STRMAX 1024
-  char req_str_buffer[REQ_STRMAX];
-  for (ii = 0; ii < req_strszs.size(); ++ii) {
-    req_offset = req_offsets[ii];
-    req_strsz = req_strszs[ii];
-    if (req_strsz > REQ_STRMAX) {
-      fprintf(stderr, "ERROR: Requirements string exceeds buffer limit of %d\n",
-              REQ_STRMAX);
-      return results;
-    }
-    pread64(fd, req_str_buffer, req_strsz, req_offset);
-    req_str_buffer[(uint)req_strsz] = '\0';
-    results.push_back(std::string(req_str_buffer));
-  }
   close(fd);
   return results;
 }


### PR DESCRIPTION
Instead of storing offload_arch info about the images in the symbol table store this list in a custom section named ".offload_arch_list". Ensure that requirement of each image is a null terminated string. During retrieval this section is queried and the list is returned. This section will survive binary stripping.