### PR TITLE
-save-temps was failing because we were adding preprocessing options …

### DIFF
--- a/clang/lib/Headers/openmp_wrappers/__clang_openmp_offloading.h
+++ b/clang/lib/Headers/openmp_wrappers/__clang_openmp_offloading.h
@@ -22,7 +22,7 @@
 
 // On device pass, include __clang_openmp_device_functions.h
 #if defined(__AMDGCN__) || defined(__NVPTX__)
-#include <__clang_openmp_device_functions.h>
+#include "openmp_wrappers/__clang_openmp_device_functions.h"
 #endif
 
 #endif // __CLANG_OPENMP_OFFLOADING_H__


### PR DESCRIPTION
…to the preprocessed output.

This also fixes how the autoheader for openmp __clang_openmp_offloading.h includes __clang_openmp_device_functions.h when a compilation is in a device pass. 