### PR TITLE
[flang][driver] Add support for -internal-isystem flag to flang -fc1

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6352,6 +6352,16 @@ def fexperimental_max_bitint_width_EQ:
 // Header Search Options
 //===----------------------------------------------------------------------===//
 
+let Flags = [CC1Option, FC1Option, NoDriverOption] in {
+
+def internal_isystem : Separate<["-"], "internal-isystem">,
+  MetaVarName<"<directory>">,
+  HelpText<"Add directory to the internal system include search path; these "
+           "are assumed to not be user-provided and are used to model system "
+           "and standard headers' paths.">;
+           
+} // let Flags = [CC1Option, FC1Option, NoDriverOption]
+
 let Flags = [CC1Option, NoDriverOption] in {
 
 def nostdsysteminc : Flag<["-"], "nostdsysteminc">,
@@ -6375,11 +6385,6 @@ def objc_isystem : Separate<["-"], "objc-isystem">,
 def objcxx_isystem : Separate<["-"], "objcxx-isystem">,
   MetaVarName<"<directory>">,
   HelpText<"Add directory to the ObjC++ SYSTEM include search path">;
-def internal_isystem : Separate<["-"], "internal-isystem">,
-  MetaVarName<"<directory>">,
-  HelpText<"Add directory to the internal system include search path; these "
-           "are assumed to not be user-provided and are used to model system "
-           "and standard headers' paths.">;
 def internal_externc_isystem : Separate<["-"], "internal-externc-isystem">,
   MetaVarName<"<directory>">,
   HelpText<"Add directory to the internal system include search path with "

--- a/flang/include/flang/Frontend/PreprocessorOptions.h
+++ b/flang/include/flang/Frontend/PreprocessorOptions.h
@@ -45,6 +45,8 @@ struct PreprocessorOptions {
   // consider collecting them in a separate aggregate. For now we keep it here
   // as there is no point creating a class for just one field.
   std::vector<std::string> searchDirectoriesFromDashI;
+  // Search directories specified by the user with -internal-isystem
+  std::vector<std::string> searchDirectoriesFromInternalIsystem;
   // Search directories specified by the user with -fintrinsic-modules-path
   std::vector<std::string> searchDirectoriesFromIntrModPath;
 

--- a/flang/include/flang/Parser/parsing.h
+++ b/flang/include/flang/Parser/parsing.h
@@ -32,6 +32,7 @@ struct Options {
   int fixedFormColumns{72};
   common::LanguageFeatureControl features;
   std::vector<std::string> searchDirectories;
+  std::vector<std::string> systemSearchDirectories;
   std::vector<std::string> intrinsicModuleDirectories;
   std::vector<Predefinition> predefinitions;
   bool instrumentedParse{false};

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -140,6 +140,8 @@
 ! HELP-FC1-NEXT: -fxor-operator         Enable .XOR. as a synonym of .NEQV.
 ! HELP-FC1-NEXT: -help                  Display available options
 ! HELP-FC1-NEXT: -init-only             Only execute frontend initialization
+! HELP-FC1-NEXT: -internal-isystem <directory>
+! HELP-FC1-NEXT:                        Add directory to the internal system include search path; these are assumed to not be user-provided and are used to model system and standard headers' paths.
 ! HELP-FC1-NEXT: -I <dir>               Add directory to the end of the list of include search paths
 ! HELP-FC1-NEXT: -load <dsopath>        Load the named plugin (dynamic shared object)
 ! HELP-FC1-NEXT: -menable-no-infs       Allow optimization to assume there are no infinities.

--- a/flang/test/Driver/internal-isystem.f90
+++ b/flang/test/Driver/internal-isystem.f90
@@ -1,0 +1,22 @@
+! Ensure argument -internal-isystem works as expected with an included header.
+
+! RUN: %flang_fc1 -E -internal-isystem %S/Inputs %s  2>&1 | FileCheck %s --check-prefix=SINGLE
+! RUN: %flang_fc1 -E -internal-isystem %S/Inputs -I %S/Inputs/header-dir %s  2>&1 | FileCheck %s --check-prefix=BOTH
+! RUN: %flang_fc1 -E -I %S/Inputs/header-dir -I %S/Inputs -internal-isystem %S/Inputs/header-dir %s  2>&1 | FileCheck %s --check-prefix=OVERRIDE
+
+! System include path is scanned
+! SINGLE: program MainDirectoryOne
+! SINGLE-NOT: program X
+
+! User include path takes precedence over system include path
+! BOTH: program SubDirectoryOne
+! BOTH-NOT: program MainDirectoryOne
+
+! If a directory is both specified as user and system path, process as system
+! directory. Then, it will take less priority than other user paths.
+! OVERRIDE: program MainDirectoryOne
+! OVERRIDE-NOT: program SubDirectoryOne
+
+#include <basic-header-one.h>
+program X
+end


### PR DESCRIPTION
This patch allows processing system and user include paths separately, and adds a flag to allow specifying system include paths.