### PR TITLE
Add LIBOMPTARGET_NO_MAP env variable to disable coarse grain and map checking

### DIFF
--- a/openmp/libomptarget/src/device.cpp
+++ b/openmp/libomptarget/src/device.cpp
@@ -250,20 +250,20 @@ void *DeviceTy::getOrAllocTgtPtr(void *HstPtrBegin, void *HstPtrBase,
       DP("Return HstPtrBegin " DPxMOD " Size=%" PRId64 " RefCount=%s\n",
          DPxPTR((uintptr_t)HstPtrBegin), Size,
          (UpdateRefCount ? " updated" : ""));
+      if (!PM->RTLs.NoMaps) {
+        // When allocating under unified_shared_memory, some plugins
+        // can optimize memory access latency by registering allocated
+        // memory as coarse_grain
+        if (HstPtrBegin && RTL->set_coarse_grain_mem_region &&
+            (PM->RTLs.RequiresFlags & OMP_REQ_UNIFIED_SHARED_MEMORY))
+          RTL->set_coarse_grain_mem_region(HstPtrBegin, Size);
 
-      // When allocating under unified_shared_memory, some plugins
-      // can optimize memory access latency by registering allocated
-      // memory as coarse_grain
-      if (HstPtrBegin && RTL->set_coarse_grain_mem_region &&
-          (PM->RTLs.RequiresFlags & OMP_REQ_UNIFIED_SHARED_MEMORY))
-        RTL->set_coarse_grain_mem_region(HstPtrBegin, Size);
-
-      // even under unified_shared_memory need to check for correctness of
-      // use of map clauses. device pointer is same as host ptr in this case
-      HostDataToTargetMap.emplace(HostDataToTargetTy(
-          (uintptr_t)HstPtrBase, (uintptr_t)HstPtrBegin,
-          (uintptr_t)HstPtrBegin + Size, (uintptr_t)HstPtrBegin, HstPtrName));
-
+        // even under unified_shared_memory need to check for correctness of
+        // use of map clauses. device pointer is same as host ptr in this case
+        HostDataToTargetMap.emplace(HostDataToTargetTy(
+            (uintptr_t)HstPtrBase, (uintptr_t)HstPtrBegin,
+            (uintptr_t)HstPtrBegin + Size, (uintptr_t)HstPtrBegin, HstPtrName));
+      }
       IsHostPtr = true;
       rc = HstPtrBegin;
     }
@@ -368,7 +368,9 @@ int DeviceTy::deallocTgtPtr(void *HstPtrBegin, int64_t Size, bool ForceDelete,
          ", Size=%" PRId64 "\n",
          (ForceDelete ? " (forced)" : ""), DPxPTR(HT.HstPtrBegin),
          DPxPTR(HT.TgtPtrBegin), Size);
-      HostDataToTargetMap.erase(lr.Entry);
+      // when the user specifies "NoMaps" then no map tracking is performed
+      if (!PM->RTLs.NoMaps)
+        HostDataToTargetMap.erase(lr.Entry);
     }
     rc = OFFLOAD_SUCCESS;
   } else {

--- a/openmp/libomptarget/src/omptarget.cpp
+++ b/openmp/libomptarget/src/omptarget.cpp
@@ -354,7 +354,7 @@ void *targetAllocExplicit(size_t size, int device_num, int kind,
   DeviceTy &Device = PM->Devices[device_num];
   rc = Device.allocData(size, nullptr, kind);
 
-  if (rc && !NoMaps && Device.RTL->set_coarse_grain_mem_region &&
+  if (rc && !PM->RTLs.NoMaps && Device.RTL->set_coarse_grain_mem_region &&
       (PM->RTLs.RequiresFlags & OMP_REQ_UNIFIED_SHARED_MEMORY))
     Device.RTL->set_coarse_grain_mem_region(rc, size);
 

--- a/openmp/libomptarget/src/omptarget.cpp
+++ b/openmp/libomptarget/src/omptarget.cpp
@@ -354,7 +354,7 @@ void *targetAllocExplicit(size_t size, int device_num, int kind,
   DeviceTy &Device = PM->Devices[device_num];
   rc = Device.allocData(size, nullptr, kind);
 
-  if (rc && Device.RTL->set_coarse_grain_mem_region &&
+  if (rc && !NoMaps && Device.RTL->set_coarse_grain_mem_region &&
       (PM->RTLs.RequiresFlags & OMP_REQ_UNIFIED_SHARED_MEMORY))
     Device.RTL->set_coarse_grain_mem_region(rc, size);
 

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -102,8 +102,8 @@ void RTLsTy::LoadRTLs() {
     }
   }
 
-  if (const char *NoMapsStr = getenv("LIBOMPTARGET_NO_MAPS")) {
-    if (NoMapStr)
+  if (const char *NoMapsStr = getenv("LIBOMPTARGET_NO_MAPS"))
+    if (NoMapsStr)
       NoMaps = std::stoi(NoMapsStr);
 
     // Parse environment variable OMP_TARGET_OFFLOAD (if set)

--- a/openmp/libomptarget/src/rtl.h
+++ b/openmp/libomptarget/src/rtl.h
@@ -116,6 +116,10 @@ struct RTLsTy {
 
   int64_t RequiresFlags = OMP_REQ_UNDEFINED;
 
+  // Mirror environment variable LIBOMPTARGET_NO_MAPS
+  // when active, maps are ignored by the runtime
+  bool NoMaps = false;
+
   explicit RTLsTy() = default;
 
   // Register the clauses of the requires directive.


### PR DESCRIPTION
This is the same behavior as trunk's USM