### PR TITLE
[flang][driver] Add support for -include flag to flang -fc1

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3326,7 +3326,7 @@ def imacros : JoinedOrSeparate<["-", "--"], "imacros">, Group<clang_i_Group>, Fl
   MarshallingInfoStringVector<PreprocessorOpts<"MacroIncludes">>;
 def image__base : Separate<["-"], "image_base">;
 def include_ : JoinedOrSeparate<["-", "--"], "include">, Group<clang_i_Group>, EnumName<"include">,
-    MetaVarName<"<file>">, HelpText<"Include file before parsing">, Flags<[CC1Option]>;
+    MetaVarName<"<file>">, HelpText<"Include file before parsing">, Flags<[CC1Option, FC1Option]>;
 def include_pch : Separate<["-"], "include-pch">, Group<clang_i_Group>, Flags<[CC1Option]>,
   HelpText<"Include precompiled header file">, MetaVarName<"<file>">,
   MarshallingInfoString<PreprocessorOpts<"ImplicitPCHInclude">>;

--- a/flang/include/flang/Frontend/PreprocessorOptions.h
+++ b/flang/include/flang/Frontend/PreprocessorOptions.h
@@ -47,6 +47,8 @@ struct PreprocessorOptions {
   std::vector<std::string> searchDirectoriesFromDashI;
   // Search directories specified by the user with -fintrinsic-modules-path
   std::vector<std::string> searchDirectoriesFromIntrModPath;
+  // Includes specified by the user with -include
+  std::vector<std::string> includes;
 
   PPMacrosFlag macrosFlag = PPMacrosFlag::Unknown;
 

--- a/flang/include/flang/Parser/parsing.h
+++ b/flang/include/flang/Parser/parsing.h
@@ -34,6 +34,7 @@ struct Options {
   std::vector<std::string> searchDirectories;
   std::vector<std::string> intrinsicModuleDirectories;
   std::vector<Predefinition> predefinitions;
+  std::vector<std::string> includes;
   bool instrumentedParse{false};
   bool isModuleFile{false};
   bool needProvenanceRangeToCharBlockMappings{false};

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -538,6 +538,11 @@ static void parsePreprocessorArgs(Fortran::frontend::PreprocessorOptions &opts,
        args.filtered(clang::driver::options::OPT_fintrinsic_modules_path))
     opts.searchDirectoriesFromIntrModPath.emplace_back(currentArg->getValue());
 
+  // Add the ordered list of -include's
+  for (const auto *currentArg :
+       args.filtered(clang::driver::options::OPT_include))
+    opts.includes.emplace_back(currentArg->getValue());
+
   // -cpp/-nocpp
   if (const auto *currentArg = args.getLastArg(
           clang::driver::options::OPT_cpp, clang::driver::options::OPT_nocpp))
@@ -908,6 +913,11 @@ void CompilerInvocation::setFortranOpts() {
       fortranOptions.searchDirectories.end(),
       preprocessorOptions.searchDirectoriesFromIntrModPath.begin(),
       preprocessorOptions.searchDirectoriesFromIntrModPath.end());
+
+  // Adding includes specified by -include
+  fortranOptions.includes.insert(fortranOptions.includes.end(),
+                                 preprocessorOptions.includes.begin(),
+                                 preprocessorOptions.includes.end());
 
   //  Add the default intrinsic module directory
   fortranOptions.intrinsicModuleDirectories.emplace_back(getIntrinsicDir());

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -139,6 +139,7 @@
 ! HELP-FC1-NEXT: -fsyntax-only          Run the preprocessor, parser and semantic analysis stages
 ! HELP-FC1-NEXT: -fxor-operator         Enable .XOR. as a synonym of .NEQV.
 ! HELP-FC1-NEXT: -help                  Display available options
+! HELP-FC1-NEXT: -include <file>        Include file before parsing
 ! HELP-FC1-NEXT: -init-only             Only execute frontend initialization
 ! HELP-FC1-NEXT: -I <dir>               Add directory to the end of the list of include search paths
 ! HELP-FC1-NEXT: -load <dsopath>        Load the named plugin (dynamic shared object)

--- a/flang/test/Driver/include-file.f90
+++ b/flang/test/Driver/include-file.f90
@@ -1,0 +1,13 @@
+! Ensure argument -include works as expected with an included header file.
+
+! RUN: %flang_fc1 -E -include "%S/Inputs/basic-header-one.h" %s  2>&1 | FileCheck %s --check-prefix=INCLUDED
+! RUN: not %flang_fc1 -E -include does-not-exist.h %s  2>&1 | FileCheck %s --check-prefix=MISSING
+
+! INCLUDED: program MainDirectoryOne
+! INCLUDED-NOT: program X
+
+! MISSING: error: Source file 'does-not-exist.h' was not found
+! MISSING-NOT: program
+
+program X
+end


### PR DESCRIPTION
This patch adds the -include flag, which is functionally equivalent to adding an `#include` statement to the beginning of the file being compiled.