### PR TITLE
Set xnack env

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/src/trace.h
+++ b/openmp/libomptarget/plugins/amdgpu/src/trace.h
@@ -372,8 +372,7 @@ int32_t __tgt_rtl_init_lib(int64_t requires_flags) {
   t.res(r);
   return r;
 }
-#define __tgt_rtl_init_lib(...)                           \
-  __tgt_rtl_init_lib_impl(__VA_ARGS__)
+#define __tgt_rtl_init_lib(...) __tgt_rtl_init_lib_impl(__VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/openmp/libomptarget/plugins/amdgpu/src/trace.h
+++ b/openmp/libomptarget/plugins/amdgpu/src/trace.h
@@ -364,6 +364,17 @@ int32_t __tgt_rtl_synchronize(int32_t device_id,
 }
 #define __tgt_rtl_synchronize(...) __tgt_rtl_synchronize_impl(__VA_ARGS__)
 
+static int32_t __tgt_rtl_init_lib_impl(int64_t requires_flags);
+
+int32_t __tgt_rtl_init_lib(int64_t requires_flags) {
+  auto t = detail::log<int32_t>(__func__, requires_flags);
+  int32_t r = __tgt_rtl_init_lib_impl(requires_flags);
+  t.res(r);
+  return r;
+}
+#define __tgt_rtl_init_lib(...)                           \
+  __tgt_rtl_init_lib_impl(__VA_ARGS__)
+
 #ifdef __cplusplus
 }
 #endif

--- a/openmp/libomptarget/plugins/exports
+++ b/openmp/libomptarget/plugins/exports
@@ -22,6 +22,7 @@ VERS1.0 {
     __tgt_rtl_register_lib;
     __tgt_rtl_unregister_lib;
     __tgt_rtl_supports_empty_images;
+    __tgt_rtl_init_lib;   
   local:
     *;
 };

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -239,8 +239,7 @@ void RTLsTy::LoadRTLs() {
     // Should never be called anywhere else in libomptarget than here
     typedef int64_t(init_lib_ty)(int64_t);
     init_lib_ty *init_lib = nullptr;
-    if ((*((void **)&init_lib) =
-	  dlsym(dynlib_handle, "__tgt_rtl_init_lib")))
+    if ((*((void **)&init_lib) = dlsym(dynlib_handle, "__tgt_rtl_init_lib")))
       init_lib(RequiresFlags);
   }
   delete[] libomptarget_dir_name;

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -234,6 +234,14 @@ void RTLsTy::LoadRTLs() {
         dlsym(dynlib_handle, "__tgt_rtl_unregister_lib");
     *((void **)&R.supports_empty_images) =
         dlsym(dynlib_handle, "__tgt_rtl_supports_empty_images");
+
+    // If RTL has init_lib function, call it
+    // Should never be called anywhere else in libomptarget than here
+    typedef int64_t(init_lib_ty)(int64_t);
+    init_lib_ty *init_lib = nullptr;
+    if ((*((void **)&init_lib) =
+	  dlsym(dynlib_handle, "__tgt_rtl_init_lib")))
+      init_lib(RequiresFlags);
   }
   delete[] libomptarget_dir_name;
   DP("RTLs loaded!\n");


### PR DESCRIPTION
This PR shows how we need to modify libomptarget and the amdgpu plugin to automatically set HSA_XNACK=1 when the input program uses "requires unified_shared_memory".

Example to test this, mixing hip and openmp:
https://github.com/ROCm-Developer-Tools/aomp/pull/243