### PR TITLE
Make all functions in libLLVMOffloadArch.a consistent c++ functions (…

### DIFF
--- a/llvm/include/llvm/OffloadArch/OffloadArch.h
+++ b/llvm/include/llvm/OffloadArch/OffloadArch.h
@@ -31,9 +31,8 @@
 
 ///
 /// Called by libomptarget runtime to get runtime capabilities.
-extern "C" int
-__aot_get_capabilities_for_runtime(char *offload_arch_output_buffer,
-                                   size_t offload_arch_output_buffer_size);
+int _aot_get_capabilities_for_runtime(char *offload_arch_output_buffer,
+                                      size_t offload_arch_output_buffer_size);
 
 /// Get the vendor specified softeare capabilities of the current runtime
 /// The input vendor id selects the vendor function to call.

--- a/llvm/lib/OffloadArch/CMakeLists.txt
+++ b/llvm/lib/OffloadArch/CMakeLists.txt
@@ -26,26 +26,24 @@ add_custom_target(
   generated-table
   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/generated_offload_arch.h)
 
-set(AOT_sources 
-  ${CMAKE_CURRENT_SOURCE_DIR}/OffloadArch.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/vendor_specific_capabilities.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/nvidia/vendor_specific_capabilities.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/intelhd/vendor_specific_capabilities.cpp
-)
-
 add_llvm_component_library(LLVMOffloadArch
-  STATIC
-  ${AOT_sources}
+    OffloadArch.cpp
+    amdgpu/vendor_specific_capabilities.cpp
+    nvidia/vendor_specific_capabilities.cpp
+    intelhd/vendor_specific_capabilities.cpp
   ADDITIONAL_HEADER_DIRS
-  "${LLVM_MAIN_INCLUDE_DIR}/llvm/OffloadArch"
-  DEPENDS generated-table
+    "${LLVM_MAIN_INCLUDE_DIR}/llvm/OffloadArch"
+    ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS 
+    generated-table
+  LINK_COMPONENTS
+    BinaryFormat
+    Core 
+    Object
+    ProfileData
+    Support
+    InterfaceStub
 )
-target_link_libraries(LLVMOffloadArch LLVMObject LLVMSupport )
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu
-  ${CMAKE_CURRENT_SOURCE_DIR}/nvidia
-  ${CMAKE_CURRENT_SOURCE_DIR}/intelhd)
 
 add_subdirectory(offload-arch)
 

--- a/llvm/lib/OffloadArch/OffloadArch.cpp
+++ b/llvm/lib/OffloadArch/OffloadArch.cpp
@@ -176,9 +176,8 @@ std::vector<std::string> _aot_get_all_pci_ids() {
 }
 
 /// Get runtime capabilities of this system for libomptarget runtime
-extern "C" int
-__aot_get_capabilities_for_runtime(char *offload_arch_output_buffer,
-                                   size_t offload_arch_output_buffer_size) {
+int _aot_get_capabilities_for_runtime(char *offload_arch_output_buffer,
+                                      size_t offload_arch_output_buffer_size) {
   std::vector<std::string> PCI_IDS = _aot_get_all_pci_ids();
   std::string offload_arch;
   for (auto PCI_ID : PCI_IDS) {

--- a/openmp/libomptarget/src/CMakeLists.txt
+++ b/openmp/libomptarget/src/CMakeLists.txt
@@ -23,33 +23,32 @@ set(LIBOMPTARGET_SRC_FILES
 
 set(LIBOMPTARGET_SRC_FILES ${LIBOMPTARGET_SRC_FILES} PARENT_SCOPE)
 
-include_directories(${LIBOMPTARGET_LLVM_INCLUDE_DIRS})
+include_directories(
+ ${LIBOMPTARGET_LLVM_INCLUDE_DIRS}
+ ${CMAKE_INSTALL_PREFIX}/include
+ ${LLVM_MAIN_INCLUDE_DIR})
 
-# Build libomptarget library with libdl dependency. Add LLVMSupport
-# dependency if building in-tree with profiling enabled.
-if(OPENMP_STANDALONE_BUILD OR (NOT OPENMP_ENABLE_LIBOMPTARGET_PROFILING))
-  add_library(omptarget SHARED ${LIBOMPTARGET_SRC_FILES})
-  target_link_libraries(omptarget
-    ${CMAKE_INSTALL_PREFIX}/lib/libLLVMOffloadArch.a
-    ${CMAKE_DL_LIBS}
-    "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")
-else()
-  set(LLVM_LINK_COMPONENTS
-    Support
-    )
-  add_llvm_library(omptarget SHARED ${LIBOMPTARGET_SRC_FILES}
-      LINK_LIBS ${CMAKE_DL_LIBS}
-      ${CMAKE_INSTALL_PREFIX}/lib/libLLVMOffloadArch.a
-      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports"
-      )
+# Build libomptarget library with libdl dependency.
+add_library(omptarget SHARED ${LIBOMPTARGET_SRC_FILES})
+if (OPENMP_ENABLE_LIBOMPTARGET_PROFILING)
+  # Linking with LLVM component libraries also requires
+  # aligning the compile flags.
+  #llvm_update_compile_flags(omptarget)
   target_compile_definitions(omptarget PUBLIC OMPTARGET_PROFILE_ENABLED)
 endif()
-
 # libomptarget needs to be set separately because add_llvm_library doesn't
 # conform with location configuration of its parent scope.
 set_target_properties(omptarget
   PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${LIBOMPTARGET_LIBRARY_DIR})
+
+# libclang-cpp.so resolves symbols from LLVM libraries  
+target_link_libraries(omptarget PRIVATE
+  ${CMAKE_DL_LIBS}
+  -lLLVMOffloadArch
+  -lclang-cpp
+  "-Wl,--no-allow-shlib-undefined"
+  "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")
 
 # Install libomptarget under the lib destination folder.
 install(TARGETS omptarget LIBRARY COMPONENT omptarget

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -350,7 +350,7 @@ __tgt_get_active_offload_env(__tgt_active_offload_env *active_env,
                              char *offload_arch_output_buffer,
                              size_t offload_arch_output_buffer_size) {
   // Qget runtime capabilities of this system with libLLVMOffloadArch.a
-  if (int rc = __aot_get_capabilities_for_runtime(
+  if (int rc = _aot_get_capabilities_for_runtime(
           offload_arch_output_buffer, offload_arch_output_buffer_size))
     return;
   active_env->capabilities = offload_arch_output_buffer;


### PR DESCRIPTION
…no extern C). Simplify the cmake build instructions for libLLVMOffloadArch.a and properly reference LINK_COMPONENTS (other LLVM Libraries). Correct and simplify the build of libomptarget.so.  It needs -lclang-cpp so linking with libomptarget.so  does not generate unresolved referencers