### PR TITLE
[WIP][FLANG][MLIR][OpenMP] Initial addition & integration of an omp::ModuleOp

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6442,7 +6442,7 @@ def fno_cuda_host_device_constexpr : Flag<["-"], "fno-cuda-host-device-constexpr
 
 def fopenmp_is_device : Flag<["-"], "fopenmp-is-device">,
   HelpText<"Generate code only for an OpenMP target device.">,
-  Flags<[CC1Option, NoDriverOption]>;
+  Flags<[CC1Option, NoDriverOption, FC1Option]>;
 def fopenmp_host_ir_file_path : Separate<["-"], "fopenmp-host-ir-file-path">,
   HelpText<"Path to the IR file produced by the frontend for the host.">,
   Flags<[CC1Option, NoDriverOption]>;

--- a/flang/include/flang/Common/module-wrapper.h
+++ b/flang/include/flang/Common/module-wrapper.h
@@ -1,0 +1,156 @@
+//===-- include/flang/Common/module-wrapper.h -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_MODULE_WRAPPER_H_
+#define FORTRAN_MODULE_WRAPPER_H_
+
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace fortran::common {
+
+// An interface class that contains a single module (which can be more than one
+// type) and gives access to a subset of the shared features amongst all
+// modules.
+class ModuleInterface {
+public:
+  enum class ModuleType { Builtin, OpenMP };
+
+  ModuleInterface(mlir::omp::ModuleOp mod)
+      : module(mod), modType(ModuleType::OpenMP) {}
+
+  ModuleInterface(mlir::omp::ModuleOp *mod)
+      : module(*mod), modType(ModuleType::OpenMP) {}
+
+  ModuleInterface(mlir::ModuleOp mod)
+      : module(mod), modType(ModuleType::Builtin) {}
+
+  ModuleInterface(mlir::ModuleOp *mod)
+      : module(*mod), modType(ModuleType::Builtin) {}
+
+  mlir::omp::ModuleOp getAsOMPModule() {
+    return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module);
+  }
+
+  mlir::ModuleOp getAsBuiltinModule() {
+    return mlir::dyn_cast_or_null<mlir::ModuleOp>(module);
+  }
+
+  mlir::Operation *getAsOperation() { return module; }
+
+  template <typename T, typename U> auto lookupSymbol(U name) {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).lookupSymbol<T>(
+          name);
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module)
+          .lookupSymbol<T>(name);
+      break;
+    default:
+      assert(false && "lookupSymbol invoked with incorrect module type");
+      break;
+    }
+  }
+
+  std::optional<llvm::StringRef> getName() {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).getName();
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getName();
+      break;
+    default:
+      assert(false && "getName invoked with incorrect module type");
+      break;
+    }
+  }
+
+  template <typename PrinterT> void print(PrinterT &printer) {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).print(printer);
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).print(printer);
+      break;
+    default:
+      assert(false && "lookupSymbol invoked with incorrect module type");
+      break;
+    }
+  }
+
+  mlir::Block *getBody() {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).getBody();
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getBody();
+      break;
+    default:
+      assert(false && "getBody invoked with incorrect module type");
+      break;
+    }
+  }
+
+  ::mlir::Region &getBodyRegion() {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).getBodyRegion();
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module)
+          .getBodyRegion();
+      break;
+    default:
+      assert(false && "getBodyRegion invoked with incorrect module type");
+      break;
+    }
+  }
+
+  mlir::MLIRContext *getContext() {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).getContext();
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getContext();
+      break;
+    default:
+      assert(false && "getContext invoked with incorrect module type");
+      break;
+    }
+  }
+
+  ::mlir::LogicalResult verifyInvariants() {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).verifyInvariants();
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module)
+          .verifyInvariants();
+      break;
+    default:
+      assert(false && "getContext invoked with incorrect module type");
+      break;
+    }
+  }
+
+  mlir::Operation *operator->() { return module; }
+  operator mlir::Operation *() { return module; }
+
+private:
+  mlir::Operation *module;
+  ModuleType modType;
+};
+} // namespace fortran::common
+#endif // FORTRAN_MODULE_WRAPPER_H_

--- a/flang/include/flang/Common/module-wrapper.h
+++ b/flang/include/flang/Common/module-wrapper.h
@@ -19,7 +19,9 @@ namespace fortran::common {
 // modules.
 class ModuleInterface {
 public:
-  enum class ModuleType { Builtin, OpenMP };
+  enum class ModuleType { Builtin, OpenMP, NoModule };
+
+  ModuleInterface() : modType(ModuleType::NoModule) {}
 
   ModuleInterface(mlir::omp::ModuleOp mod)
       : module(mod), modType(ModuleType::OpenMP) {}
@@ -42,6 +44,14 @@ public:
   }
 
   mlir::Operation *getAsOperation() { return module; }
+  ModuleType getModuleType() { return modType; }
+  bool isValidModule() {
+    if (module &&
+        (modType == ModuleType::Builtin || modType == ModuleType::OpenMP)) {
+      return true;
+    }
+    return false;
+  }
 
   template <typename T, typename U> auto lookupSymbol(U name) {
     switch (modType) {
@@ -54,7 +64,7 @@ public:
           .lookupSymbol<T>(name);
       break;
     default:
-      assert(false && "lookupSymbol invoked with incorrect module type");
+      assert(false && "lookupSymbol unsupported for current module type");
       break;
     }
   }
@@ -68,7 +78,7 @@ public:
       return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getName();
       break;
     default:
-      assert(false && "getName invoked with incorrect module type");
+      assert(false && "getName unsupported for current module type");
       break;
     }
   }
@@ -82,7 +92,7 @@ public:
       return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).print(printer);
       break;
     default:
-      assert(false && "lookupSymbol invoked with incorrect module type");
+      assert(false && "print unsupported for current module type");
       break;
     }
   }
@@ -96,7 +106,7 @@ public:
       return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getBody();
       break;
     default:
-      assert(false && "getBody invoked with incorrect module type");
+      assert(false && "getBody unsupported for current module type");
       break;
     }
   }
@@ -111,7 +121,7 @@ public:
           .getBodyRegion();
       break;
     default:
-      assert(false && "getBodyRegion invoked with incorrect module type");
+      assert(false && "getBodyRegion unsupported for current module type");
       break;
     }
   }
@@ -125,7 +135,7 @@ public:
       return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getContext();
       break;
     default:
-      assert(false && "getContext invoked with incorrect module type");
+      assert(false && "getContext unsupported for current module type");
       break;
     }
   }
@@ -140,7 +150,7 @@ public:
           .verifyInvariants();
       break;
     default:
-      assert(false && "getContext invoked with incorrect module type");
+      assert(false && "getContext unsupported for current module type");
       break;
     }
   }

--- a/flang/include/flang/Frontend/FrontendActions.h
+++ b/flang/include/flang/Frontend/FrontendActions.h
@@ -13,11 +13,11 @@
 #ifndef FORTRAN_FRONTEND_FRONTENDACTIONS_H
 #define FORTRAN_FRONTEND_FRONTENDACTIONS_H
 
-#include "flang/Common/module-wrapper.h"
 #include "flang/Frontend/CodeGenOptions.h"
 #include "flang/Frontend/FrontendAction.h"
 #include "flang/Parser/parsing.h"
 #include "flang/Semantics/semantics.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -216,7 +216,7 @@ protected:
   CodeGenAction(BackendActionTy act) : action{act} {};
   /// @name MLIR
   /// {
-  std::unique_ptr<fortran::common::ModuleInterface> mlirModule;
+  std::unique_ptr<mlir::ModuleInterface> mlirModule;
   std::unique_ptr<mlir::MLIRContext> mlirCtx;
   /// }
 

--- a/flang/include/flang/Frontend/FrontendActions.h
+++ b/flang/include/flang/Frontend/FrontendActions.h
@@ -13,6 +13,7 @@
 #ifndef FORTRAN_FRONTEND_FRONTENDACTIONS_H
 #define FORTRAN_FRONTEND_FRONTENDACTIONS_H
 
+#include "flang/Common/module-wrapper.h"
 #include "flang/Frontend/CodeGenOptions.h"
 #include "flang/Frontend/FrontendAction.h"
 #include "flang/Parser/parsing.h"
@@ -206,14 +207,6 @@ class CodeGenAction : public FrontendAction {
   bool beginSourceFileAction() override;
   /// Sets up LLVM's TargetMachine.
   void setUpTargetMachine();
-  /// Parses an MLIR file into a Module of a specified type
-  template <typename Mod>
-  bool parseMLIRFileToModule();
-
-  /// Parse, lower and optimise an MLIR file utilising a Module of a specified
-  /// type
-  template <typename Mod>
-  bool parseLowerAndOptimiseModule();
 
   /// Runs the optimization (aka middle-end) pipeline on the LLVM module
   /// associated with this action.
@@ -223,9 +216,7 @@ protected:
   CodeGenAction(BackendActionTy act) : action{act} {};
   /// @name MLIR
   /// {
-  std::variant<std::unique_ptr<mlir::ModuleOp>,
-               std::unique_ptr<mlir::omp::ModuleOp>>
-      mlirModule;
+  std::unique_ptr<fortran::common::ModuleInterface> mlirModule;
   std::unique_ptr<mlir::MLIRContext> mlirCtx;
   /// }
 
@@ -238,7 +229,6 @@ protected:
 
   /// Generates an LLVM IR module from CodeGenAction::mlirModule and saves it
   /// in CodeGenAction::llvmModule.
-  template <typename Mod>
   void generateLLVMIR();
 
   BackendActionTy action;

--- a/flang/include/flang/Frontend/FrontendActions.h
+++ b/flang/include/flang/Frontend/FrontendActions.h
@@ -19,7 +19,6 @@
 #include "flang/Semantics/semantics.h"
 #include "mlir/Interfaces/ModuleInterface.h"
 
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Module.h"

--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -14,6 +14,7 @@
 #define FORTRAN_LOWER_ABSTRACTCONVERTER_H
 
 #include "flang/Common/Fortran.h"
+#include "flang/Common/module-wrapper.h"
 #include "flang/Lower/LoweringOptions.h"
 #include "flang/Lower/PFTDefs.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
@@ -227,9 +228,7 @@ public:
   /// Get the OpBuilder
   virtual fir::FirOpBuilder &getFirOpBuilder() = 0;
   /// Get the ModuleOp
-  virtual std::variant<std::unique_ptr<mlir::ModuleOp>,
-                       std::unique_ptr<mlir::omp::ModuleOp>> *
-  getModuleOp() = 0;
+  virtual fortran::common::ModuleInterface &getModuleOp() = 0;
   /// Get the MLIRContext
   virtual mlir::MLIRContext &getMLIRContext() = 0;
   /// Unique a symbol

--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -18,7 +18,6 @@
 #include "flang/Lower/PFTDefs.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Semantics/symbol.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"

--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -14,7 +14,6 @@
 #define FORTRAN_LOWER_ABSTRACTCONVERTER_H
 
 #include "flang/Common/Fortran.h"
-#include "flang/Common/module-wrapper.h"
 #include "flang/Lower/LoweringOptions.h"
 #include "flang/Lower/PFTDefs.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
@@ -23,6 +22,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace fir {
@@ -228,7 +228,7 @@ public:
   /// Get the OpBuilder
   virtual fir::FirOpBuilder &getFirOpBuilder() = 0;
   /// Get the ModuleOp
-  virtual fortran::common::ModuleInterface &getModuleOp() = 0;
+  virtual mlir::ModuleInterface &getModuleOp() = 0;
   /// Get the MLIRContext
   virtual mlir::MLIRContext &getMLIRContext() = 0;
   /// Unique a symbol

--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -18,6 +18,7 @@
 #include "flang/Lower/PFTDefs.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Semantics/symbol.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
@@ -226,7 +227,9 @@ public:
   /// Get the OpBuilder
   virtual fir::FirOpBuilder &getFirOpBuilder() = 0;
   /// Get the ModuleOp
-  virtual mlir::ModuleOp &getModuleOp() = 0;
+  virtual std::variant<std::unique_ptr<mlir::ModuleOp>,
+                       std::unique_ptr<mlir::omp::ModuleOp>> *
+  getModuleOp() = 0;
   /// Get the MLIRContext
   virtual mlir::MLIRContext &getMLIRContext() = 0;
   /// Unique a symbol

--- a/flang/include/flang/Lower/Bridge.h
+++ b/flang/include/flang/Lower/Bridge.h
@@ -20,7 +20,6 @@
 #include "flang/Lower/StatementContext.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Support/KindMapping.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/ModuleInterface.h"
 namespace Fortran {

--- a/flang/include/flang/Lower/Bridge.h
+++ b/flang/include/flang/Lower/Bridge.h
@@ -14,7 +14,6 @@
 #define FORTRAN_LOWER_BRIDGE_H
 
 #include "flang/Common/Fortran.h"
-#include "flang/Common/module-wrapper.h"
 #include "flang/Lower/AbstractConverter.h"
 #include "flang/Lower/EnvironmentDefault.h"
 #include "flang/Lower/LoweringOptions.h"
@@ -23,6 +22,7 @@
 #include "flang/Optimizer/Support/KindMapping.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 namespace Fortran {
 namespace common {
 class IntrinsicTypeDefaultKinds;
@@ -73,7 +73,7 @@ public:
 
   /// Get the ModuleOp. At least one Module type must exist, otherwise the
   /// ctor should have asserted.
-  fortran::common::ModuleInterface &getModule() { return *module.get(); }
+  mlir::ModuleInterface &getModule() { return *module.get(); }
 
   const Fortran::common::IntrinsicTypeDefaultKinds &getDefaultKinds() const {
     return defaultKinds;
@@ -145,7 +145,7 @@ private:
   const Fortran::evaluate::TargetCharacteristics &targetCharacteristics;
   const Fortran::parser::AllCookedSources *cooked;
   mlir::MLIRContext &context;
-  std::unique_ptr<fortran::common::ModuleInterface> module;
+  std::unique_ptr<mlir::ModuleInterface> module;
   fir::KindMapping &kindMap;
   const Fortran::lower::LoweringOptions &loweringOptions;
   const std::vector<Fortran::lower::EnvironmentDefault> &envDefaults;

--- a/flang/include/flang/Lower/LoweringOptions.def
+++ b/flang/include/flang/Lower/LoweringOptions.def
@@ -13,11 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #ifndef LOWERINGOPT
-#  error Define the LOWERINGOPT macro to handle lowering options
+#error Define the LOWERINGOPT macro to handle lowering options
 #endif
 
 #ifndef ENUM_LOWERINGOPT
-#  define ENUM_LOWERINGOPT(Name, Type, Bits, Default) \
+#define ENUM_LOWERINGOPT(Name, Type, Bits, Default)                            \
 LOWERINGOPT(Name, Bits, Default)
 #endif
 
@@ -30,6 +30,14 @@ ENUM_LOWERINGOPT(PolymorphicTypeImpl, unsigned, 1, 0)
 /// If true, lower to High level FIR before lowering to FIR.
 /// Off by default until fully ready.
 ENUM_LOWERINGOPT(LowerToHighLevelFIR, unsigned, 1, 0)
+
+/// If true, perform OpenMP specific handling during lowering.
+/// Off by default unless -fopenmp is provided
+ENUM_LOWERINGOPT(IsOpenMP, unsigned, 1, 0)
+
+/// If true, perform OpenMP specific device handling during lowering.
+/// Off by default unless -fopenmp and relevant offload flags are provided
+ENUM_LOWERINGOPT(IsOpenMPDevice, unsigned, 1, 0)
 
 #undef LOWERINGOPT
 #undef ENUM_LOWERINGOPT

--- a/flang/include/flang/Optimizer/Builder/FIRBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/FIRBuilder.h
@@ -24,10 +24,10 @@
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 #include "llvm/ADT/DenseMap.h"
 #include <optional>
 
-#include "flang/Common/module-wrapper.h"
 namespace fir {
 class AbstractArrayBox;
 class ExtendedValue;
@@ -60,7 +60,7 @@ public:
   mlir::Region &getRegion() { return *getBlock()->getParent(); }
 
   /// Get the current Module
-  fortran::common::ModuleInterface getModule() {
+  mlir::ModuleInterface getModule() {
     if (auto modOp = getRegion().getParentOfType<mlir::ModuleOp>())
       return modOp;
     return getRegion().getParentOfType<mlir::omp::ModuleOp>();
@@ -254,24 +254,22 @@ public:
   mlir::func::FuncOp getNamedFunction(llvm::StringRef name) {
     return getNamedFunction(getModule(), name);
   }
-  static mlir::func::FuncOp
-  getNamedFunction(fortran::common::ModuleInterface module,
-                   llvm::StringRef name);
+  static mlir::func::FuncOp getNamedFunction(mlir::ModuleInterface module,
+                                             llvm::StringRef name);
 
   /// Get a function by symbol name. The result will be null if there is no
   /// function with the given symbol in the module.
   mlir::func::FuncOp getNamedFunction(mlir::SymbolRefAttr symbol) {
     return getNamedFunction(getModule(), symbol);
   }
-  static mlir::func::FuncOp
-  getNamedFunction(fortran::common::ModuleInterface module,
-                   mlir::SymbolRefAttr symbol);
+  static mlir::func::FuncOp getNamedFunction(mlir::ModuleInterface module,
+                                             mlir::SymbolRefAttr symbol);
 
   fir::GlobalOp getNamedGlobal(llvm::StringRef name) {
     return getNamedGlobal(getModule(), name);
   }
 
-  static fir::GlobalOp getNamedGlobal(fortran::common::ModuleInterface module,
+  static fir::GlobalOp getNamedGlobal(mlir::ModuleInterface module,
                                       llvm::StringRef name);
 
   /// Lazy creation of fir.convert op.
@@ -290,9 +288,10 @@ public:
     return createFunction(loc, getModule(), name, ty);
   }
 
-  static mlir::func::FuncOp
-  createFunction(mlir::Location loc, fortran::common::ModuleInterface module,
-                 llvm::StringRef name, mlir::FunctionType ty);
+  static mlir::func::FuncOp createFunction(mlir::Location loc,
+                                           mlir::ModuleInterface module,
+                                           llvm::StringRef name,
+                                           mlir::FunctionType ty);
 
   /// Determine if the named function is already in the module. Return the
   /// instance if found, otherwise add a new named function to the module.
@@ -303,9 +302,10 @@ public:
     return createFunction(loc, name, ty);
   }
 
-  static mlir::func::FuncOp
-  addNamedFunction(mlir::Location loc, fortran::common::ModuleInterface module,
-                   llvm::StringRef name, mlir::FunctionType ty) {
+  static mlir::func::FuncOp addNamedFunction(mlir::Location loc,
+                                             mlir::ModuleInterface module,
+                                             llvm::StringRef name,
+                                             mlir::FunctionType ty) {
     if (auto func = getNamedFunction(module, name))
       return func;
     return createFunction(loc, module, name, ty);

--- a/flang/include/flang/Optimizer/CodeGen/CGPasses.td
+++ b/flang/include/flang/Optimizer/CodeGen/CGPasses.td
@@ -16,7 +16,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def FIRToLLVMLowering : Pass<"fir-to-llvm-ir", "mlir::ModuleOp"> {
+def FIRToLLVMLowering : Pass<"fir-to-llvm-ir"> {
   let summary = "Convert FIR dialect to LLVM-IR dialect";
   let description = [{
     Convert the FIR dialect to the LLVM-IR dialect of MLIR. This conversion
@@ -32,7 +32,7 @@ def FIRToLLVMLowering : Pass<"fir-to-llvm-ir", "mlir::ModuleOp"> {
   ];
 }
 
-def CodeGenRewrite : Pass<"cg-rewrite", "mlir::ModuleOp"> {
+def CodeGenRewrite : Pass<"cg-rewrite"> {
   let summary = "Rewrite some FIR ops into their code-gen forms.";
   let description = [{
     Fuse specific subgraphs into single Ops for code generation.
@@ -46,7 +46,7 @@ def CodeGenRewrite : Pass<"cg-rewrite", "mlir::ModuleOp"> {
   ];
 }
 
-def TargetRewritePass : Pass<"target-rewrite", "mlir::ModuleOp"> {
+def TargetRewritePass : Pass<"target-rewrite"> {
   let summary = "Rewrite some FIR dialect into target specific forms.";
   let description = [{
       Certain abstractions in the FIR dialect need to be rewritten to reflect
@@ -66,7 +66,7 @@ def TargetRewritePass : Pass<"target-rewrite", "mlir::ModuleOp"> {
   ];
 }
 
-def BoxedProcedurePass : Pass<"boxed-procedure", "mlir::ModuleOp"> {
+def BoxedProcedurePass : Pass<"boxed-procedure"> {
   let constructor = "::fir::createBoxedProcedurePass()";
   let options = [
     Option<"useThunks", "use-thunks",

--- a/flang/include/flang/Optimizer/CodeGen/CodeGen.h
+++ b/flang/include/flang/Optimizer/CodeGen/CodeGen.h
@@ -38,7 +38,7 @@ struct TargetRewriteOptions {
 
 /// Prerequiste pass for code gen. Perform intermediate rewrites to tailor the
 /// FIR for the chosen target.
-std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createFirTargetRewritePass(
+std::unique_ptr<mlir::OperationPass<>> createFirTargetRewritePass(
     const TargetRewriteOptions &options = TargetRewriteOptions());
 
 /// FIR to LLVM translation pass options.

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -9,9 +9,9 @@
 #ifndef FORTRAN_OPTIMIZER_DIALECT_FIROPSSUPPORT_H
 #define FORTRAN_OPTIMIZER_DIALECT_FIROPSSUPPORT_H
 
+#include "flang/Common/module-wrapper.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 namespace fir {
 
@@ -54,17 +54,15 @@ inline bool pureCall(mlir::Operation *op) {
 /// If `module` already contains FuncOp `name`, it is returned. Otherwise, a new
 /// FuncOp is created, and that new FuncOp is returned.
 mlir::func::FuncOp
-createFuncOp(mlir::Location loc,
-             std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> module,
+createFuncOp(mlir::Location loc, fortran::common::ModuleInterface module,
              llvm::StringRef name, mlir::FunctionType type,
              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
 /// Get or create a GlobalOp in a module.
-fir::GlobalOp
-createGlobalOp(mlir::Location loc,
-               std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> module,
-               llvm::StringRef name, mlir::Type type,
-               llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
+fir::GlobalOp createGlobalOp(mlir::Location loc,
+                             fortran::common::ModuleInterface module,
+                             llvm::StringRef name, mlir::Type type,
+                             llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
 /// Attribute to mark Fortran entities with the CONTIGUOUS attribute.
 constexpr llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -11,8 +11,8 @@
 
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
-
 namespace fir {
 
 /// Return true iff the Operation is a non-volatile LoadOp or ArrayLoadOp.
@@ -54,14 +54,17 @@ inline bool pureCall(mlir::Operation *op) {
 /// If `module` already contains FuncOp `name`, it is returned. Otherwise, a new
 /// FuncOp is created, and that new FuncOp is returned.
 mlir::func::FuncOp
-createFuncOp(mlir::Location loc, mlir::ModuleOp module, llvm::StringRef name,
-             mlir::FunctionType type,
+createFuncOp(mlir::Location loc,
+             std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> module,
+             llvm::StringRef name, mlir::FunctionType type,
              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
 /// Get or create a GlobalOp in a module.
-fir::GlobalOp createGlobalOp(mlir::Location loc, mlir::ModuleOp module,
-                             llvm::StringRef name, mlir::Type type,
-                             llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
+fir::GlobalOp
+createGlobalOp(mlir::Location loc,
+               std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> module,
+               llvm::StringRef name, mlir::Type type,
+               llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
 /// Attribute to mark Fortran entities with the CONTIGUOUS attribute.
 constexpr llvm::StringRef getContiguousAttrName() { return "fir.contiguous"; }

--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -9,10 +9,10 @@
 #ifndef FORTRAN_OPTIMIZER_DIALECT_FIROPSSUPPORT_H
 #define FORTRAN_OPTIMIZER_DIALECT_FIROPSSUPPORT_H
 
-#include "flang/Common/module-wrapper.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 namespace fir {
 
 /// Return true iff the Operation is a non-volatile LoadOp or ArrayLoadOp.
@@ -54,13 +54,12 @@ inline bool pureCall(mlir::Operation *op) {
 /// If `module` already contains FuncOp `name`, it is returned. Otherwise, a new
 /// FuncOp is created, and that new FuncOp is returned.
 mlir::func::FuncOp
-createFuncOp(mlir::Location loc, fortran::common::ModuleInterface module,
+createFuncOp(mlir::Location loc, mlir::ModuleInterface module,
              llvm::StringRef name, mlir::FunctionType type,
              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 
 /// Get or create a GlobalOp in a module.
-fir::GlobalOp createGlobalOp(mlir::Location loc,
-                             fortran::common::ModuleInterface module,
+fir::GlobalOp createGlobalOp(mlir::Location loc, mlir::ModuleInterface module,
                              llvm::StringRef name, mlir::Type type,
                              llvm::ArrayRef<mlir::NamedAttribute> attrs = {});
 

--- a/flang/include/flang/Optimizer/Support/FIRContext.h
+++ b/flang/include/flang/Optimizer/Support/FIRContext.h
@@ -17,31 +17,32 @@
 #ifndef FORTRAN_OPTIMIZER_SUPPORT_FIRCONTEXT_H
 #define FORTRAN_OPTIMIZER_SUPPORT_FIRCONTEXT_H
 
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Triple.h"
-
-namespace mlir {
-class ModuleOp;
-} // namespace mlir
-
 namespace fir {
 class KindMapping;
 struct NameUniquer;
 
 /// Set the target triple for the module. `triple` must not be deallocated while
 /// module `mod` is still live.
-void setTargetTriple(mlir::ModuleOp mod, llvm::StringRef triple);
+void setTargetTriple(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod,
+                     llvm::StringRef triple);
 
 /// Get the Triple instance from the Module or return the default Triple.
-llvm::Triple getTargetTriple(mlir::ModuleOp mod);
+llvm::Triple
+getTargetTriple(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod);
 
 /// Set the kind mapping for the module. `kindMap` must not be deallocated while
 /// module `mod` is still live.
-void setKindMapping(mlir::ModuleOp mod, KindMapping &kindMap);
+void setKindMapping(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod,
+                    KindMapping &kindMap);
 
 /// Get the KindMapping instance from the Module. If none was set, returns a
 /// default.
-KindMapping getKindMapping(mlir::ModuleOp mod);
+KindMapping
+getKindMapping(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod);
 
 /// Helper for determining the target from the host, etc. Tools may use this
 /// function to provide a consistent interpretation of the `--target=<string>`

--- a/flang/include/flang/Optimizer/Support/FIRContext.h
+++ b/flang/include/flang/Optimizer/Support/FIRContext.h
@@ -17,7 +17,7 @@
 #ifndef FORTRAN_OPTIMIZER_SUPPORT_FIRCONTEXT_H
 #define FORTRAN_OPTIMIZER_SUPPORT_FIRCONTEXT_H
 
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "flang/Common/module-wrapper.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Triple.h"
@@ -27,22 +27,19 @@ struct NameUniquer;
 
 /// Set the target triple for the module. `triple` must not be deallocated while
 /// module `mod` is still live.
-void setTargetTriple(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod,
+void setTargetTriple(fortran::common::ModuleInterface mod,
                      llvm::StringRef triple);
 
 /// Get the Triple instance from the Module or return the default Triple.
-llvm::Triple
-getTargetTriple(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod);
+llvm::Triple getTargetTriple(fortran::common::ModuleInterface mod);
 
 /// Set the kind mapping for the module. `kindMap` must not be deallocated while
 /// module `mod` is still live.
-void setKindMapping(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod,
-                    KindMapping &kindMap);
+void setKindMapping(fortran::common::ModuleInterface mod, KindMapping &kindMap);
 
 /// Get the KindMapping instance from the Module. If none was set, returns a
 /// default.
-KindMapping
-getKindMapping(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod);
+KindMapping getKindMapping(fortran::common::ModuleInterface mod);
 
 /// Helper for determining the target from the host, etc. Tools may use this
 /// function to provide a consistent interpretation of the `--target=<string>`

--- a/flang/include/flang/Optimizer/Support/FIRContext.h
+++ b/flang/include/flang/Optimizer/Support/FIRContext.h
@@ -17,8 +17,8 @@
 #ifndef FORTRAN_OPTIMIZER_SUPPORT_FIRCONTEXT_H
 #define FORTRAN_OPTIMIZER_SUPPORT_FIRCONTEXT_H
 
-#include "flang/Common/module-wrapper.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Triple.h"
 namespace fir {
@@ -27,19 +27,18 @@ struct NameUniquer;
 
 /// Set the target triple for the module. `triple` must not be deallocated while
 /// module `mod` is still live.
-void setTargetTriple(fortran::common::ModuleInterface mod,
-                     llvm::StringRef triple);
+void setTargetTriple(mlir::ModuleInterface mod, llvm::StringRef triple);
 
 /// Get the Triple instance from the Module or return the default Triple.
-llvm::Triple getTargetTriple(fortran::common::ModuleInterface mod);
+llvm::Triple getTargetTriple(mlir::ModuleInterface mod);
 
 /// Set the kind mapping for the module. `kindMap` must not be deallocated while
 /// module `mod` is still live.
-void setKindMapping(fortran::common::ModuleInterface mod, KindMapping &kindMap);
+void setKindMapping(mlir::ModuleInterface mod, KindMapping &kindMap);
 
 /// Get the KindMapping instance from the Module. If none was set, returns a
 /// default.
-KindMapping getKindMapping(fortran::common::ModuleInterface mod);
+KindMapping getKindMapping(mlir::ModuleInterface mod);
 
 /// Helper for determining the target from the host, etc. Tools may use this
 /// function to provide a consistent interpretation of the `--target=<string>`

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -656,6 +656,17 @@ static bool parseDialectArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
   if (args.hasArg(clang::driver::options::OPT_fopenmp)) {
     res.getFrontendOpts().features.Enable(
         Fortran::common::LanguageFeature::OpenMP);
+
+    // Triggers OpenMP specific lowering such as omp.module
+    // rather than a builtin module
+    res.getLoweringOpts().setIsOpenMP(true);
+  }
+
+  // Should be specified by driver during offloading, but specifies that we
+  // are in target offloading mode for a target device, so we are not
+  // compiling for the host.
+  if (args.hasArg(clang::driver::options::OPT_fopenmp_is_device)) {
+    res.getLoweringOpts().setIsOpenMPDevice(true);
   }
 
   // -pedantic

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -90,7 +90,7 @@ bool PrescanAndSemaDebugAction::beginSourceFileAction() {
          (generateRtTypeTables() || true);
 }
 
-static void setMLIRDataLayout(fortran::common::ModuleInterface &mlirModule,
+static void setMLIRDataLayout(mlir::ModuleInterface &mlirModule,
                               const llvm::DataLayout &dl) {
   mlir::MLIRContext *context = mlirModule.getContext();
   mlirModule->setAttr(
@@ -135,13 +135,13 @@ bool CodeGenAction::beginSourceFileAction() {
     sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), llvm::SMLoc());
 
     if (ci.getInvocation().getLoweringOpts().getIsOpenMP()) {
-      mlirModule = std::make_unique<fortran::common::ModuleInterface>(
+      mlirModule = std::make_unique<mlir::ModuleInterface>(
           mlir::parseSourceFile<mlir::omp::ModuleOp>(sourceMgr, mlirCtx.get())
               .release());
       if (ci.getInvocation().getLoweringOpts().getIsOpenMPDevice())
         mlirModule->getAsOMPModule().setIsDevice(true);
     } else {
-      mlirModule = std::make_unique<fortran::common::ModuleInterface>(
+      mlirModule = std::make_unique<mlir::ModuleInterface>(
           mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, mlirCtx.get())
               .release());
     }
@@ -187,8 +187,7 @@ bool CodeGenAction::beginSourceFileAction() {
       ci.getInvocation().getFrontendOpts().envDefaults);
 
   // Fetch module from lb, so we can set
-  mlirModule =
-      std::make_unique<fortran::common::ModuleInterface>(lb.getModule());
+  mlirModule = std::make_unique<mlir::ModuleInterface>(lb.getModule());
   setUpTargetMachine();
   const llvm::DataLayout &dl = tm->createDataLayout();
   setMLIRDataLayout(*mlirModule, dl);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -51,6 +51,7 @@
 #include "flang/Semantics/runtime-type-info.h"
 #include "flang/Semantics/tools.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Transforms/RegionUtils.h"
@@ -720,7 +721,11 @@ public:
 
   fir::FirOpBuilder &getFirOpBuilder() override final { return *builder; }
 
-  mlir::ModuleOp &getModuleOp() override final { return bridge.getModule(); }
+  std::variant<std::unique_ptr<mlir::ModuleOp>,
+               std::unique_ptr<mlir::omp::ModuleOp>> *
+  getModuleOp() override final {
+    return bridge.getModule();
+  }
 
   mlir::MLIRContext &getMLIRContext() override final {
     return bridge.getMLIRContext();
@@ -3468,10 +3473,23 @@ private:
     // FIXME: get rid of the bogus function context and instantiate the
     // globals directly into the module.
     mlir::MLIRContext *context = &getMLIRContext();
-    mlir::func::FuncOp func = fir::FirOpBuilder::createFunction(
-        mlir::UnknownLoc::get(context), getModuleOp(),
+    mlir::func::FuncOp func;
+
+    if (std::holds_alternative<std::unique_ptr<mlir::omp::ModuleOp>>(
+            *getModuleOp())) {
+      func = fir::FirOpBuilder::createFunction(
+          mlir::UnknownLoc::get(context),
+          *std::get<std::unique_ptr<mlir::omp::ModuleOp>>(*getModuleOp()).get(),
         fir::NameUniquer::doGenerated("Sham"),
         mlir::FunctionType::get(context, std::nullopt, std::nullopt));
+    } else {
+      func = fir::FirOpBuilder::createFunction(
+          mlir::UnknownLoc::get(context),
+          *std::get<std::unique_ptr<mlir::ModuleOp>>(*getModuleOp()).get(),
+          fir::NameUniquer::doGenerated("Sham"),
+          mlir::FunctionType::get(context, std::nullopt, std::nullopt));
+    }
+
     func.addEntryBlock();
     builder = new fir::FirOpBuilder(func, bridge.getKindMap());
     assert(builder && "FirOpBuilder did not instantiate");
@@ -3830,10 +3848,19 @@ void Fortran::lower::LoweringBridge::lower(
 }
 
 void Fortran::lower::LoweringBridge::parseSourceFile(llvm::SourceMgr &srcMgr) {
+  if (getLoweringOptions().getIsOpenMP()) {
+    mlir::OwningOpRef<mlir::omp::ModuleOp> owningRef =
+        mlir::parseSourceFile<mlir::omp::ModuleOp>(srcMgr, &context);
+    std::get<std::unique_ptr<mlir::omp::ModuleOp>>(module).reset(
+        new mlir::omp::ModuleOp(owningRef.get().getOperation()));
+    owningRef.release();
+  } else {
   mlir::OwningOpRef<mlir::ModuleOp> owningRef =
       mlir::parseSourceFile<mlir::ModuleOp>(srcMgr, &context);
-  module.reset(new mlir::ModuleOp(owningRef.get().getOperation()));
+    std::get<std::unique_ptr<mlir::ModuleOp>>(module).reset(
+        new mlir::ModuleOp(owningRef.get().getOperation()));
   owningRef.release();
+}
 }
 
 Fortran::lower::LoweringBridge::LoweringBridge(
@@ -3895,9 +3922,22 @@ Fortran::lower::LoweringBridge::LoweringBridge(
   };
 
   // Create the module and attach the attributes.
-  module = std::make_unique<mlir::ModuleOp>(
-      mlir::ModuleOp::create(getPathLocation()));
-  assert(module.get() && "module was not created");
-  fir::setTargetTriple(*module.get(), triple);
-  fir::setKindMapping(*module.get(), kindMap);
+  if (getLoweringOptions().getIsOpenMP()) {
+    auto mod = mlir::omp::ModuleOp::create(getPathLocation());
+    if (getLoweringOptions().getIsOpenMPDevice())
+      mod.setIsDevice(true);
+
+    fir::setTargetTriple(mod, triple);
+    fir::setKindMapping(mod, kindMap);
+    module = std::make_unique<mlir::omp::ModuleOp>(mod);
+    assert(std::get<std::unique_ptr<mlir::omp::ModuleOp>>(module).get() &&
+           "module was not created");
+  } else {
+    auto mod = mlir::ModuleOp::create(getPathLocation());
+    fir::setTargetTriple(mod, triple);
+    fir::setKindMapping(mod, kindMap);
+    module = std::make_unique<mlir::ModuleOp>(mod);
+    assert(std::get<std::unique_ptr<mlir::ModuleOp>>(module).get() &&
+           "module was not created");
+  }
 }

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -721,7 +721,7 @@ public:
 
   fir::FirOpBuilder &getFirOpBuilder() override final { return *builder; }
 
-  fortran::common::ModuleInterface &getModuleOp() override final {
+  mlir::ModuleInterface &getModuleOp() override final {
     return bridge.getModule();
   }
 
@@ -3836,13 +3836,13 @@ void Fortran::lower::LoweringBridge::parseSourceFile(llvm::SourceMgr &srcMgr) {
   if (getLoweringOptions().getIsOpenMP()) {
     mlir::OwningOpRef<mlir::omp::ModuleOp> owningRef =
         mlir::parseSourceFile<mlir::omp::ModuleOp>(srcMgr, &context);
-    module.reset(new fortran::common::ModuleInterface(
+    module.reset(new mlir::ModuleInterface(
         new mlir::omp::ModuleOp(owningRef.get().getOperation())));
     owningRef.release();
   } else {
     mlir::OwningOpRef<mlir::ModuleOp> owningRef =
         mlir::parseSourceFile<mlir::ModuleOp>(srcMgr, &context);
-    module.reset(new fortran::common::ModuleInterface(
+    module.reset(new mlir::ModuleInterface(
         new mlir::ModuleOp(owningRef.get().getOperation())));
     owningRef.release();
   }
@@ -3908,12 +3908,12 @@ Fortran::lower::LoweringBridge::LoweringBridge(
 
   // Create the module and attach the attributes.
   if (getLoweringOptions().getIsOpenMP()) {
-    module = std::make_unique<fortran::common::ModuleInterface>(
+    module = std::make_unique<mlir::ModuleInterface>(
         mlir::omp::ModuleOp::create(getPathLocation()));
     if (getLoweringOptions().getIsOpenMPDevice())
       module->getAsOMPModule().setIsDevice(true);
   } else {
-    module = std::make_unique<fortran::common::ModuleInterface>(
+    module = std::make_unique<mlir::ModuleInterface>(
         mlir::ModuleOp::create(getPathLocation()));
   }
   assert(module.get()->getAsOperation() && "module was not created");

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -481,10 +481,7 @@ void Fortran::lower::CallInterface<T>::declare() {
   // holding the indirection is used when creating the fir::CallOp.
   if (!side().isIndirectCall()) {
     std::string name = side().getMangledName();
-    if (std::holds_alternative<std::unique_ptr<mlir::omp::ModuleOp>>(
-            *converter.getModuleOp())) {
-      auto module = *std::get<std::unique_ptr<mlir::omp::ModuleOp>>(
-          *converter.getModuleOp());
+    auto module = converter.getModuleOp();
     func = fir::FirOpBuilder::getNamedFunction(module, name);
     if (!func) {
       mlir::Location loc = side().getCalleeLocation();
@@ -494,26 +491,8 @@ void Fortran::lower::CallInterface<T>::declare() {
         addSymbolAttribute(func, *sym, converter.getMLIRContext());
       for (const auto &placeHolder : llvm::enumerate(inputs))
         if (!placeHolder.value().attributes.empty())
-            func.setArgAttrs(placeHolder.index(),
-                             placeHolder.value().attributes);
+          func.setArgAttrs(placeHolder.index(), placeHolder.value().attributes);
       side().setFuncAttrs(func);
-    }
-    } else {
-      auto module =
-          *std::get<std::unique_ptr<mlir::ModuleOp>>(*converter.getModuleOp());
-      func = fir::FirOpBuilder::getNamedFunction(module, name);
-      if (!func) {
-        mlir::Location loc = side().getCalleeLocation();
-        mlir::FunctionType ty = genFunctionType();
-        func = fir::FirOpBuilder::createFunction(loc, module, name, ty);
-        if (const Fortran::semantics::Symbol *sym = side().getProcedureSymbol())
-          addSymbolAttribute(func, *sym, converter.getMLIRContext());
-        for (const auto &placeHolder : llvm::enumerate(inputs))
-          if (!placeHolder.value().attributes.empty())
-            func.setArgAttrs(placeHolder.index(),
-                             placeHolder.value().attributes);
-        side().setFuncAttrs(func);
-      }
     }
   }
 }
@@ -1325,37 +1304,7 @@ mlir::FunctionType Fortran::lower::translateSignature(
 mlir::func::FuncOp Fortran::lower::getOrDeclareFunction(
     llvm::StringRef name, const Fortran::evaluate::ProcedureDesignator &proc,
     Fortran::lower::AbstractConverter &converter) {
-  if (std::holds_alternative<std::unique_ptr<mlir::omp::ModuleOp>>(
-          *converter.getModuleOp())) {
-    auto module = *std::get<std::unique_ptr<mlir::omp::ModuleOp>>(
-        *converter.getModuleOp());
-
-    mlir::func::FuncOp func = fir::FirOpBuilder::getNamedFunction(module, name);
-    if (func)
-      return func;
-
-    const Fortran::semantics::Symbol *symbol = proc.GetSymbol();
-    assert(symbol && "non user function in getOrDeclareFunction");
-    // getOrDeclareFunction is only used for functions not defined in the
-    // current program unit, so use the location of the procedure designator
-    // symbol, which is the first occurrence of the procedure in the program
-    // unit.
-    mlir::Location loc = converter.genLocation(symbol->name());
-    std::optional<Fortran::evaluate::characteristics::Procedure>
-        characteristics =
-            Fortran::evaluate::characteristics::Procedure::Characterize(
-                proc, converter.getFoldingContext());
-    mlir::FunctionType ty = SignatureBuilder{characteristics.value(), converter,
-                                             /*forceImplicit=*/false}
-                                .getFunctionType();
-    mlir::func::FuncOp newFunc =
-        fir::FirOpBuilder::createFunction(loc, module, name, ty);
-    addSymbolAttribute(newFunc, *symbol, converter.getMLIRContext());
-    return newFunc;
-  }
-
-  auto module =
-      *std::get<std::unique_ptr<mlir::ModuleOp>>(*converter.getModuleOp());
+  auto module = converter.getModuleOp();
   mlir::func::FuncOp func = fir::FirOpBuilder::getNamedFunction(module, name);
   if (func)
     return func;

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1554,8 +1554,16 @@ static mlir::FunctionType getFunctionType(std::optional<mlir::Type> resultType,
   llvm::SmallVector<mlir::Type> resTypes;
   if (resultType)
     resTypes.push_back(*resultType);
-  return mlir::FunctionType::get(builder.getModule().getContext(), argTypes,
-                                 resTypes);
+
+  mlir::MLIRContext *ctx;
+  auto modVar = builder.getModule();
+  if (std::holds_alternative<mlir::ModuleOp>(modVar))
+    ctx = std::get<mlir::ModuleOp>(modVar)->getContext();
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(modVar))
+    ctx = std::get<mlir::omp::ModuleOp>(modVar)->getContext();
+
+  return mlir::FunctionType::get(ctx, argTypes, resTypes);
 }
 
 /// fir::ExtendedValue to mlir::Value translation layer

--- a/flang/lib/Lower/IntrinsicCall.cpp
+++ b/flang/lib/Lower/IntrinsicCall.cpp
@@ -1554,16 +1554,8 @@ static mlir::FunctionType getFunctionType(std::optional<mlir::Type> resultType,
   llvm::SmallVector<mlir::Type> resTypes;
   if (resultType)
     resTypes.push_back(*resultType);
-
-  mlir::MLIRContext *ctx;
-  auto modVar = builder.getModule();
-  if (std::holds_alternative<mlir::ModuleOp>(modVar))
-    ctx = std::get<mlir::ModuleOp>(modVar)->getContext();
-
-  if (std::holds_alternative<mlir::omp::ModuleOp>(modVar))
-    ctx = std::get<mlir::omp::ModuleOp>(modVar)->getContext();
-
-  return mlir::FunctionType::get(ctx, argTypes, resTypes);
+  return mlir::FunctionType::get(builder.getModule().getContext(), argTypes,
+                                 resTypes);
 }
 
 /// fir::ExtendedValue to mlir::Value translation layer

--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -1039,22 +1039,10 @@ static omp::ReductionDeclareOp createReductionDecl(
     Fortran::parser::DefinedOperator::IntrinsicOperator intrinsicOp,
     mlir::Type type, mlir::Location loc) {
   OpBuilder::InsertionGuard guard(builder);
-
-  mlir::omp::ReductionDeclareOp decl;
-  mlir::Region *reg;
-  if (std::holds_alternative<mlir::ModuleOp>(builder.getModule())) {
-    auto mod = std::get<mlir::ModuleOp>(builder.getModule());
-    decl = mod.lookupSymbol<mlir::omp::ReductionDeclareOp>(reductionOpName);
-    reg = &mod.getBodyRegion();
-  }
-
-  if (std::holds_alternative<mlir::omp::ModuleOp>(builder.getModule())) {
-    auto mod = std::get<mlir::omp::ModuleOp>(builder.getModule());
-    decl = mod.lookupSymbol<mlir::omp::ReductionDeclareOp>(reductionOpName);
-    reg = &mod.getBodyRegion();
-  }
-
-  mlir::OpBuilder modBuilder(reg);
+  auto module = builder.getModule();
+  mlir::OpBuilder modBuilder(module.getBodyRegion());
+  auto decl =
+      module.lookupSymbol<mlir::omp::ReductionDeclareOp>(reductionOpName);
   if (!decl)
     decl =
         modBuilder.create<omp::ReductionDeclareOp>(loc, reductionOpName, type);
@@ -1480,23 +1468,9 @@ genOMP(Fortran::lower::AbstractConverter &converter,
       return firOpBuilder.create<mlir::omp::CriticalOp>(currentLocation,
                                                         FlatSymbolRefAttr());
     } else {
-      mlir::omp::CriticalDeclareOp global;
-      mlir::Region *reg;
-      if (std::holds_alternative<mlir::ModuleOp>(firOpBuilder.getModule())) {
-        auto mod = std::get<mlir::ModuleOp>(firOpBuilder.getModule());
-        global = mod.lookupSymbol<mlir::omp::CriticalDeclareOp>(name);
-        reg = &mod.getBodyRegion();
-      }
-
-      if (std::holds_alternative<mlir::omp::ModuleOp>(
-              firOpBuilder.getModule())) {
-        auto mod = std::get<mlir::omp::ModuleOp>(firOpBuilder.getModule());
-        global = mod.lookupSymbol<mlir::omp::CriticalDeclareOp>(name);
-        reg = &mod.getBodyRegion();
-      }
-
-      mlir::OpBuilder modBuilder(reg);
-
+      auto module = firOpBuilder.getModule();
+      mlir::OpBuilder modBuilder(module.getBodyRegion());
+      auto global = module.lookupSymbol<mlir::omp::CriticalDeclareOp>(name);
       if (!global)
         global = modBuilder.create<mlir::omp::CriticalDeclareOp>(
             currentLocation, name, hint);

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -34,26 +34,25 @@ static llvm::cl::opt<std::size_t>
 
 mlir::func::FuncOp
 fir::FirOpBuilder::createFunction(mlir::Location loc,
-                                  fortran::common::ModuleInterface module,
+                                  mlir::ModuleInterface module,
                                   llvm::StringRef name, mlir::FunctionType ty) {
   return fir::createFuncOp(loc, module, name, ty);
 }
 
 mlir::func::FuncOp
-fir::FirOpBuilder::getNamedFunction(fortran::common::ModuleInterface modOp,
+fir::FirOpBuilder::getNamedFunction(mlir::ModuleInterface modOp,
                                     llvm::StringRef name) {
   return modOp.lookupSymbol<mlir::func::FuncOp>(name);
 }
 
 mlir::func::FuncOp
-fir::FirOpBuilder::getNamedFunction(fortran::common::ModuleInterface modOp,
+fir::FirOpBuilder::getNamedFunction(mlir::ModuleInterface modOp,
                                     mlir::SymbolRefAttr symbol) {
   return modOp.lookupSymbol<mlir::func::FuncOp>(symbol);
 }
 
-fir::GlobalOp
-fir::FirOpBuilder::getNamedGlobal(fortran::common::ModuleInterface modOp,
-                                  llvm::StringRef name) {
+fir::GlobalOp fir::FirOpBuilder::getNamedGlobal(mlir::ModuleInterface modOp,
+                                                llvm::StringRef name) {
   return modOp.lookupSymbol<fir::GlobalOp>(name);
 }
 

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -32,27 +32,59 @@ static llvm::cl::opt<std::size_t>
                                       "name"),
                        llvm::cl::init(32));
 
-mlir::func::FuncOp fir::FirOpBuilder::createFunction(mlir::Location loc,
-                                                     mlir::ModuleOp module,
-                                                     llvm::StringRef name,
-                                                     mlir::FunctionType ty) {
+mlir::func::FuncOp fir::FirOpBuilder::createFunction(
+    mlir::Location loc,
+    std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> module,
+    llvm::StringRef name, mlir::FunctionType ty) {
   return fir::createFuncOp(loc, module, name, ty);
 }
 
-mlir::func::FuncOp fir::FirOpBuilder::getNamedFunction(mlir::ModuleOp modOp,
-                                                       llvm::StringRef name) {
-  return modOp.lookupSymbol<mlir::func::FuncOp>(name);
+mlir::func::FuncOp fir::FirOpBuilder::getNamedFunction(
+    std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> modOp,
+    llvm::StringRef name) {
+  mlir::func::FuncOp fOp;
+  if (std::holds_alternative<mlir::ModuleOp>(modOp)) {
+    auto mod = std::get<mlir::ModuleOp>(modOp);
+    fOp = mod.lookupSymbol<mlir::func::FuncOp>(name);
+  }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(modOp)) {
+    auto mod = std::get<mlir::omp::ModuleOp>(modOp);
+    fOp = mod.lookupSymbol<mlir::func::FuncOp>(name);
+  }
+  return fOp;
 }
 
-mlir::func::FuncOp
-fir::FirOpBuilder::getNamedFunction(mlir::ModuleOp modOp,
-                                    mlir::SymbolRefAttr symbol) {
-  return modOp.lookupSymbol<mlir::func::FuncOp>(symbol);
+mlir::func::FuncOp fir::FirOpBuilder::getNamedFunction(
+    std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> modOp,
+    mlir::SymbolRefAttr symbol) {
+  mlir::func::FuncOp fOp;
+  if (std::holds_alternative<mlir::ModuleOp>(modOp)) {
+    auto mod = std::get<mlir::ModuleOp>(modOp);
+    fOp = mod.lookupSymbol<mlir::func::FuncOp>(symbol);
+  }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(modOp)) {
+    auto mod = std::get<mlir::omp::ModuleOp>(modOp);
+    fOp = mod.lookupSymbol<mlir::func::FuncOp>(symbol);
+  }
+  return fOp;
 }
 
-fir::GlobalOp fir::FirOpBuilder::getNamedGlobal(mlir::ModuleOp modOp,
-                                                llvm::StringRef name) {
-  return modOp.lookupSymbol<fir::GlobalOp>(name);
+fir::GlobalOp fir::FirOpBuilder::getNamedGlobal(
+    std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> modOp,
+    llvm::StringRef name) {
+  fir::GlobalOp gOp;
+  if (std::holds_alternative<mlir::ModuleOp>(modOp)) {
+    auto mod = std::get<mlir::ModuleOp>(modOp);
+    gOp = mod.lookupSymbol<fir::GlobalOp>(name);
+  }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(modOp)) {
+    auto mod = std::get<mlir::omp::ModuleOp>(modOp);
+    gOp = mod.lookupSymbol<fir::GlobalOp>(name);
+  }
+  return gOp;
 }
 
 mlir::Type fir::FirOpBuilder::getRefType(mlir::Type eleTy) {
@@ -255,11 +287,24 @@ fir::GlobalOp fir::FirOpBuilder::createGlobal(mlir::Location loc,
                                               mlir::StringAttr linkage,
                                               mlir::Attribute value,
                                               bool isConst, bool isTarget) {
-  auto module = getModule();
+  mlir::Block *body;
+  if (std::holds_alternative<mlir::ModuleOp>(getModule())) {
+    auto mod = std::get<mlir::ModuleOp>(getModule());
+    if (auto glob = mod.lookupSymbol<fir::GlobalOp>(name))
+      return glob;
+    body = mod.getBody();
+  }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(getModule())) {
+    auto mod = std::get<mlir::omp::ModuleOp>(getModule());
+    if (auto glob = mod.lookupSymbol<fir::GlobalOp>(name))
+      return glob;
+    body = mod.getBody();
+  }
+
   auto insertPt = saveInsertionPoint();
-  if (auto glob = module.lookupSymbol<fir::GlobalOp>(name))
-    return glob;
-  setInsertionPoint(module.getBody(), module.getBody()->end());
+
+  setInsertionPoint(body, body->end());
   auto glob =
       create<fir::GlobalOp>(loc, name, isConst, isTarget, type, value, linkage);
   restoreInsertionPoint(insertPt);
@@ -270,11 +315,23 @@ fir::GlobalOp fir::FirOpBuilder::createGlobal(
     mlir::Location loc, mlir::Type type, llvm::StringRef name, bool isConst,
     bool isTarget, std::function<void(FirOpBuilder &)> bodyBuilder,
     mlir::StringAttr linkage) {
-  auto module = getModule();
+  mlir::Block *body;
+  if (std::holds_alternative<mlir::ModuleOp>(getModule())) {
+    auto mod = std::get<mlir::ModuleOp>(getModule());
+    if (auto glob = mod.lookupSymbol<fir::GlobalOp>(name))
+      return glob;
+    body = mod.getBody();
+  }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(getModule())) {
+    auto mod = std::get<mlir::omp::ModuleOp>(getModule());
+    if (auto glob = mod.lookupSymbol<fir::GlobalOp>(name))
+      return glob;
+    body = mod.getBody();
+  }
+
   auto insertPt = saveInsertionPoint();
-  if (auto glob = module.lookupSymbol<fir::GlobalOp>(name))
-    return glob;
-  setInsertionPoint(module.getBody(), module.getBody()->end());
+  setInsertionPoint(body, body->end());
   auto glob = create<fir::GlobalOp>(loc, name, isConst, isTarget, type,
                                     mlir::Attribute{}, linkage);
   auto &region = glob.getRegion();
@@ -288,11 +345,23 @@ fir::GlobalOp fir::FirOpBuilder::createGlobal(
 
 fir::DispatchTableOp fir::FirOpBuilder::createDispatchTableOp(
     mlir::Location loc, llvm::StringRef name, llvm::StringRef parentName) {
-  auto module = getModule();
+  mlir::Block *body;
+  if (std::holds_alternative<mlir::ModuleOp>(getModule())) {
+    auto mod = std::get<mlir::ModuleOp>(getModule());
+    if (auto dt = mod.lookupSymbol<fir::DispatchTableOp>(name))
+      return dt;
+    body = mod.getBody();
+  }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(getModule())) {
+    auto mod = std::get<mlir::omp::ModuleOp>(getModule());
+    if (auto dt = mod.lookupSymbol<fir::DispatchTableOp>(name))
+      return dt;
+    body = mod.getBody();
+  }
+
   auto insertPt = saveInsertionPoint();
-  if (auto dt = module.lookupSymbol<fir::DispatchTableOp>(name))
-    return dt;
-  setInsertionPoint(module.getBody(), module.getBody()->end());
+  setInsertionPoint(body, body->end());
   auto dt = create<fir::DispatchTableOp>(loc, name, mlir::Type{}, parentName);
   restoreInsertionPoint(insertPt);
   return dt;

--- a/flang/lib/Optimizer/CodeGen/BoxedProcedure.cpp
+++ b/flang/lib/Optimizer/CodeGen/BoxedProcedure.cpp
@@ -182,15 +182,19 @@ public:
   BoxedProcedurePass() { options = {true}; }
   BoxedProcedurePass(bool useThunks) { options = {useThunks}; }
 
-  inline mlir::ModuleOp getModule() { return getOperation(); }
+  bool canScheduleOn(mlir::RegisteredOperationName opInfo) const override {
+    return opInfo.getStringRef() == "builtin.module" ||
+           opInfo.getStringRef() == "omp.module";
+  }
 
-  void runOnOperation() override final {
+  template <typename T>
+  void runOperationOnModule(T mod) {
     if (options.useThunks) {
       auto *context = &getContext();
       mlir::IRRewriter rewriter(context);
       BoxprocTypeRewriter typeConverter(mlir::UnknownLoc::get(context));
       mlir::Dialect *firDialect = context->getLoadedDialect("fir");
-      getModule().walk([&](mlir::Operation *op) {
+      mod.walk([&](mlir::Operation *op) {
         typeConverter.setLocation(op->getLoc());
         if (auto addr = mlir::dyn_cast<BoxAddrOp>(op)) {
           auto ty = addr.getVal().getType();
@@ -331,6 +335,15 @@ public:
           rewriter.finalizeRootUpdate(op);
         }
       });
+    }
+  }
+
+  void runOnOperation() override final {
+    if (mlir::ModuleOp mod = mlir::dyn_cast<mlir::ModuleOp>(getOperation())) {
+      runOperationOnModule<mlir::ModuleOp>(mod);
+    } else if (mlir::omp::ModuleOp mod =
+                   mlir::dyn_cast<mlir::omp::ModuleOp>(getOperation())) {
+      runOperationOnModule<mlir::omp::ModuleOp>(mod);
     }
   }
 

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -282,6 +282,11 @@ public:
 
 class CodeGenRewrite : public fir::impl::CodeGenRewriteBase<CodeGenRewrite> {
 public:
+  bool canScheduleOn(mlir::RegisteredOperationName opInfo) const override {
+    return opInfo.getStringRef() == "builtin.module" ||
+           opInfo.getStringRef() == "omp.module";
+  }
+
   void runOn(mlir::Operation *op, mlir::Region &region) {
     auto &context = getContext();
     mlir::OpBuilder rewriter(&context);
@@ -310,13 +315,22 @@ public:
     simplifyRegion(region);
   }
 
-  void runOnOperation() override final {
+  template <typename T>
+  void runOperationOnModule(T mod) {
     // Call runOn on all top level regions that may contain emboxOp/arrayCoorOp.
-    auto mod = getOperation();
-    for (auto func : mod.getOps<mlir::func::FuncOp>())
+    for (auto func : mod.template getOps<mlir::func::FuncOp>())
       runOn(func, func.getBody());
-    for (auto global : mod.getOps<fir::GlobalOp>())
+    for (auto global : mod.template getOps<fir::GlobalOp>())
       runOn(global, global.getRegion());
+  }
+
+  void runOnOperation() override final {
+    if (mlir::ModuleOp mod = mlir::dyn_cast<mlir::ModuleOp>(getOperation())) {
+      runOperationOnModule<mlir::ModuleOp>(mod);
+    } else if (mlir::omp::ModuleOp mod =
+                   mlir::dyn_cast<mlir::omp::ModuleOp>(getOperation())) {
+      runOperationOnModule<mlir::omp::ModuleOp>(mod);
+    }
   }
 
   // Clean up the region.

--- a/flang/lib/Optimizer/CodeGen/TBAABuilder.cpp
+++ b/flang/lib/Optimizer/CodeGen/TBAABuilder.cpp
@@ -12,7 +12,6 @@
 
 #include "TBAABuilder.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 

--- a/flang/lib/Optimizer/CodeGen/TBAABuilder.h
+++ b/flang/lib/Optimizer/CodeGen/TBAABuilder.h
@@ -15,12 +15,8 @@
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 
-namespace mlir {
-namespace omp {
-class ModuleOp;
-} // namespace omp
-} // namespace mlir
 namespace fir {
 
 // TBAA builder provides mapping between FIR types and their TBAA type
@@ -169,8 +165,7 @@ namespace fir {
 //   < `<any data access>`, `<any data access>`, 0 >
 class TBAABuilder {
 public:
-  TBAABuilder(mlir::ModuleOp module, bool applyTBAA);
-  TBAABuilder(mlir::omp::ModuleOp module, bool applyTBAA);
+  TBAABuilder(mlir::ModuleInterface module, bool applyTBAA);
 
   TBAABuilder(TBAABuilder const &) = delete;
   TBAABuilder &operator=(TBAABuilder const &) = delete;
@@ -181,10 +176,6 @@ public:
                      mlir::Type accessFIRType, mlir::LLVM::GEPOp gep);
 
 private:
-  // generalises costruction of TBAA information for other module types
-  template <typename ModType>
-  void constructTBAAForModule(ModType module);
-
   // Return unique string name based on `basename`.
   std::string getNewTBAANodeName(llvm::StringRef basename);
 

--- a/flang/lib/Optimizer/CodeGen/TBAABuilder.h
+++ b/flang/lib/Optimizer/CodeGen/TBAABuilder.h
@@ -16,6 +16,11 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
+namespace mlir {
+namespace omp {
+class ModuleOp;
+} // namespace omp
+} // namespace mlir
 namespace fir {
 
 // TBAA builder provides mapping between FIR types and their TBAA type
@@ -165,6 +170,8 @@ namespace fir {
 class TBAABuilder {
 public:
   TBAABuilder(mlir::ModuleOp module, bool applyTBAA);
+  TBAABuilder(mlir::omp::ModuleOp module, bool applyTBAA);
+
   TBAABuilder(TBAABuilder const &) = delete;
   TBAABuilder &operator=(TBAABuilder const &) = delete;
 
@@ -174,6 +181,10 @@ public:
                      mlir::Type accessFIRType, mlir::LLVM::GEPOp gep);
 
 private:
+  // generalises costruction of TBAA information for other module types
+  template <typename ModType>
+  void constructTBAAForModule(ModType module);
+
   // Return unique string name based on `basename`.
   std::string getNewTBAANodeName(llvm::StringRef basename);
 

--- a/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
@@ -282,6 +282,7 @@ public:
           })
           .template Case<mlir::TupleType>([&](mlir::TupleType tuple) {
             if (fir::isCharacterProcedureTuple(tuple)) {
+              auto module = getModule();
               if constexpr (std::is_same_v<std::decay_t<A>, fir::CallOp>) {
                 if (callOp.getCallee()) {
                   llvm::StringRef charProcAttr =
@@ -290,7 +291,7 @@ public:
                   // confirm that this is a dummy procedure and should be split.
                   // It cannot be used to match because attributes are not
                   // available in case of indirect calls.
-                  auto funcOp = getModule().lookupSymbol<mlir::func::FuncOp>(
+                  auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(
                       *callOp.getCallee());
                   if (funcOp &&
                       !funcOp.template getArgAttrOfType<mlir::UnitAttr>(
@@ -302,7 +303,7 @@ public:
               }
               mlir::Type funcPointerType = tuple.getType(0);
               mlir::Type lenType = tuple.getType(1);
-              fir::KindMapping kindMap = fir::getKindMapping(getModule());
+              fir::KindMapping kindMap = fir::getKindMapping(module);
               fir::FirOpBuilder builder(*rewriter, kindMap);
               auto [funcPointer, len] =
                   fir::factory::extractCharacterProcedureTuple(builder, loc,

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.h
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.h
@@ -46,7 +46,8 @@ namespace fir {
 /// This converts FIR types to LLVM types (for now)
 class LLVMTypeConverter : public mlir::LLVMTypeConverter {
 public:
-  LLVMTypeConverter(mlir::ModuleOp module, bool applyTBAA)
+  template <typename T>
+  LLVMTypeConverter(T module, bool applyTBAA)
       : mlir::LLVMTypeConverter(module.getContext()),
         kindMapping(getKindMapping(module)),
         specifics(CodeGenSpecifics::get(module.getContext(),

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3508,7 +3508,7 @@ fir::parseSelector(mlir::OpAsmParser &parser, mlir::OperationState &result,
 }
 
 mlir::func::FuncOp
-fir::createFuncOp(mlir::Location loc, fortran::common::ModuleInterface module,
+fir::createFuncOp(mlir::Location loc, mlir::ModuleInterface module,
                   llvm::StringRef name, mlir::FunctionType type,
                   llvm::ArrayRef<mlir::NamedAttribute> attrs) {
   if (auto f = module.lookupSymbol<mlir::func::FuncOp>(name))
@@ -3521,7 +3521,7 @@ fir::createFuncOp(mlir::Location loc, fortran::common::ModuleInterface module,
 }
 
 fir::GlobalOp fir::createGlobalOp(mlir::Location loc,
-                                  fortran::common::ModuleInterface module,
+                                  mlir::ModuleInterface module,
                                   llvm::StringRef name, mlir::Type type,
                                   llvm::ArrayRef<mlir::NamedAttribute> attrs) {
   if (auto g = module.lookupSymbol<fir::GlobalOp>(name))

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3615,7 +3615,6 @@ valueCheckFirAttributes(mlir::Value value,
     if (auto addressOfOp = mlir::dyn_cast<fir::AddrOfOp>(definingOp)) {
       if (testAttributeSets(addressOfOp->getAttrs(), attributeNames))
         return true;
-
       if (auto module = definingOp->getParentOfType<mlir::ModuleOp>()) {
         if (auto globalOp =
                 module.lookupSymbol<fir::GlobalOp>(addressOfOp.getSymbol()))

--- a/flang/lib/Optimizer/Support/FIRContext.cpp
+++ b/flang/lib/Optimizer/Support/FIRContext.cpp
@@ -17,37 +17,88 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/Support/Host.h"
 
-void fir::setTargetTriple(mlir::ModuleOp mod, llvm::StringRef triple) {
+void fir::setTargetTriple(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod,
+                          llvm::StringRef triple) {
   auto target = fir::determineTargetTriple(triple);
-  mod->setAttr(mlir::LLVM::LLVMDialect::getTargetTripleAttrName(),
-               mlir::StringAttr::get(mod.getContext(), target));
+  if (std::holds_alternative<mlir::ModuleOp>(mod)) {
+    auto module = std::get<mlir::ModuleOp>(mod);
+    module->setAttr(mlir::LLVM::LLVMDialect::getTargetTripleAttrName(),
+                    mlir::StringAttr::get(module.getContext(), target));
+  } else if (std::holds_alternative<mlir::omp::ModuleOp>(mod)) {
+    auto module = std::get<mlir::omp::ModuleOp>(mod);
+    module->setAttr(mlir::LLVM::LLVMDialect::getTargetTripleAttrName(),
+                    mlir::StringAttr::get(module.getContext(), target));
+  }
 }
 
-llvm::Triple fir::getTargetTriple(mlir::ModuleOp mod) {
-  if (auto target = mod->getAttrOfType<mlir::StringAttr>(
-          mlir::LLVM::LLVMDialect::getTargetTripleAttrName()))
-    return llvm::Triple(target.getValue());
+llvm::Triple
+fir::getTargetTriple(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod) {
+  if (std::holds_alternative<mlir::ModuleOp>(mod)) {
+    auto module = std::get<mlir::ModuleOp>(mod);
+    if (auto target = module->getAttrOfType<mlir::StringAttr>(
+            mlir::LLVM::LLVMDialect::getTargetTripleAttrName()))
+      return llvm::Triple(target.getValue());
+  }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(mod)) {
+    auto module = std::get<mlir::omp::ModuleOp>(mod);
+    if (auto target = module->getAttrOfType<mlir::StringAttr>(
+            mlir::LLVM::LLVMDialect::getTargetTripleAttrName()))
+      return llvm::Triple(target.getValue());
+  }
+
   return llvm::Triple(llvm::sys::getDefaultTargetTriple());
 }
 
 static constexpr const char *kindMapName = "fir.kindmap";
 static constexpr const char *defKindName = "fir.defaultkind";
 
-void fir::setKindMapping(mlir::ModuleOp mod, fir::KindMapping &kindMap) {
-  auto *ctx = mod.getContext();
-  mod->setAttr(kindMapName, mlir::StringAttr::get(ctx, kindMap.mapToString()));
-  auto defs = kindMap.defaultsToString();
-  mod->setAttr(defKindName, mlir::StringAttr::get(ctx, defs));
+void fir::setKindMapping(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod,
+                         fir::KindMapping &kindMap) {
+
+  if (std::holds_alternative<mlir::ModuleOp>(mod)) {
+    auto module = std::get<mlir::ModuleOp>(mod);
+    auto *ctx = module.getContext();
+    module->setAttr(kindMapName,
+                    mlir::StringAttr::get(ctx, kindMap.mapToString()));
+    auto defs = kindMap.defaultsToString();
+    module->setAttr(defKindName, mlir::StringAttr::get(ctx, defs));
+
+  } else if (std::holds_alternative<mlir::omp::ModuleOp>(mod)) {
+    auto module = std::get<mlir::omp::ModuleOp>(mod);
+    auto *ctx = module.getContext();
+    module->setAttr(kindMapName,
+                    mlir::StringAttr::get(ctx, kindMap.mapToString()));
+    auto defs = kindMap.defaultsToString();
+    module->setAttr(defKindName, mlir::StringAttr::get(ctx, defs));
+  }
 }
 
-fir::KindMapping fir::getKindMapping(mlir::ModuleOp mod) {
-  auto *ctx = mod.getContext();
-  if (auto defs = mod->getAttrOfType<mlir::StringAttr>(defKindName)) {
-    auto defVals = fir::KindMapping::toDefaultKinds(defs.getValue());
-    if (auto maps = mod->getAttrOfType<mlir::StringAttr>(kindMapName))
-      return fir::KindMapping(ctx, maps.getValue(), defVals);
-    return fir::KindMapping(ctx, defVals);
+fir::KindMapping
+fir::getKindMapping(std::variant<mlir::ModuleOp, mlir::omp::ModuleOp> mod) {
+  mlir::MLIRContext *ctx = nullptr;
+  if (std::holds_alternative<mlir::ModuleOp>(mod)) {
+    auto module = std::get<mlir::ModuleOp>(mod);
+    ctx = module.getContext();
+    if (auto defs = module->getAttrOfType<mlir::StringAttr>(defKindName)) {
+      auto defVals = fir::KindMapping::toDefaultKinds(defs.getValue());
+      if (auto maps = module->getAttrOfType<mlir::StringAttr>(kindMapName))
+        return fir::KindMapping(ctx, maps.getValue(), defVals);
+      return fir::KindMapping(ctx, defVals);
+    }
   }
+
+  if (std::holds_alternative<mlir::omp::ModuleOp>(mod)) {
+    auto module = std::get<mlir::omp::ModuleOp>(mod);
+    ctx = module.getContext();
+    if (auto defs = module->getAttrOfType<mlir::StringAttr>(defKindName)) {
+      auto defVals = fir::KindMapping::toDefaultKinds(defs.getValue());
+      if (auto maps = module->getAttrOfType<mlir::StringAttr>(kindMapName))
+        return fir::KindMapping(ctx, maps.getValue(), defVals);
+      return fir::KindMapping(ctx, defVals);
+    }
+  }
+
   return fir::KindMapping(ctx);
 }
 

--- a/flang/lib/Optimizer/Support/FIRContext.cpp
+++ b/flang/lib/Optimizer/Support/FIRContext.cpp
@@ -17,14 +17,13 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/Support/Host.h"
 
-void fir::setTargetTriple(fortran::common::ModuleInterface mod,
-                          llvm::StringRef triple) {
+void fir::setTargetTriple(mlir::ModuleInterface mod, llvm::StringRef triple) {
   auto target = fir::determineTargetTriple(triple);
   mod->setAttr(mlir::LLVM::LLVMDialect::getTargetTripleAttrName(),
                mlir::StringAttr::get(mod.getContext(), target));
 }
 
-llvm::Triple fir::getTargetTriple(fortran::common::ModuleInterface mod) {
+llvm::Triple fir::getTargetTriple(mlir::ModuleInterface mod) {
   if (auto target = mod->getAttrOfType<mlir::StringAttr>(
           mlir::LLVM::LLVMDialect::getTargetTripleAttrName()))
     return llvm::Triple(target.getValue());
@@ -34,15 +33,14 @@ llvm::Triple fir::getTargetTriple(fortran::common::ModuleInterface mod) {
 static constexpr const char *kindMapName = "fir.kindmap";
 static constexpr const char *defKindName = "fir.defaultkind";
 
-void fir::setKindMapping(fortran::common::ModuleInterface mod,
-                         fir::KindMapping &kindMap) {
+void fir::setKindMapping(mlir::ModuleInterface mod, fir::KindMapping &kindMap) {
   auto *ctx = mod.getContext();
   mod->setAttr(kindMapName, mlir::StringAttr::get(ctx, kindMap.mapToString()));
   auto defs = kindMap.defaultsToString();
   mod->setAttr(defKindName, mlir::StringAttr::get(ctx, defs));
 }
 
-fir::KindMapping fir::getKindMapping(fortran::common::ModuleInterface mod) {
+fir::KindMapping fir::getKindMapping(mlir::ModuleInterface mod) {
   auto *ctx = mod.getContext();
   if (auto defs = mod->getAttrOfType<mlir::StringAttr>(defKindName)) {
     auto defVals = fir::KindMapping::toDefaultKinds(defs.getValue());

--- a/flang/lib/Optimizer/Transforms/SimplifyIntrinsics.cpp
+++ b/flang/lib/Optimizer/Transforms/SimplifyIntrinsics.cpp
@@ -461,10 +461,10 @@ mlir::func::FuncOp SimplifyIntrinsicsPass::getOrCreateFunction(
   //          We can also avoid this by using internal linkage, but
   //          this may increase the size of final executable/shared library.
   std::string replacementName = mlir::Twine{baseName, "_simplified"}.str();
-
+  fortran::common::ModuleInterface module = builder.getModule();
   // If we already have a function, just return it.
   mlir::func::FuncOp newFunc =
-      fir::FirOpBuilder::getNamedFunction(builder.getModule(), replacementName);
+      fir::FirOpBuilder::getNamedFunction(module, replacementName);
   mlir::FunctionType fType = typeGenerator(builder);
   if (newFunc) {
     assert(newFunc.getFunctionType() == fType &&
@@ -474,8 +474,8 @@ mlir::func::FuncOp SimplifyIntrinsicsPass::getOrCreateFunction(
 
   // Need to build the function!
   auto loc = mlir::UnknownLoc::get(builder.getContext());
-  newFunc = fir::FirOpBuilder::createFunction(loc, builder.getModule(),
-                                              replacementName, fType);
+  newFunc =
+      fir::FirOpBuilder::createFunction(loc, module, replacementName, fType);
   auto inlineLinkage = mlir::LLVM::linkage::Linkage::LinkonceODR;
   auto linkage =
       mlir::LLVM::LinkageAttr::get(builder.getContext(), inlineLinkage);

--- a/flang/lib/Optimizer/Transforms/SimplifyIntrinsics.cpp
+++ b/flang/lib/Optimizer/Transforms/SimplifyIntrinsics.cpp
@@ -461,7 +461,7 @@ mlir::func::FuncOp SimplifyIntrinsicsPass::getOrCreateFunction(
   //          We can also avoid this by using internal linkage, but
   //          this may increase the size of final executable/shared library.
   std::string replacementName = mlir::Twine{baseName, "_simplified"}.str();
-  fortran::common::ModuleInterface module = builder.getModule();
+  mlir::ModuleInterface module = builder.getModule();
   // If we already have a function, just return it.
   mlir::func::FuncOp newFunc =
       fir::FirOpBuilder::getNamedFunction(module, replacementName);

--- a/flang/lib/Optimizer/Transforms/SimplifyIntrinsics.cpp
+++ b/flang/lib/Optimizer/Transforms/SimplifyIntrinsics.cpp
@@ -461,10 +461,10 @@ mlir::func::FuncOp SimplifyIntrinsicsPass::getOrCreateFunction(
   //          We can also avoid this by using internal linkage, but
   //          this may increase the size of final executable/shared library.
   std::string replacementName = mlir::Twine{baseName, "_simplified"}.str();
-  mlir::ModuleOp module = builder.getModule();
+
   // If we already have a function, just return it.
   mlir::func::FuncOp newFunc =
-      fir::FirOpBuilder::getNamedFunction(module, replacementName);
+      fir::FirOpBuilder::getNamedFunction(builder.getModule(), replacementName);
   mlir::FunctionType fType = typeGenerator(builder);
   if (newFunc) {
     assert(newFunc.getFunctionType() == fType &&
@@ -474,8 +474,8 @@ mlir::func::FuncOp SimplifyIntrinsicsPass::getOrCreateFunction(
 
   // Need to build the function!
   auto loc = mlir::UnknownLoc::get(builder.getContext());
-  newFunc =
-      fir::FirOpBuilder::createFunction(loc, module, replacementName, fType);
+  newFunc = fir::FirOpBuilder::createFunction(loc, builder.getModule(),
+                                              replacementName, fType);
   auto inlineLinkage = mlir::LLVM::linkage::Linkage::LinkonceODR;
   auto linkage =
       mlir::LLVM::LinkageAttr::get(builder.getContext(), inlineLinkage);

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-1.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-1.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Testing : "_QPtest"
 // CHECK-DAG: alloca_1#0 <-> address_of#0: NoAlias

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-2.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-2.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Testing : "_QFPtest"
 

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-3.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-3.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // module m
 //   type t

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -133,6 +133,7 @@
 ! HELP-FC1-NEXT: -fno-reformat          Dump the cooked character stream in -E mode
 ! HELP-FC1-NEXT: -fno-signed-zeros      Allow optimizations that ignore the sign of floating point zeros
 ! HELP-FC1-NEXT: -fopenacc              Enable OpenACC
+! HELP-FC1-NEXT: -fopenmp-is-device     Generate code only for an OpenMP target device.
 ! HELP-FC1-NEXT: -fopenmp               Parse OpenMP pragmas and generate parallel code.
 ! HELP-FC1-NEXT: -fpass-plugin=<dsopath> Load pass plugin from a dynamic shared object file (only with new pass manager).
 ! HELP-FC1-NEXT: -freciprocal-math      Allow division operations to be reassociated

--- a/flang/test/Fir/Todo/allocmem.fir
+++ b/flang/test/Fir/Todo/allocmem.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // Test `fir.allocmem` of derived type with LEN parameters conversion to llvm.
 // Not implemented yet.

--- a/flang/test/Fir/Todo/boxproc_host.fir
+++ b/flang/test/Fir/Todo/boxproc_host.fir
@@ -1,4 +1,4 @@
-// RUN: not fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: not fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // Test that `fir.boxproc_host` fails conversion to llvm.
 // At the moment this test fails since `fir.boxproc` type does not have a conversion.

--- a/flang/test/Fir/Todo/coordinate_of_2.fir
+++ b/flang/test/Fir/Todo/coordinate_of_2.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // CHECK: not yet implemented: fir.array nested inside other array and/or derived type
 

--- a/flang/test/Fir/Todo/coordinate_of_3.fir
+++ b/flang/test/Fir/Todo/coordinate_of_3.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // CHECK: not yet implemented: fir.array nested inside other array and/or derived type
 

--- a/flang/test/Fir/Todo/coordinate_of_4.fir
+++ b/flang/test/Fir/Todo/coordinate_of_4.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // `!fir.coordinate_of` - derived type with `!fir.len_param_index`. As
 // `!fir.len_param_index` is not implemented yet, the error that we hit is

--- a/flang/test/Fir/Todo/end.fir
+++ b/flang/test/Fir/Todo/end.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // Test `fir.end` conversion to llvm.
 // Not implemented yet.

--- a/flang/test/Fir/Todo/global_len.fir
+++ b/flang/test/Fir/Todo/global_len.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // Test `fir.global_len` conversion to llvm.
 // Not implemented yet.

--- a/flang/test/Fir/Todo/len_param_index.fir
+++ b/flang/test/Fir/Todo/len_param_index.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // Test `fir.len_param_index` conversion to llvm.
 // Not implemented yet.

--- a/flang/test/Fir/Todo/select_case_with_character.fir
+++ b/flang/test/Fir/Todo/select_case_with_character.fir
@@ -1,4 +1,4 @@
-// RUN: %not_todo_cmd fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: %not_todo_cmd fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // Test `fir.select_case` conversion to llvm with character type.
 // Not implemented yet.

--- a/flang/test/Fir/Todo/unboxproc.fir
+++ b/flang/test/Fir/Todo/unboxproc.fir
@@ -1,4 +1,4 @@
-// RUN: not fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
+// RUN: not fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s 2>&1 | FileCheck %s
 
 // Test `fir.unboxproc` conversion to llvm.
 // Not implemented yet.

--- a/flang/test/Fir/abstract-result-2.fir
+++ b/flang/test/Fir/abstract-result-2.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s --abstract-result-on-func-opt | FileCheck %s 
+// RUN: fir-opt --no-implicit-module=false %s --abstract-result-on-func-opt | FileCheck %s 
 
 // Check that the attributes are shifted along with their corresponding arguments
 

--- a/flang/test/Fir/abstract-results.fir
+++ b/flang/test/Fir/abstract-results.fir
@@ -1,10 +1,10 @@
 // Test rewrite of functions that return fir.array<>, fir.type<>, fir.box<> to
 // functions that take an additional argument for the result.
 
-// RUN: fir-opt %s --abstract-result-on-func-opt | FileCheck %s --check-prefix=FUNC-REF
-// RUN: fir-opt %s --abstract-result-on-func-opt=abstract-result-as-box | FileCheck %s --check-prefix=FUNC-BOX
-// RUN: fir-opt %s --abstract-result-on-global-opt | FileCheck %s --check-prefix=GLOBAL-REF
-// RUN: fir-opt %s --abstract-result-on-global-opt=abstract-result-as-box | FileCheck %s --check-prefix=GLOBAL-BOX
+// RUN: fir-opt %s --no-implicit-module=false --abstract-result-on-func-opt | FileCheck %s --check-prefix=FUNC-REF
+// RUN: fir-opt %s --no-implicit-module=false --abstract-result-on-func-opt=abstract-result-as-box | FileCheck %s --check-prefix=FUNC-BOX
+// RUN: fir-opt %s --no-implicit-module=false --abstract-result-on-global-opt | FileCheck %s --check-prefix=GLOBAL-REF
+// RUN: fir-opt %s --no-implicit-module=false --abstract-result-on-global-opt=abstract-result-as-box | FileCheck %s --check-prefix=GLOBAL-BOX
 
 // ----------------------- Test declaration rewrite ----------------------------
 

--- a/flang/test/Fir/array-copies-pointers.fir
+++ b/flang/test/Fir/array-copies-pointers.fir
@@ -1,8 +1,8 @@
 // Test array-copy-value pass (copy elision) with array assignment
 // involving Fortran pointers. Focus in only on wether copy ellision
 // is made or not.
-// RUN: fir-opt %s --array-value-copy -split-input-file | FileCheck --check-prefixes=ALL,NOOPT %s
-// RUN: fir-opt %s --array-value-copy="optimize-conflicts=true" -split-input-file | FileCheck --check-prefixes=ALL,OPT %s
+// RUN: fir-opt %s --no-implicit-module=false --array-value-copy -split-input-file | FileCheck --check-prefixes=ALL,NOOPT %s
+// RUN: fir-opt %s --no-implicit-module=false --array-value-copy="optimize-conflicts=true" -split-input-file | FileCheck --check-prefixes=ALL,OPT %s
 
 // Test `pointer(:) = array(:)`
 // ALL-LABEL: func @maybe_overlap

--- a/flang/test/Fir/array-modify.fir
+++ b/flang/test/Fir/array-modify.fir
@@ -1,6 +1,6 @@
 // Test array-copy-value pass (copy elision) with fir.array_modify
-// RUN: fir-opt %s --array-value-copy | FileCheck %s
-// RUN: fir-opt %s --array-value-copy="optimize-conflicts=true" | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false --array-value-copy | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false --array-value-copy="optimize-conflicts=true" | FileCheck %s
 
 // Test user_defined_assignment(arg0(:), arg1(:))
 func.func @no_overlap(%arg0: !fir.ref<!fir.array<100xf32>>, %arg1: !fir.ref<!fir.array<100xf32>>) {

--- a/flang/test/Fir/array-value-copy-2.fir
+++ b/flang/test/Fir/array-value-copy-2.fir
@@ -1,5 +1,5 @@
-// RUN: fir-opt --array-value-copy --cfg-conversion %s | FileCheck %s
-// RUN: fir-opt --array-value-copy="optimize-conflicts=true" --cfg-conversion %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy --cfg-conversion %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy="optimize-conflicts=true" --cfg-conversion %s | FileCheck %s
 
 // CHECK-LABEL: func @_QPslice1(
 // CHECK-NOT: fir.allocmem

--- a/flang/test/Fir/array-value-copy-3.fir
+++ b/flang/test/Fir/array-value-copy-3.fir
@@ -3,8 +3,8 @@
 // before they can be used in component assignments, and to deallocate the components
 // that may have been allocated in the end.
 
-// RUN: fir-opt --array-value-copy %s | FileCheck %s
-// RUN: fir-opt --array-value-copy="optimize-conflicts=true" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy="optimize-conflicts=true" %s | FileCheck %s
 
 
 !t_with_alloc_comp = !fir.type<t{i:!fir.box<!fir.heap<!fir.array<?xi32>>>}>

--- a/flang/test/Fir/array-value-copy-4.fir
+++ b/flang/test/Fir/array-value-copy-4.fir
@@ -2,8 +2,8 @@
 // Conversion was previously crashing as reported in
 // https://github.com/llvm/llvm-project/issues/59342.
 
-// RUN: fir-opt --array-value-copy %s | FileCheck %s
-// RUN: fir-opt --array-value-copy="optimize-conflicts=true" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy="optimize-conflicts=true" %s | FileCheck %s
 
 func.func @_QMmodPsub1(%arg0: !fir.box<!fir.array<?x!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>> {fir.bindc_name = "x"}) {
   %0 = fir.alloca !fir.box<!fir.type<_QMmodTrec1{dat:!fir.box<!fir.heap<!fir.array<?xi32>>>}>>

--- a/flang/test/Fir/array-value-copy-cam4.fir
+++ b/flang/test/Fir/array-value-copy-cam4.fir
@@ -1,5 +1,5 @@
-// RUN: fir-opt --array-value-copy %s | FileCheck --check-prefix=NOOPT %s
-// RUN: fir-opt --array-value-copy="optimize-conflicts=true" %s | FileCheck --check-prefix=OPT %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy %s | FileCheck --check-prefix=NOOPT %s
+// RUN: fir-opt --no-implicit-module=false --array-value-copy="optimize-conflicts=true" %s | FileCheck --check-prefix=OPT %s
 
 // Reproducer from SPEC CPU2017/527.cam4_r:
 // module cam4

--- a/flang/test/Fir/array-value-copy.fir
+++ b/flang/test/Fir/array-value-copy.fir
@@ -1,5 +1,5 @@
 // Test for the array-value-copy pass
-// RUN: fir-opt --split-input-file --array-value-copy %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --array-value-copy %s | FileCheck %s
 
 // Test simple fir.array_load/fir.array_fetch conversion to fir.array_coor
 func.func @array_fetch_conversion(%arr1 : !fir.ref<!fir.array<?x?xf32>>, %m: index, %n: index) {

--- a/flang/test/Fir/boxaddr-folding.fir
+++ b/flang/test/Fir/boxaddr-folding.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --canonicalize %s -split-input-file | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --canonicalize %s -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func @check_no_folding
 func.func @check_no_folding(%arg0 : !fir.ref<!fir.array<?xi32>>) {

--- a/flang/test/Fir/boxproc-2.fir
+++ b/flang/test/Fir/boxproc-2.fir
@@ -1,5 +1,5 @@
 // Test fir.boxproc type conversion in the boxed-procedure pass.
-// RUN: fir-opt --boxed-procedure %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --boxed-procedure %s | FileCheck %s
 
 //CHECK-LABEL:  func.func private @test1(!fir.type<a{x:i32,y:f64}>, () -> ()) -> none
 func.func private @test1(!fir.type<a{x:i32, y:f64}>, !fir.boxproc<() -> ()>) -> none

--- a/flang/test/Fir/cg-ops.fir
+++ b/flang/test/Fir/cg-ops.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --split-input-file --pass-pipeline="builtin.module(cg-rewrite,cse)" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --pass-pipeline="builtin.module(cg-rewrite,cse)" %s | FileCheck %s
 
 // CHECK-LABEL: func @codegen(
 // CHECK-SAME: %[[arg:.*]]: !fir

--- a/flang/test/Fir/char-conversion.fir
+++ b/flang/test/Fir/char-conversion.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --character-conversion %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --character-conversion %s | FileCheck %s
 
 func.func @char_convert() {
   %1 = fir.undefined i32

--- a/flang/test/Fir/commute.fir
+++ b/flang/test/Fir/commute.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s | tco | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | tco | FileCheck %s
 
 // CHECK-LABEL: define i32 @f1(i32 %0, i32 %1)
 func.func @f1(%a : i32, %b : i32) -> i32 {

--- a/flang/test/Fir/compare.fir
+++ b/flang/test/Fir/compare.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s | tco --target=x86_64-unknown-linux-gnu | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | tco --target=x86_64-unknown-linux-gnu | FileCheck %s
 
 // CHECK-LABEL: define i1 @cmp3(<2 x float> %0, <2 x float> %1)
 func.func @cmp3(%a : !fir.complex<4>, %b : !fir.complex<4>) -> i1 {

--- a/flang/test/Fir/constant.fir
+++ b/flang/test/Fir/constant.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s | tco | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | tco | FileCheck %s
 
 // CHECK-LABEL: define [3 x i8] @x
 func.func @x() -> !fir.char<1,3> {

--- a/flang/test/Fir/convert-fold.fir
+++ b/flang/test/Fir/convert-fold.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --canonicalize %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @ftest
 func.func @ftest(%x : i1) -> i1 {

--- a/flang/test/Fir/convert-to-llvm-invalid.fir
+++ b/flang/test/Fir/convert-to-llvm-invalid.fir
@@ -1,6 +1,6 @@
 // Test FIR to LLVM IR conversion invalid cases and diagnostics.
 
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" --verify-diagnostics %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" --verify-diagnostics %s
 
 // Test `fir.zero` conversion failure with aggregate type.
 // Not implemented yet.

--- a/flang/test/Fir/convert-to-llvm-openmp-and-fir.fir
+++ b/flang/test/Fir/convert-to-llvm-openmp-and-fir.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --split-input-file --cfg-conversion --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --cfg-conversion --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
 
 func.func @_QPsb1(%arg0: !fir.ref<i32> {fir.bindc_name = "n"}, %arg1: !fir.ref<!fir.array<?xi32>> {fir.bindc_name = "arr"}) {
   %c1_i64 = arith.constant 1 : i64

--- a/flang/test/Fir/convert-to-llvm-target.fir
+++ b/flang/test/Fir/convert-to-llvm-target.fir
@@ -1,7 +1,7 @@
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix INT64
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes INT64
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefixes INT32
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=powerpc64le-unknown-linux-gn" %s | FileCheck %s --check-prefixes INT64
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix INT64
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes INT64
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefixes INT32
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=powerpc64le-unknown-linux-gn" %s | FileCheck %s --check-prefixes INT64
 
 //=============================================================================
 // SUMMARY: Tests for FIR --> LLVM MLIR conversion that *depend* on the target

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -1,7 +1,7 @@
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=i386-unknown-linux-gnu" %s | FileCheck %s
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=powerpc64le-unknown-linux-gn" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=i386-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=powerpc64le-unknown-linux-gn" %s | FileCheck %s
 
 //=============================================================================
 // SUMMARY: Tests for FIR --> LLVM MLIR conversion independent of the target

--- a/flang/test/Fir/coordinateof.fir
+++ b/flang/test/Fir/coordinateof.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s | tco | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | tco | FileCheck %s
 
 // tests on coordinate_of op
 

--- a/flang/test/Fir/declare-codegen.fir
+++ b/flang/test/Fir/declare-codegen.fir
@@ -1,5 +1,5 @@
 // Test rewrite of fir.declare. The result is replaced by the memref operand.
-// RUN: fir-opt --cg-rewrite %s -o - | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --cg-rewrite %s -o - | FileCheck %s
 
 
 func.func @test(%arg0: !fir.ref<!fir.array<12x23xi32>>) {

--- a/flang/test/Fir/declare.fir
+++ b/flang/test/Fir/declare.fir
@@ -1,6 +1,6 @@
 // Test fir.declare operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @numeric_declare(%arg0: !fir.ref<f32>) {
   %0 = fir.declare %arg0 {uniq_name = "x"} : (!fir.ref<f32>) -> !fir.ref<f32>

--- a/flang/test/Fir/external-mangling-emboxproc.fir
+++ b/flang/test/Fir/external-mangling-emboxproc.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --external-name-interop %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --external-name-interop %s | FileCheck %s
 
 func.func @_QPfoo() {  
   %e6 = fir.alloca tuple<i32,f64>

--- a/flang/test/Fir/external-mangling.fir
+++ b/flang/test/Fir/external-mangling.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --external-name-interop %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --external-name-interop %s | FileCheck %s
 // RUN: tco --external-name-interop %s | FileCheck %s
 // RUN: tco --external-name-interop %s | tco --fir-to-llvm-ir | FileCheck %s --check-prefix=LLVMIR
 

--- a/flang/test/Fir/field-index.fir
+++ b/flang/test/Fir/field-index.fir
@@ -1,5 +1,5 @@
 // Test fir.field_index llvm code generation
-// RUN: fir-opt %s | tco | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | tco | FileCheck %s
 
 
 // CHECK-DAG: %[[a:.*]] = type { float, i32 }

--- a/flang/test/Fir/fir-fast-math.fir
+++ b/flang/test/Fir/fir-fast-math.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt | FileCheck %s
 
 // CHECK-LABEL: @test_callop
 func.func @test_callop(%arg0 : f32) {

--- a/flang/test/Fir/fir-int-conversion.fir
+++ b/flang/test/Fir/fir-int-conversion.fir
@@ -1,6 +1,6 @@
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,DEFAULT %s
-// RUN: fir-opt --kind-mapping="i1:4,i2:8,i4:16,i8:32,i16:64" --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,ALL-CUSTOM %s
-// RUN: fir-opt --kind-mapping="i2:1,i4:8,i16:32" --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,SOME-CUSTOM %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,DEFAULT %s
+// RUN: fir-opt --no-implicit-module=false --kind-mapping="i1:4,i2:8,i4:16,i8:32,i16:64" --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,ALL-CUSTOM %s
+// RUN: fir-opt --no-implicit-module=false --kind-mapping="i2:1,i4:8,i16:32" --split-input-file --fir-to-llvm-ir %s | FileCheck --check-prefixes=COMMON,SOME-CUSTOM %s
 
 // Test `!fir.integer<KIND>` conversion with and without kind-mapping string
 

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -1,6 +1,6 @@
 // Test the FIR operations
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false | FileCheck %s
 
 // CHECK-LABEL: func private @it1() -> !fir.int<4>
 // CHECK: func private @box1() -> !fir.boxchar<2>

--- a/flang/test/Fir/fir-types.fir
+++ b/flang/test/Fir/fir-types.fir
@@ -1,6 +1,6 @@
 // Test the FIR types
 // Parse types and check that we can reparse what we print.
-// RUN: fir-opt --split-input-file %s | fir-opt --split-input-file | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file %s | fir-opt --no-implicit-module=false --split-input-file | FileCheck %s
 
 // Fortran Intrinsic types
 // CHECK-LABEL: func private @it1() -> !fir.int<4>

--- a/flang/test/Fir/global-initialization.fir
+++ b/flang/test/Fir/global-initialization.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --fir-to-llvm-ir %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --fir-to-llvm-ir %s | FileCheck %s
 // RUN: tco --fir-to-llvm-ir %s | FileCheck %s
 
 fir.global internal @_QEmask : !fir.array<32xi32> {

--- a/flang/test/Fir/loop01.fir
+++ b/flang/test/Fir/loop01.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --split-input-file --cfg-conversion %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --cfg-conversion %s | FileCheck %s
 
 func.func @x(%lb : index, %ub : index, %step : index, %b : i1, %addr : !fir.ref<index>) {
   fir.do_loop %iv = %lb to %ub step %step unordered {

--- a/flang/test/Fir/loop02.fir
+++ b/flang/test/Fir/loop02.fir
@@ -1,5 +1,5 @@
-// RUN: fir-opt --cfg-conversion="always-execute-loop-body=true" %s | FileCheck %s
-// RUN: fir-opt --cfg-conversion %s | FileCheck %s --check-prefix=NOOPT
+// RUN: fir-opt --no-implicit-module=false --cfg-conversion="always-execute-loop-body=true" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --cfg-conversion %s | FileCheck %s --check-prefix=NOOPT
 
 func.func @x(%addr : !fir.ref<index>) {
   %bound = arith.constant 452 : index

--- a/flang/test/Fir/memory-allocation-opt.fir
+++ b/flang/test/Fir/memory-allocation-opt.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --memory-allocation-opt="dynamic-array-on-heap=true maximum-array-alloc-size=1024" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --memory-allocation-opt="dynamic-array-on-heap=true maximum-array-alloc-size=1024" %s | FileCheck %s
 
 // Test for size of array being too big.
 

--- a/flang/test/Fir/rebox-susbtring.fir
+++ b/flang/test/Fir/rebox-susbtring.fir
@@ -1,6 +1,6 @@
 // Test translation to llvm IR of fir.rebox with substring array sections.
 
-// RUN: fir-opt -o - -cg-rewrite --fir-to-llvm-ir -cse %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false -o - -cg-rewrite --fir-to-llvm-ir -cse %s | FileCheck %s
 // RUN: tco -o - -cg-rewrite --fir-to-llvm-ir -cse %s | FileCheck %s
 
 // Test a fir.rebox with a substring on a character array with constant

--- a/flang/test/Fir/recursive-type.fir
+++ b/flang/test/Fir/recursive-type.fir
@@ -1,9 +1,9 @@
 // Test lowering FIR to LLVM IR for recursive types
   
-// RUN: fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
-// RUN: fir-opt --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
-// RUN: fir-opt --fir-to-llvm-ir="target=i386-unknown-linux-gnu" %s | FileCheck %s
-// RUN: fir-opt --fir-to-llvm-ir="target=powerpc64le-unknown-linux-gn" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=i386-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=powerpc64le-unknown-linux-gn" %s | FileCheck %s
 
 !t1 = !fir.type<t1 {a1:!fir.ptr<!fir.type<t1>>}>
 !t2 = !fir.type<t2 {b1:f32,b2:!fir.ptr<!fir.type<t2>>,b3:i32,b4:!fir.ptr<!fir.type<t2>>}>

--- a/flang/test/Fir/rename-msvc-libm.fir
+++ b/flang/test/Fir/rename-msvc-libm.fir
@@ -1,5 +1,5 @@
-// RUN: fir-opt --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s -DHYPOTF=hypotf
-// RUN: fir-opt --fir-to-llvm-ir="target=aarch64-pc-windows-msvc" %s | FileCheck %s -DHYPOTF=_hypotf
+// RUN: fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s -DHYPOTF=hypotf
+// RUN: fir-opt --no-implicit-module=false --fir-to-llvm-ir="target=aarch64-pc-windows-msvc" %s | FileCheck %s -DHYPOTF=_hypotf
 
 // Test hypotf renaming
 

--- a/flang/test/Fir/target-rewrite-arg-position.fir
+++ b/flang/test/Fir/target-rewrite-arg-position.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
 
 // Test with an argument shift.
 

--- a/flang/test/Fir/target-rewrite-boxchar.fir
+++ b/flang/test/Fir/target-rewrite-boxchar.fir
@@ -1,7 +1,7 @@
-// RUN: fir-opt --target-rewrite="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT32
-// RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT64
-// RUN: fir-opt --target-rewrite="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT64
-// RUN: fir-opt --target-rewrite="target=powerpc64le-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT64
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT32
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT64
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT64
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=powerpc64le-unknown-linux-gnu" %s | FileCheck %s --check-prefix=INT64
 
 // Test that we rewrite the signatures and bodies of functions that take boxchar
 // parameters.

--- a/flang/test/Fir/target-rewrite-char-proc.fir
+++ b/flang/test/Fir/target-rewrite-char-proc.fir
@@ -1,7 +1,7 @@
 // Test rewrite of character procedure pointer tuple argument to two different
 // arguments: one for the function address, and one for the length. The length
 // argument is added after other characters.
-// RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
 
 // CHECK:  func private @takes_char_proc(() -> () {fir.char_proc}, i64)
 func.func private @takes_char_proc(tuple<() -> (), i64> {fir.char_proc})

--- a/flang/test/Fir/target-rewrite-complex.fir
+++ b/flang/test/Fir/target-rewrite-complex.fir
@@ -1,11 +1,11 @@
-// RUN: fir-opt --target-rewrite="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefix=I32
-// RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=X64
-// RUN: fir-opt --target-rewrite="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=AARCH64
-// RUN: fir-opt --target-rewrite="target=powerpc64le-unknown-linux-gnu" %s | FileCheck %s --check-prefix=PPC64le
-// RUN: fir-opt --target-rewrite="target=sparc64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=SPARCV9
-// RUN: fir-opt --target-rewrite="target=sparcv9-sun-solaris2.11" %s | FileCheck %s --check-prefix=SPARCV9
-// RUN: fir-opt --target-rewrite="target=riscv64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=RISCV64
-// RUN: fir-opt --target-rewrite="target=powerpc64-ibm-aix7.2.0.0" %s | FileCheck %s --check-prefix=PPC64
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefix=I32
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=X64
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=AARCH64
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=powerpc64le-unknown-linux-gnu" %s | FileCheck %s --check-prefix=PPC64le
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=sparc64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=SPARCV9
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=sparcv9-sun-solaris2.11" %s | FileCheck %s --check-prefix=SPARCV9
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=riscv64-unknown-linux-gnu" %s | FileCheck %s --check-prefix=RISCV64
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=powerpc64-ibm-aix7.2.0.0" %s | FileCheck %s --check-prefix=PPC64
 
 // Test that we rewrite the signature and body of a function that returns a
 // complex<4>.

--- a/flang/test/Fir/target-rewrite-complex16.fir
+++ b/flang/test/Fir/target-rewrite-complex16.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
 
 // Test that we rewrite the signature and body of a func.function that returns a
 // complex<16>.

--- a/flang/test/Fir/target-rewrite-integer.fir
+++ b/flang/test/Fir/target-rewrite-integer.fir
@@ -1,9 +1,9 @@
-// RUN: fir-opt --split-input-file --target-rewrite="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=I32,ALL
-// RUN: fir-opt --split-input-file --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=X64,ALL
-// RUN: fir-opt --split-input-file --target-rewrite="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=AARCH64,ALL
-// RUN: fir-opt --split-input-file --target-rewrite="target=powerpc64le-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=PPC,ALL
-// RUN: fir-opt --split-input-file --target-rewrite="target=sparc64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=SPARCV9,ALL
-// RUN: fir-opt --split-input-file --target-rewrite="target=sparcv9-sun-solaris2.11" %s | FileCheck %s --check-prefixes=SPARCV9,ALL
+// RUN: fir-opt --no-implicit-module=false --split-input-file --target-rewrite="target=i386-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=I32,ALL
+// RUN: fir-opt --no-implicit-module=false --split-input-file --target-rewrite="target=x86_64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=X64,ALL
+// RUN: fir-opt --no-implicit-module=false --split-input-file --target-rewrite="target=aarch64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=AARCH64,ALL
+// RUN: fir-opt --no-implicit-module=false --split-input-file --target-rewrite="target=powerpc64le-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=PPC,ALL
+// RUN: fir-opt --no-implicit-module=false --split-input-file --target-rewrite="target=sparc64-unknown-linux-gnu" %s | FileCheck %s --check-prefixes=SPARCV9,ALL
+// RUN: fir-opt --no-implicit-module=false --split-input-file --target-rewrite="target=sparcv9-sun-solaris2.11" %s | FileCheck %s --check-prefixes=SPARCV9,ALL
 
 // -----
 

--- a/flang/test/Fir/tbaa.fir
+++ b/flang/test/Fir/tbaa.fir
@@ -1,5 +1,5 @@
-// RUN: fir-opt %s --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu apply-tbaa=true" | FileCheck %s
-// RUN: fir-opt %s --split-input-file --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu apply-tbaa=true" | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu apply-tbaa=true" | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu apply-tbaa=true" | FileCheck %s
 
 module {
   func.func @tbaa(%arg0: !fir.class<!fir.array<?xnone>> {fir.bindc_name = "a"}) {

--- a/flang/test/Fir/types-to-llvm.fir
+++ b/flang/test/Fir/types-to-llvm.fir
@@ -1,6 +1,6 @@
 // Test FIR types conversion.
 
-// RUN: fir-opt --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
 
 
 // Test sequence types `!fir.array`

--- a/flang/test/Fir/undo-complex-pattern.fir
+++ b/flang/test/Fir/undo-complex-pattern.fir
@@ -1,5 +1,5 @@
 // Test regrouping of + and - operations on complex components into complex operations
-// RUN: fir-opt --canonicalize %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --canonicalize %s | FileCheck %s
 
 
 // CHECK-LABEL: @add

--- a/flang/test/HLFIR/apply-codegen.fir
+++ b/flang/test/HLFIR/apply-codegen.fir
@@ -1,5 +1,5 @@
 // Test hlfir.apply code generation
-// RUN: fir-opt %s -bufferize-hlfir | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -bufferize-hlfir | FileCheck %s
 
 func.func @numeric_apply(%arg0 : !fir.ref<!fir.array<100xi32>>) {
   %expr = hlfir.as_expr %arg0 : (!fir.ref<!fir.array<100xi32>>) -> !hlfir.expr<100xi32>

--- a/flang/test/HLFIR/apply.fir
+++ b/flang/test/HLFIR/apply.fir
@@ -1,6 +1,6 @@
 // Test hlfir.apply operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @numeric(%expr: !hlfir.expr<?x?xf32>) {
   %c9 = arith.constant 9 : index

--- a/flang/test/HLFIR/as_expr-codegen.fir
+++ b/flang/test/HLFIR/as_expr-codegen.fir
@@ -1,6 +1,6 @@
 // Test hlfir.as_expr code generation
 
-// RUN: fir-opt %s -bufferize-hlfir | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -bufferize-hlfir | FileCheck %s
 
 func.func @char_expr(%addr: !fir.ref<!fir.char<1,?>>, %len: index) {
   %0:2 = hlfir.declare %addr typeparams %len {uniq_name = "c"} : (!fir.ref<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)

--- a/flang/test/HLFIR/as_expr.fir
+++ b/flang/test/HLFIR/as_expr.fir
@@ -1,6 +1,6 @@
 // Test hlfir.as_expr operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @char_expr(%arg0: !fir.boxchar<1>) {
   %0 = hlfir.as_expr %arg0 : (!fir.boxchar<1>) -> !hlfir.expr<!fir.char<1,?>>

--- a/flang/test/HLFIR/assign-codegen.fir
+++ b/flang/test/HLFIR/assign-codegen.fir
@@ -1,6 +1,6 @@
 // Test hlfir.assign code generation to FIR
 
-// RUN: fir-opt %s -convert-hlfir-to-fir | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -convert-hlfir-to-fir | FileCheck %s
 
 func.func @scalar_int(%arg0: !fir.ref<i32>, %arg1: !fir.ref<i32>) {
   hlfir.assign %arg0 to %arg1 : !fir.ref<i32>, !fir.ref<i32>

--- a/flang/test/HLFIR/assign.fir
+++ b/flang/test/HLFIR/assign.fir
@@ -1,6 +1,6 @@
 // Test hlfir.assign operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @scalar_logical(%arg0: !fir.ref<!fir.logical<1>>, %arg1: !fir.ref<!fir.logical<1>>) {
   hlfir.assign %arg1 to %arg0 : !fir.ref<!fir.logical<1>>, !fir.ref<!fir.logical<1>>

--- a/flang/test/HLFIR/associate-codegen.fir
+++ b/flang/test/HLFIR/associate-codegen.fir
@@ -1,6 +1,6 @@
 // Test hlfir.associate/hlfir.end_associate operation code generation to FIR.
 
-// RUN: fir-opt %s -bufferize-hlfir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false  %s -bufferize-hlfir | FileCheck %s
 
 func.func @associate_int() {
   %c42_i32 = arith.constant 42 : i32

--- a/flang/test/HLFIR/associate.fir
+++ b/flang/test/HLFIR/associate.fir
@@ -1,7 +1,7 @@
 // Test hlfir.associate and hlfir.end_associate operations parse, verify
 // (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false  %s | fir-opt --no-implicit-module=false  | FileCheck %s
 
 func.func @test_cst_char(%arg0: !hlfir.expr<!fir.char<1,12>>) {
   %c12 = arith.constant 12 : index

--- a/flang/test/HLFIR/concat-bufferization.fir
+++ b/flang/test/HLFIR/concat-bufferization.fir
@@ -1,6 +1,6 @@
 // Test hlfir.concat operation lowering to operations operating on memory.
 
-// RUN: fir-opt %s -bufferize-hlfir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s -bufferize-hlfir | FileCheck %s
 
 
 func.func @concat(%arg0: !fir.boxchar<1>, %arg1: !fir.boxchar<1>, %arg2: !fir.boxchar<1>) {

--- a/flang/test/HLFIR/concat.fir
+++ b/flang/test/HLFIR/concat.fir
@@ -1,6 +1,6 @@
 // Test hlfir.concat operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @concat_var(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: !fir.ref<!fir.char<1,20>>) {
   %c30 = arith.constant 30 : index

--- a/flang/test/HLFIR/copy-in-out-codegen.fir
+++ b/flang/test/HLFIR/copy-in-out-codegen.fir
@@ -1,6 +1,6 @@
 // Test hlfir.copy_in and hlfir.copy_out operation codegen
 
-// RUN: fir-opt %s -convert-hlfir-to-fir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s -convert-hlfir-to-fir | FileCheck %s
 
 func.func @test_copy_in(%box: !fir.box<!fir.array<?xf64>>) {
   %0:2 = hlfir.copy_in %box : (!fir.box<!fir.array<?xf64>>) -> (!fir.box<!fir.array<?xf64>>, i1)

--- a/flang/test/HLFIR/copy-in-out.fir
+++ b/flang/test/HLFIR/copy-in-out.fir
@@ -1,7 +1,7 @@
 // Test hlfir.copy_in and hlfir.copy_out operation parse, verify (no errors),
 // and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @test_copy_in(%box: !fir.box<!fir.array<?xf64>>, %is_present: i1) {
   %0:2 = hlfir.copy_in %box : (!fir.box<!fir.array<?xf64>>) -> (!fir.box<!fir.array<?xf64>>, i1)

--- a/flang/test/HLFIR/declare-codegen.fir
+++ b/flang/test/HLFIR/declare-codegen.fir
@@ -1,6 +1,6 @@
 // Test hlfir.declare operation code generation to FIR
 
-// RUN: fir-opt %s -convert-hlfir-to-fir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s -convert-hlfir-to-fir | FileCheck %s
 
 func.func @numeric_declare(%arg0: !fir.ref<f32>) {
   %0:2 = hlfir.declare %arg0 {uniq_name = "x"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)

--- a/flang/test/HLFIR/declare.fir
+++ b/flang/test/HLFIR/declare.fir
@@ -1,6 +1,6 @@
 // Test hlfir.declare operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false  | FileCheck %s
 
 func.func @numeric_declare(%arg0: !fir.ref<f32>) {
   %0:2 = hlfir.declare %arg0 {uniq_name = "x"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)

--- a/flang/test/HLFIR/designate-codegen-component-refs.fir
+++ b/flang/test/HLFIR/designate-codegen-component-refs.fir
@@ -1,6 +1,6 @@
 // Test code generation to FIR of hlfir.designate operations
 // with component reference.
-// RUN: fir-opt %s -convert-hlfir-to-fir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false  %s -convert-hlfir-to-fir | FileCheck %s
 
 func.func @test_scalar(%arg0: !fir.ref<!fir.type<t1{scalar_i:i32,scalar_x:f32}>>) {
   %0:2 = hlfir.declare %arg0 {uniq_name = "a"} : (!fir.ref<!fir.type<t1{scalar_i:i32,scalar_x:f32}>>) -> (!fir.ref<!fir.type<t1{scalar_i:i32,scalar_x:f32}>>, !fir.ref<!fir.type<t1{scalar_i:i32,scalar_x:f32}>>)

--- a/flang/test/HLFIR/designate-codegen.fir
+++ b/flang/test/HLFIR/designate-codegen.fir
@@ -1,6 +1,6 @@
 // Test code generation to FIR of hlfir.designate operations
 // without component reference.
-// RUN: fir-opt %s -convert-hlfir-to-fir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s -convert-hlfir-to-fir | FileCheck %s
 
 func.func @array_ref(%arg0: !fir.box<!fir.array<?xf32>>, %arg1: !fir.ref<i64>) {
   %0:2 = hlfir.declare %arg1 {uniq_name = "n"} : (!fir.ref<i64>) -> (!fir.ref<i64>, !fir.ref<i64>)

--- a/flang/test/HLFIR/designate.fir
+++ b/flang/test/HLFIR/designate.fir
@@ -1,6 +1,6 @@
 // Test hlfir.designate operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false  %s | fir-opt --no-implicit-module=false  | FileCheck %s
 
 // array(1)
 func.func @array_ref(%arg0 : !fir.ref<!fir.array<10xi32>>) {

--- a/flang/test/HLFIR/destroy-codegen.fir
+++ b/flang/test/HLFIR/destroy-codegen.fir
@@ -1,7 +1,7 @@
 // Test hlfir.destroy code generation and hlfir.yield_element "implicit
 // hlfir.destroy" aspect.
 
-// RUN: fir-opt %s -bufferize-hlfir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s -bufferize-hlfir | FileCheck %s
 
 func.func @test_move_with_cleanup(%arg0 : !fir.ref<!fir.array<100xi32>>) {
   %must_free = arith.constant true

--- a/flang/test/HLFIR/elemental-codegen.fir
+++ b/flang/test/HLFIR/elemental-codegen.fir
@@ -1,5 +1,5 @@
 // Test hlfir.elemental code generation
-// RUN: fir-opt %s --bufferize-hlfir | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false  %s --bufferize-hlfir | FileCheck %s
 
 func.func @numeric_type(%arg0: !fir.ref<!fir.array<10x20xi32>>, %arg1: !fir.ref<!fir.array<10x20xi32>>) {
   %c10 = arith.constant 10 : index

--- a/flang/test/HLFIR/elemental.fir
+++ b/flang/test/HLFIR/elemental.fir
@@ -1,7 +1,7 @@
 // Test hlfir.elemental and hlfir.yield_element operation parse, verify
 // (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false  | FileCheck %s
 
 func.func @numeric_type(%x: !fir.ref<!fir.array<10x20xi32>>, %y: !fir.ref<!fir.array<10x20xi32>>) {
   %c10 = arith.constant 10 : index

--- a/flang/test/HLFIR/expr-type.fir
+++ b/flang/test/HLFIR/expr-type.fir
@@ -1,6 +1,6 @@
 // Test the HLFIR Expr type
 // Parse types and check that we can reparse what we print.
-// RUN: fir-opt --split-input-file %s | fir-opt --split-input-file | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file %s | fir-opt --no-implicit-module=false --split-input-file | FileCheck %s
 
 // Scalar expression types
 func.func private @scalar01() -> !hlfir.expr<!fir.char<1,?>>

--- a/flang/test/HLFIR/no_reassoc-codegen.fir
+++ b/flang/test/HLFIR/no_reassoc-codegen.fir
@@ -1,6 +1,6 @@
 // Test hlfir.noreassoc code generation to FIR.
 
-// RUN: fir-opt %s -bufferize-hlfir -convert-hlfir-to-fir | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -bufferize-hlfir -convert-hlfir-to-fir | FileCheck %s
 
 func.func @no_reassoc_expr(%addr: !fir.ref<!fir.char<1,?>>, %len: index) {
   %0:2 = hlfir.declare %addr typeparams %len {uniq_name = "c"} : (!fir.ref<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)

--- a/flang/test/HLFIR/no_reassoc.fir
+++ b/flang/test/HLFIR/no_reassoc.fir
@@ -1,6 +1,6 @@
 // Test hlfir.no_reassoc operation parse, verify (no errors), and unparse.
 
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @no_reassoc_value(%arg0: i32) {
   %0 = hlfir.no_reassoc %arg0 : i32

--- a/flang/test/HLFIR/null-codegen.fir
+++ b/flang/test/HLFIR/null-codegen.fir
@@ -1,6 +1,6 @@
 // Test hlfir.null code generation to FIR
 
-// RUN: fir-opt %s -convert-hlfir-to-fir | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -convert-hlfir-to-fir | FileCheck %s
 
 func.func @test() {
   // CHECK: fir.zero_bits !fir.ref<none>

--- a/flang/test/HLFIR/set_length-codegen.fir
+++ b/flang/test/HLFIR/set_length-codegen.fir
@@ -1,5 +1,5 @@
 // Test hlfir.set_length operation lowering to operations operating on memory.
-// RUN: fir-opt %s -bufferize-hlfir | FileCheck %s
+// RUN: fir-opt %s --no-implicit-module=false -bufferize-hlfir | FileCheck %s
 
 func.func @test_cst_len(%str : !fir.boxchar<1>) {
   %c10 = arith.constant 10 : index

--- a/flang/test/HLFIR/set_length.fir
+++ b/flang/test/HLFIR/set_length.fir
@@ -1,5 +1,5 @@
 // Test hlfir.set_length operation parse, verify (no errors), and unparse.
-// RUN: fir-opt %s | fir-opt | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false %s | fir-opt --no-implicit-module=false | FileCheck %s
 
 func.func @test_cst_len(%str : !fir.boxchar<1>) {
   %c10 = arith.constant 10 : index

--- a/flang/test/Intrinsics/math-codegen.fir
+++ b/flang/test/Intrinsics/math-codegen.fir
@@ -2,7 +2,7 @@
 // TODO: verify that Fast-Math Flags and 'strictfp' are properly set.
 
 //--- abs_fast.fir
-// RUN: fir-opt %t/abs_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/abs_fast.fir
+// RUN: fir-opt --no-implicit-module=false %t/abs_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/abs_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.fabs({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -74,7 +74,7 @@ func.func private @hypotf(f32, f32) -> f32
 func.func private @hypot(f64, f64) -> f64
 
 //--- abs_relaxed.fir
-// RUN: fir-opt %t/abs_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/abs_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false %t/abs_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/abs_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.fabs({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -146,7 +146,7 @@ func.func private @hypotf(f32, f32) -> f32
 func.func private @hypot(f64, f64) -> f64
 
 //--- abs_precise.fir
-// RUN: fir-opt %t/abs_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/abs_precise.fir
+// RUN: fir-opt --no-implicit-module=false %t/abs_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/abs_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @fabsf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -221,7 +221,7 @@ func.func private @hypotf(f32, f32) -> f32
 func.func private @hypot(f64, f64) -> f64
 
 //--- aint_fast.fir
-// RUN: fir-opt %t/aint_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/aint_fast.fir
+// RUN: fir-opt --no-implicit-module=false %t/aint_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/aint_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.trunc.f32({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -248,7 +248,7 @@ func.func private @llvm.trunc.f32(f32) -> f32
 func.func private @llvm.trunc.f64(f64) -> f64
 
 //--- aint_relaxed.fir
-// RUN: fir-opt %t/aint_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/aint_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false %t/aint_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/aint_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.trunc.f32({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -275,7 +275,7 @@ func.func private @llvm.trunc.f32(f32) -> f32
 func.func private @llvm.trunc.f64(f64) -> f64
 
 //--- aint_precise.fir
-// RUN: fir-opt %t/aint_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/aint_precise.fir
+// RUN: fir-opt --no-implicit-module=false %t/aint_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/aint_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.trunc.f32({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -302,7 +302,7 @@ func.func private @llvm.trunc.f32(f32) -> f32
 func.func private @llvm.trunc.f64(f64) -> f64
 
 //--- anint_fast.fir
-// RUN: fir-opt %t/anint_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/anint_fast.fir
+// RUN: fir-opt --no-implicit-module=false %t/anint_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/anint_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.round({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -327,7 +327,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- anint_relaxed.fir
-// RUN: fir-opt %t/anint_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/anint_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false %t/anint_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/anint_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.round({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -352,7 +352,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- anint_precise.fir
-// RUN: fir-opt %t/anint_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/anint_precise.fir
+// RUN: fir-opt --no-implicit-module=false %t/anint_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/anint_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.round.f32({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -379,7 +379,7 @@ func.func private @llvm.round.f32(f32) -> f32
 func.func private @llvm.round.f64(f64) -> f64
 
 //--- atan_fast.fir
-// RUN: fir-opt %t/atan_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan_fast.fir
+// RUN: fir-opt --no-implicit-module=false %t/atan_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @atanf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -404,7 +404,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- atan_relaxed.fir
-// RUN: fir-opt %t/atan_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false %t/atan_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @atanf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -429,7 +429,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- atan_precise.fir
-// RUN: fir-opt %t/atan_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan_precise.fir
+// RUN: fir-opt --no-implicit-module=false %t/atan_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @atanf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -456,7 +456,7 @@ func.func private @atanf(f32) -> f32
 func.func private @atan(f64) -> f64
 
 //--- atan2_fast.fir
-// RUN: fir-opt %t/atan2_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan2_fast.fir
+// RUN: fir-opt --no-implicit-module=false %t/atan2_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan2_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @atan2f({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) : (f32, f32) -> f32
 
@@ -483,7 +483,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}, %arg1: !fi
 }
 
 //--- atan2_relaxed.fir
-// RUN: fir-opt %t/atan2_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan2_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/atan2_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan2_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @atan2f({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) : (f32, f32) -> f32
 
@@ -510,7 +510,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}, %arg1: !fi
 }
 
 //--- atan2_precise.fir
-// RUN: fir-opt %t/atan2_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan2_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/atan2_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/atan2_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @atan2f({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) : (f32, f32) -> f32
 
@@ -539,7 +539,7 @@ func.func private @atan2f(f32, f32) -> f32
 func.func private @atan2(f64, f64) -> f64
 
 //--- ceiling_fast.fir
-// RUN: fir-opt %t/ceiling_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/ceiling_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/ceiling_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/ceiling_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.ceil({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -568,7 +568,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- ceiling_relaxed.fir
-// RUN: fir-opt %t/ceiling_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/ceiling_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/ceiling_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/ceiling_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.ceil({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -597,7 +597,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- ceiling_precise.fir
-// RUN: fir-opt %t/ceiling_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/ceiling_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/ceiling_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/ceiling_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @ceilf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -628,7 +628,7 @@ func.func private @ceilf(f32) -> f32
 func.func private @ceil(f64) -> f64
 
 //--- cos_fast.fir
-// RUN: fir-opt %t/cos_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cos_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/cos_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cos_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.cos({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -653,7 +653,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- cos_relaxed.fir
-// RUN: fir-opt %t/cos_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cos_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/cos_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cos_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.cos({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -678,7 +678,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- cos_precise.fir
-// RUN: fir-opt %t/cos_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cos_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/cos_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cos_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @cosf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -705,7 +705,7 @@ func.func private @cosf(f32) -> f32
 func.func private @cos(f64) -> f64
 
 //--- cosh_fast.fir
-// RUN: fir-opt %t/cosh_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cosh_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/cosh_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cosh_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @coshf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -732,7 +732,7 @@ func.func private @coshf(f32) -> f32
 func.func private @cosh(f64) -> f64
 
 //--- cosh_relaxed.fir
-// RUN: fir-opt %t/cosh_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cosh_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/cosh_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cosh_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @coshf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -759,7 +759,7 @@ func.func private @coshf(f32) -> f32
 func.func private @cosh(f64) -> f64
 
 //--- cosh_precise.fir
-// RUN: fir-opt %t/cosh_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cosh_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/cosh_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/cosh_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @coshf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -786,7 +786,7 @@ func.func private @coshf(f32) -> f32
 func.func private @cosh(f64) -> f64
 
 //--- erf_fast.fir
-// RUN: fir-opt %t/erf_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/erf_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/erf_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/erf_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @erff({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -811,7 +811,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- erf_relaxed.fir
-// RUN: fir-opt %t/erf_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/erf_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/erf_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/erf_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @erff({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -836,7 +836,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- erf_precise.fir
-// RUN: fir-opt %t/erf_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/erf_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/erf_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/erf_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @erff({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -863,7 +863,7 @@ func.func private @erff(f32) -> f32
 func.func private @erf(f64) -> f64
 
 //--- exp_fast.fir
-// RUN: fir-opt %t/exp_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exp_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/exp_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exp_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.exp({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -888,7 +888,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- exp_relaxed.fir
-// RUN: fir-opt %t/exp_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exp_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/exp_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exp_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.exp({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -913,7 +913,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- exp_precise.fir
-// RUN: fir-opt %t/exp_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exp_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/exp_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exp_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @expf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -940,7 +940,7 @@ func.func private @expf(f32) -> f32
 func.func private @exp(f64) -> f64
 
 //--- floor_fast.fir
-// RUN: fir-opt %t/floor_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/floor_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/floor_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/floor_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.floor({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -969,7 +969,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- floor_relaxed.fir
-// RUN: fir-opt %t/floor_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/floor_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/floor_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/floor_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.floor({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -998,7 +998,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- floor_precise.fir
-// RUN: fir-opt %t/floor_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/floor_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/floor_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/floor_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @floorf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1029,7 +1029,7 @@ func.func private @floorf(f32) -> f32
 func.func private @floor(f64) -> f64
 
 //--- log_fast.fir
-// RUN: fir-opt %t/log_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/log_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.log({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1054,7 +1054,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- log_relaxed.fir
-// RUN: fir-opt %t/log_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/log_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.log({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1079,7 +1079,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- log_precise.fir
-// RUN: fir-opt %t/log_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/log_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @logf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1106,7 +1106,7 @@ func.func private @logf(f32) -> f32
 func.func private @log(f64) -> f64
 
 //--- log10_fast.fir
-// RUN: fir-opt %t/log10_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log10_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/log10_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log10_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.log10({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1131,7 +1131,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- log10_relaxed.fir
-// RUN: fir-opt %t/log10_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log10_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/log10_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log10_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.log10({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1156,7 +1156,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- log10_precise.fir
-// RUN: fir-opt %t/log10_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log10_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/log10_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/log10_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @log10f({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1183,7 +1183,7 @@ func.func private @log10f(f32) -> f32
 func.func private @log10(f64) -> f64
 
 //--- nint_fast.fir
-// RUN: fir-opt %t/nint_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/nint_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/nint_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/nint_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.lround.i32.f32({{%[A-Za-z0-9._]+}}) : (f32) -> i32
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.lround.i64.f32({{%[A-Za-z0-9._]+}}) : (f32) -> i64
@@ -1224,7 +1224,7 @@ func.func private @llvm.lround.i32.f64(f64) -> i32
 func.func private @llvm.lround.i64.f64(f64) -> i64
 
 //--- nint_relaxed.fir
-// RUN: fir-opt %t/nint_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/nint_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/nint_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/nint_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.lround.i32.f32({{%[A-Za-z0-9._]+}}) : (f32) -> i32
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.lround.i64.f32({{%[A-Za-z0-9._]+}}) : (f32) -> i64
@@ -1265,7 +1265,7 @@ func.func private @llvm.lround.i32.f64(f64) -> i32
 func.func private @llvm.lround.i64.f64(f64) -> i64
 
 //--- nint_precise.fir
-// RUN: fir-opt %t/nint_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/nint_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/nint_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/nint_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.lround.i32.f32({{%[A-Za-z0-9._]+}}) : (f32) -> i32
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.lround.i64.f32({{%[A-Za-z0-9._]+}}) : (f32) -> i64
@@ -1306,7 +1306,7 @@ func.func private @llvm.lround.i32.f64(f64) -> i32
 func.func private @llvm.lround.i64.f64(f64) -> i64
 
 //--- exponentiation_fast.fir
-// RUN: fir-opt %t/exponentiation_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/exponentiation_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: [[STOI:%[A-Za-z0-9._]+]] = llvm.sext {{%[A-Za-z0-9._]+}} : i16 to i32
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.powi.f32.i32({{%[A-Za-z0-9._]+}}, [[STOI]]) : (f32, i32) -> f32
@@ -1359,7 +1359,7 @@ func.func private @llvm.powi.f32.i32(f32, i32) -> f32
 func.func private @llvm.powi.f64.i32(f64, i32) -> f64
 
 //--- exponentiation_relaxed.fir
-// RUN: fir-opt %t/exponentiation_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/exponentiation_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: [[STOI:%[A-Za-z0-9._]+]] = llvm.sext {{%[A-Za-z0-9._]+}} : i16 to i32
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.powi.f32.i32({{%[A-Za-z0-9._]+}}, [[STOI]]) : (f32, i32) -> f32
@@ -1412,7 +1412,7 @@ func.func private @llvm.powi.f32.i32(f32, i32) -> f32
 func.func private @llvm.powi.f64.i32(f64, i32) -> f64
 
 //--- exponentiation_precise.fir
-// RUN: fir-opt %t/exponentiation_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/exponentiation_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: [[STOI:%[A-Za-z0-9._]+]] = llvm.sext {{%[A-Za-z0-9._]+}} : i16 to i32
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @llvm.powi.f32.i32({{%[A-Za-z0-9._]+}}, [[STOI]]) : (f32, i32) -> f32
@@ -1467,7 +1467,7 @@ func.func private @llvm.powi.f64.i32(f64, i32) -> f64
 func.func private @pow(f64, f64) -> f64
 
 //--- exponentiation_integer.fir
-// RUN: fir-opt %t/exponentiation_integer.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_integer.fir
+// RUN: fir-opt --no-implicit-module=false  %t/exponentiation_integer.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/exponentiation_integer.fir
 // CHECK: @_QPtest_int4
 // CHECK: llvm.call @__mlir_math_ipowi_i32({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) : (i32, i32) -> i32
 
@@ -1480,7 +1480,7 @@ func.func @_QPtest_int4(%arg0: !fir.ref<i32> {fir.bindc_name = "x"}, %arg1: !fir
 }
 
 //--- sign_fast.fir
-// RUN: fir-opt %t/sign_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sign_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sign_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sign_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.copysign({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) : (f32, f32) -> f32
 
@@ -1531,7 +1531,7 @@ func.func @_QPtest_real16(%arg0: !fir.ref<f128> {fir.bindc_name = "x"}, %arg1: !
 }
 
 //--- sign_relaxed.fir
-// RUN: fir-opt %t/sign_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sign_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sign_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sign_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.copysign({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) : (f32, f32) -> f32
 
@@ -1582,7 +1582,7 @@ func.func @_QPtest_real16(%arg0: !fir.ref<f128> {fir.bindc_name = "x"}, %arg1: !
 }
 
 //--- sign_precise.fir
-// RUN: fir-opt %t/sign_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sign_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sign_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sign_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @copysignf({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) : (f32, f32) -> f32
 
@@ -1637,7 +1637,7 @@ func.func private @copysignl(f80, f80) -> f80
 func.func private @llvm.copysign.f128(f128, f128) -> f128
 
 //--- sin_fast.fir
-// RUN: fir-opt %t/sin_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sin_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sin_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sin_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.sin({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1662,7 +1662,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- sin_relaxed.fir
-// RUN: fir-opt %t/sin_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sin_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sin_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sin_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.intr.sin({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1687,7 +1687,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- sin_precise.fir
-// RUN: fir-opt %t/sin_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sin_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sin_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sin_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @sinf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1714,7 +1714,7 @@ func.func private @sinf(f32) -> f32
 func.func private @sin(f64) -> f64
 
 //--- sinh_fast.fir
-// RUN: fir-opt %t/sinh_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sinh_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sinh_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sinh_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @sinhf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1741,7 +1741,7 @@ func.func private @sinhf(f32) -> f32
 func.func private @sinh(f64) -> f64
 
 //--- sinh_relaxed.fir
-// RUN: fir-opt %t/sinh_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sinh_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sinh_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sinh_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @sinhf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1768,7 +1768,7 @@ func.func private @sinhf(f32) -> f32
 func.func private @sinh(f64) -> f64
 
 //--- sinh_precise.fir
-// RUN: fir-opt %t/sinh_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sinh_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/sinh_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/sinh_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @sinhf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1795,7 +1795,7 @@ func.func private @sinhf(f32) -> f32
 func.func private @sinh(f64) -> f64
 
 //--- tanh_fast.fir
-// RUN: fir-opt %t/tanh_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tanh_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/tanh_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tanh_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @tanhf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1820,7 +1820,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- tanh_relaxed.fir
-// RUN: fir-opt %t/tanh_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tanh_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/tanh_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tanh_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @tanhf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1845,7 +1845,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- tanh_precise.fir
-// RUN: fir-opt %t/tanh_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tanh_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/tanh_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tanh_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @tanhf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1872,7 +1872,7 @@ func.func private @tanhf(f32) -> f32
 func.func private @tanh(f64) -> f64
 
 //--- tan_fast.fir
-// RUN: fir-opt %t/tan_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tan_fast.fir
+// RUN: fir-opt --no-implicit-module=false  %t/tan_fast.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tan_fast.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @tanf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1897,7 +1897,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- tan_relaxed.fir
-// RUN: fir-opt %t/tan_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tan_relaxed.fir
+// RUN: fir-opt --no-implicit-module=false  %t/tan_relaxed.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tan_relaxed.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @tanf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 
@@ -1922,7 +1922,7 @@ func.func @_QPtest_real8(%arg0: !fir.ref<f64> {fir.bindc_name = "x"}) -> f64 {
 }
 
 //--- tan_precise.fir
-// RUN: fir-opt %t/tan_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tan_precise.fir
+// RUN: fir-opt --no-implicit-module=false  %t/tan_precise.fir --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" | FileCheck %t/tan_precise.fir
 // CHECK: @_QPtest_real4
 // CHECK: {{%[A-Za-z0-9._]+}} = llvm.call @tanf({{%[A-Za-z0-9._]+}}) : (f32) -> f32
 

--- a/flang/test/Lower/HLFIR/substrings.f90
+++ b/flang/test/Lower/HLFIR/substrings.f90
@@ -1,7 +1,7 @@
 ! Test lowering of substrings to HLFIR
 ! Note: cse is run to make the expected output more readable by sharing
 ! the boilerplate between the different susbtring cases.
-! RUN: bbc -emit-fir -hlfir -o - %s | fir-opt -cse -o - | FileCheck %s
+! RUN: bbc -emit-fir -hlfir -o - %s | fir-opt --no-implicit-module=false -cse -o - | FileCheck %s
 
 ! CHECK-LABEL:   func.func @_QPcst_len(
 subroutine cst_len(array, scalar)

--- a/flang/test/Lower/Intrinsics/achar.f90
+++ b/flang/test/Lower/Intrinsics/achar.f90
@@ -1,5 +1,5 @@
-! RUN: bbc -emit-fir %s -o - | fir-opt --canonicalize | FileCheck %s
-! RUN: %flang_fc1 -emit-fir %s -o - | fir-opt --canonicalize | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | fir-opt --no-implicit-module=false --canonicalize | FileCheck %s
+! RUN: %flang_fc1 -emit-fir %s -o - | fir-opt --no-implicit-module=false --canonicalize | FileCheck %s
 
 ! CHECK-LABEL: test1
 ! CHECK-SAME: (%[[XREF:.*]]: !fir.ref<i32> {{.*}}, %[[CBOX:.*]]: !fir.boxchar<1> {{.*}})

--- a/flang/test/Lower/array-character.f90
+++ b/flang/test/Lower/array-character.f90
@@ -1,4 +1,4 @@
-! RUN: bbc %s -o - | fir-opt --canonicalize --cse | FileCheck %s
+! RUN: bbc %s -o - | fir-opt --no-implicit-module=false --canonicalize --cse | FileCheck %s
 
 ! CHECK-LABEL: func @_QPissue(
 ! CHECK-SAME:    %[[VAL_0:.*]]: !fir.boxchar<1>{{.*}}, %[[VAL_1:.*]]: !fir.boxchar<1>{{.*}}) {

--- a/flang/test/Lower/select-type.f90
+++ b/flang/test/Lower/select-type.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -polymorphic-type -emit-fir %s -o - | FileCheck %s
-! RUN: bbc -polymorphic-type -emit-fir %s -o - | fir-opt --cfg-conversion | FileCheck --check-prefix=CFG %s
+! RUN: bbc -polymorphic-type -emit-fir %s -o - | fir-opt --no-implicit-module=false --cfg-conversion | FileCheck --check-prefix=CFG %s
 module select_type_lower_test
   type p1
     integer :: a

--- a/flang/test/Transforms/simplifyintrinsics.fir
+++ b/flang/test/Transforms/simplifyintrinsics.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --split-input-file --simplify-intrinsics %s | FileCheck %s
+// RUN: fir-opt --no-implicit-module=false --split-input-file --simplify-intrinsics %s | FileCheck %s
 
 // Call to SUM with 1D I32 array is replaced.
 module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.target_triple = "native"} {

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -38,7 +38,6 @@
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/unparse-with-symbols.h"
 #include "flang/Version.inc"
-#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -16,7 +16,6 @@
 
 #include "flang/Common/Fortran-features.h"
 #include "flang/Common/default-kinds.h"
-#include "flang/Common/module-wrapper.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/Support/Verifier.h"
@@ -43,6 +42,7 @@
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -150,7 +150,7 @@ static llvm::cl::opt<bool> useHLFIR("hlfir",
 using ProgramName = std::string;
 
 // Print the module without the "module { ... }" wrapper.
-static void printModule(fortran::common::ModuleInterface mlirModule,
+static void printModule(mlir::ModuleInterface mlirModule,
                         llvm::raw_ostream &out) {
   for (auto &op : *mlirModule.getBody())
     out << op << '\n';

--- a/flang/tools/fir-opt/fir-opt.cpp
+++ b/flang/tools/fir-opt/fir-opt.cpp
@@ -34,6 +34,7 @@ int main(int argc, char **argv) {
 #endif
   DialectRegistry registry;
   fir::support::registerDialects(registry);
-  return failed(MlirOptMain(argc, argv, "FIR modular optimizer driver\n",
-      registry, /*preloadDialectsInContext=*/false));
+  return failed(
+      MlirOptMain(argc, argv, "FIR modular optimizer driver\n", registry,
+          /*preloadDialectsInContext=*/false, /*noImplicitModule*/ true));
 }

--- a/flang/tools/tco/tco.cpp
+++ b/flang/tools/tco/tco.cpp
@@ -23,6 +23,8 @@
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/ToolUtilities.h"
+#include "mlir/Tools/ParseUtilities.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Passes/OptimizationLevel.h"
 #include "llvm/Support/CommandLine.h"
@@ -60,7 +62,8 @@ static cl::opt<bool> codeGenLLVM(
 
 #include "flang/Tools/CLOptions.inc"
 
-static void printModuleBody(mlir::ModuleOp mod, raw_ostream &output) {
+template <typename ModType>
+static void printModuleBody(ModType mod, raw_ostream &output) {
   for (auto &op : *mod.getBody())
     output << op << '\n';
 }
@@ -78,69 +81,89 @@ compileFIR(const mlir::PassPipelineCLParser &passPipeline) {
   }
 
   // load the file into a module
-  SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
+  auto sourceMgr = std::make_shared<SourceMgr>();
+  sourceMgr->AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
   mlir::DialectRegistry registry;
   fir::support::registerDialects(registry);
   mlir::MLIRContext context(registry);
   fir::support::loadDialects(context);
   fir::support::registerLLVMTranslation(context);
-  auto owningRef = mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, &context);
 
-  if (!owningRef) {
+  auto owningRef = mlir::parseSourceFileForTool(sourceMgr, &context,
+                                                false /*implicitModule*/);
+
+  auto handleCompilation = [](auto mod, auto context, auto passPipeline) {
+    if (mlir::failed(mod.verifyInvariants())) {
+      errs() << "Error verifying FIR module\n";
+      return mlir::failure();
+    }
+
+    std::error_code ec;
+    ToolOutputFile out(outputFilename, ec, sys::fs::OF_None);
+
+    // run passes
+    fir::KindMapping kindMap{context};
+    fir::setTargetTriple(mod, targetTriple);
+    fir::setKindMapping(mod, kindMap);
+    mlir::PassManager pm(mod->getName(),
+                         mlir::OpPassManager::Nesting::Implicit);
+    pm.enableVerifier(/*verifyPasses=*/true);
+    mlir::applyPassManagerCLOptions(pm);
+    if (emitFir) {
+      // parse the input and pretty-print it back out
+      // -emit-fir intentionally disables all the passes
+    } else if (passPipeline->hasAnyOccurrences()) {
+      auto errorHandler = [&](const Twine &msg) {
+        mlir::emitError(mlir::UnknownLoc::get(pm.getContext())) << msg;
+        return mlir::failure();
+      };
+      if (mlir::failed(passPipeline->addToPipeline(pm, errorHandler)))
+        return mlir::failure();
+    } else {
+      if (codeGenLLVM) {
+        // Run only CodeGen passes.
+        fir::createDefaultFIRCodeGenPassPipeline(pm);
+      } else {
+        // Run tco with O2 by default.
+        fir::createMLIRToLLVMPassPipeline(pm, llvm::OptimizationLevel::O2);
+      }
+      fir::addLLVMDialectToLLVMPass(pm, out.os());
+    }
+
+    // run the pass manager
+    if (mlir::succeeded(pm.run(mod))) {
+      // passes ran successfully, so keep the output
+      if ((emitFir || passPipeline->hasAnyOccurrences()) && !codeGenLLVM)
+        printModuleBody(mod, out.os());
+      out.keep();
+      return mlir::success();
+    }
+
+    // pass manager failed
+    printModuleBody(mod, errs());
+    errs() << "\n\nFAILED: " << inputFilename << '\n';
+    return mlir::failure();
+  };
+
+  if (owningRef) {
+    if (mlir::omp::ModuleOp mod = dyn_cast<mlir::omp::ModuleOp>(*owningRef))
+      return handleCompilation(mod, &context, &passPipeline);
+
+    if (mlir::ModuleOp mod = dyn_cast<mlir::ModuleOp>(*owningRef))
+      return handleCompilation(mod, &context, &passPipeline);
+  }
+
+  //  The prior default behaviour, if no module, we wrap it implicitly
+  //  in a builtin.module
+  auto wrapModule =
+      mlir::parseSourceFile<mlir::ModuleOp>(*sourceMgr.get(), &context);
+
+  if (!wrapModule) {
     errs() << "Error can't load file " << inputFilename << '\n';
     return mlir::failure();
   }
-  if (mlir::failed(owningRef->verifyInvariants())) {
-    errs() << "Error verifying FIR module\n";
-    return mlir::failure();
-  }
 
-  std::error_code ec;
-  ToolOutputFile out(outputFilename, ec, sys::fs::OF_None);
-
-  // run passes
-  fir::KindMapping kindMap{&context};
-  fir::setTargetTriple(*owningRef, targetTriple);
-  fir::setKindMapping(*owningRef, kindMap);
-  mlir::PassManager pm((*owningRef)->getName(),
-                       mlir::OpPassManager::Nesting::Implicit);
-  pm.enableVerifier(/*verifyPasses=*/true);
-  mlir::applyPassManagerCLOptions(pm);
-  if (emitFir) {
-    // parse the input and pretty-print it back out
-    // -emit-fir intentionally disables all the passes
-  } else if (passPipeline.hasAnyOccurrences()) {
-    auto errorHandler = [&](const Twine &msg) {
-      mlir::emitError(mlir::UnknownLoc::get(pm.getContext())) << msg;
-      return mlir::failure();
-    };
-    if (mlir::failed(passPipeline.addToPipeline(pm, errorHandler)))
-      return mlir::failure();
-  } else {
-    if (codeGenLLVM) {
-      // Run only CodeGen passes.
-      fir::createDefaultFIRCodeGenPassPipeline(pm);
-    } else {
-      // Run tco with O2 by default.
-      fir::createMLIRToLLVMPassPipeline(pm, llvm::OptimizationLevel::O2);
-    }
-    fir::addLLVMDialectToLLVMPass(pm, out.os());
-  }
-
-  // run the pass manager
-  if (mlir::succeeded(pm.run(*owningRef))) {
-    // passes ran successfully, so keep the output
-    if ((emitFir || passPipeline.hasAnyOccurrences()) && !codeGenLLVM)
-      printModuleBody(*owningRef, out.os());
-    out.keep();
-    return mlir::success();
-  }
-
-  // pass manager failed
-  printModuleBody(*owningRef, errs());
-  errs() << "\n\nFAILED: " << inputFilename << '\n';
-  return mlir::failure();
+  return handleCompilation(*wrapModule, &context, &passPipeline);
 }
 
 int main(int argc, char **argv) {

--- a/mlir/include/mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h
+++ b/mlir/include/mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h
@@ -13,7 +13,7 @@
 namespace mlir {
 namespace omp {
 class ModuleOp;
-}
+} // namespace omp
 class LLVMTypeConverter;
 class ConversionTarget;
 class MLIRContext;

--- a/mlir/include/mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h
+++ b/mlir/include/mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h
@@ -11,6 +11,9 @@
 #include <memory>
 
 namespace mlir {
+namespace omp {
+class ModuleOp;
+}
 class LLVMTypeConverter;
 class ConversionTarget;
 class MLIRContext;
@@ -32,7 +35,7 @@ void populateOpenMPToLLVMConversionPatterns(LLVMTypeConverter &converter,
                                             RewritePatternSet &patterns);
 
 /// Create a pass to convert OpenMP operations to the LLVMIR dialect.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertOpenMPToLLVMPass();
+std::unique_ptr<OperationPass<omp::ModuleOp>> createConvertOpenMPToLLVMPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -538,7 +538,7 @@ def ConvertMathToSPIRV : Pass<"convert-math-to-spirv"> {
 // MathToFuncs
 //===----------------------------------------------------------------------===//
 
-def ConvertMathToFuncs : Pass<"convert-math-to-funcs", "ModuleOp"> {
+def ConvertMathToFuncs : Pass<"convert-math-to-funcs"> {
   let summary = "Convert Math operations to calls of outlined implementations.";
   let description = [{
     This pass converts supported Math ops to calls of compiler generated
@@ -651,7 +651,7 @@ def ConvertOpenACCToLLVM : Pass<"convert-openacc-to-llvm", "ModuleOp"> {
 // OpenMPToLLVM
 //===----------------------------------------------------------------------===//
 
-def ConvertOpenMPToLLVM : Pass<"convert-openmp-to-llvm", "ModuleOp"> {
+def ConvertOpenMPToLLVM : Pass<"convert-openmp-to-llvm", "omp::ModuleOp"> {
   let summary = "Convert the OpenMP ops to OpenMP ops with LLVM dialect";
   let constructor = "mlir::createConvertOpenMPToLLVMPass()";
   let dependentDialects = ["LLVM::LLVMDialect"];

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -18,6 +18,8 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 include "mlir/Dialect/OpenMP/OpenMPOpsInterfaces.td"
@@ -42,6 +44,70 @@ def IntLikeType : AnyTypeOf<[AnyInteger, Index]>;
 
 def OpenMP_PointerLikeType : TypeAlias<OpenMP_PointerLikeTypeInterface,
 	"OpenMP-compatible variable type">;
+
+// Add arguments for device / host flag to carry down, alongside other device 
+// dependent flags
+def OpenMP_ModuleOp : OpenMP_Op<"module", [
+    AffineScope, IsolatedFromAbove, NoRegionArguments, SymbolTable, Symbol,
+    OpAsmOpInterface
+  ] # GraphRegionNoTerminator.traits> {
+  let summary = "A top-level operation that defines an OpenMP module";
+  let description = [{
+    An OpenMP `module` represents a top-level container operation. It is
+    similar to an MLIR builtin `module` with additional extensions for 
+    information utilised within OpenMP code generation. For example, the 
+    compilation mode  during offloading for the current module i.e. device 
+    or host. 
+
+    Example:
+
+    ```omp.module {
+      func.func @foo()
+    }
+    ```
+  }];
+
+  let arguments = (ins OptionalAttr<SymbolNameAttr>:$sym_name,
+                       OptionalAttr<StrAttr>:$sym_visibility,
+                       DefaultValuedAttr<BoolAttr, "0">:$is_device);
+  let regions = (region SizedRegion<1>:$bodyRegion);
+
+  let assemblyFormat = "($sym_name^)? `(` `device_module` `:` $is_device `)` attr-dict-with-keyword $bodyRegion";
+  let builders = [OpBuilder<(ins CArg<"std::optional<StringRef>", "{}">:$name)>];
+  let extraClassDeclaration = [{
+    /// Construct a module from the given location with an optional name.
+    static ModuleOp create(Location loc, std::optional<StringRef> name = std::nullopt);
+
+    /// Return the name of this module if present.
+    std::optional<StringRef> getName() { return getSymName(); }
+
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// A ModuleOp may optionally define a symbol.
+    bool isOptionalSymbol() { return true; }
+
+    //===------------------------------------------------------------------===//
+    // DataLayoutOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    DataLayoutSpecInterface getDataLayoutSpec();
+
+    //===------------------------------------------------------------------===//
+    // OpAsmOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    static ::llvm::StringRef getDefaultDialect() {
+      return "omp";
+    }
+  }];
+  let hasVerifier = 1;
+
+  // We need to ensure the block inside the region is properly terminated;
+  // the auto-generated builders do not guarantee that.
+  let skipDefaultBuilders = 1;
+}
 
 //===----------------------------------------------------------------------===//
 // 2.6 parallel Construct

--- a/mlir/include/mlir/Interfaces/ModuleInterface.h
+++ b/mlir/include/mlir/Interfaces/ModuleInterface.h
@@ -209,7 +209,15 @@ public:
 
   template <typename T>
   static bool classof(T op) {
-    return true;
+    if constexpr (std::is_same<T, omp::ModuleOp>())
+      return true;
+
+    if constexpr (std::is_same<T, ModuleOp>())
+      return true;
+
+    if constexpr (std::is_same<T, Operation *>())
+      return true;
+    return false;
   }
 
   ::mlir::LogicalResult verifyInvariants() {

--- a/mlir/include/mlir/Interfaces/ModuleInterface.h
+++ b/mlir/include/mlir/Interfaces/ModuleInterface.h
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef FORTRAN_MODULE_WRAPPER_H_
-#define FORTRAN_MODULE_WRAPPER_H_
+#ifndef MLIR_INTERFACES_MODULEINTERFACE_H_
+#define MLIR_INTERFACES_MODULEINTERFACE_H_
 
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 
-namespace fortran::common {
+namespace mlir {
 
 // An interface class that contains a single module (which can be more than one
 // type) and gives access to a subset of the shared features amongst all
@@ -21,7 +21,7 @@ class ModuleInterface {
 public:
   enum class ModuleType { Builtin, OpenMP, NoModule };
 
-  ModuleInterface() : modType(ModuleType::NoModule) {}
+  ModuleInterface() = default;
 
   ModuleInterface(mlir::omp::ModuleOp mod)
       : module(mod), modType(ModuleType::OpenMP) {}
@@ -35,6 +35,16 @@ public:
   ModuleInterface(mlir::ModuleOp *mod)
       : module(*mod), modType(ModuleType::Builtin) {}
 
+  ModuleInterface(mlir::Operation *mod) : module(mod) {
+    if (mlir::isa_and_nonnull<mlir::omp::ModuleOp>(module)) {
+      modType = ModuleType::OpenMP;
+    } else if (mlir::isa_and_nonnull<mlir::ModuleOp>(module)) {
+      modType = ModuleType::Builtin;
+    } else {
+      modType = ModuleType::NoModule;
+    }
+  }
+
   mlir::omp::ModuleOp getAsOMPModule() {
     return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module);
   }
@@ -42,6 +52,9 @@ public:
   mlir::ModuleOp getAsBuiltinModule() {
     return mlir::dyn_cast_or_null<mlir::ModuleOp>(module);
   }
+
+  bool isOMPModule() { return (modType == ModuleType::OpenMP); }
+  bool isBuiltinModule() { return (modType == ModuleType::Builtin); }
 
   mlir::Operation *getAsOperation() { return module; }
   ModuleType getModuleType() { return modType; }
@@ -53,7 +66,60 @@ public:
     return false;
   }
 
-  template <typename T, typename U> auto lookupSymbol(U name) {
+  // NOTE: This is a bit of an issue as it's used before we know what the module
+  // type is that we're handling, however, the module interface is intended to
+  // give the base feature set of builtin.module and nothing more, any extra
+  // manipulation for specialised types requres appropriate use of getModuleType
+  // and getAs*Module
+  static ::llvm::StringLiteral getOperationName() { return "builtin.module"; }
+
+  ::mlir::Location getLoc() {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).getLoc();
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getLoc();
+      break;
+    default:
+      assert(false && "lookupSymbol unsupported for current module type");
+      break;
+    }
+  }
+
+  template <typename FnT>
+  auto walk(FnT callback) {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module)->walk(callback);
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module)->walk(
+          callback);
+      break;
+    default:
+      assert(false && "lookupSymbol unsupported for current module type");
+      break;
+    }
+  }
+
+  template <typename T>
+  auto getOps() {
+    switch (modType) {
+    case ModuleType::Builtin:
+      return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).getOps<T>();
+      break;
+    case ModuleType::OpenMP:
+      return mlir::dyn_cast_or_null<mlir::omp::ModuleOp>(module).getOps<T>();
+      break;
+    default:
+      assert(false && "lookupSymbol unsupported for current module type");
+      break;
+    }
+  }
+
+  template <typename T, typename U>
+  auto lookupSymbol(U name) {
     switch (modType) {
     case ModuleType::Builtin:
       return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).lookupSymbol<T>(
@@ -83,7 +149,8 @@ public:
     }
   }
 
-  template <typename PrinterT> void print(PrinterT &printer) {
+  template <typename PrinterT>
+  void print(PrinterT &printer) {
     switch (modType) {
     case ModuleType::Builtin:
       return mlir::dyn_cast_or_null<mlir::ModuleOp>(module).print(printer);
@@ -140,6 +207,11 @@ public:
     }
   }
 
+  template <typename T>
+  static bool classof(T op) {
+    return true;
+  }
+
   ::mlir::LogicalResult verifyInvariants() {
     switch (modType) {
     case ModuleType::Builtin:
@@ -159,8 +231,8 @@ public:
   operator mlir::Operation *() { return module; }
 
 private:
-  mlir::Operation *module;
-  ModuleType modType;
+  mlir::Operation *module = nullptr;
+  ModuleType modType = ModuleType::NoModule;
 };
-} // namespace fortran::common
-#endif // FORTRAN_MODULE_WRAPPER_H_
+} // namespace mlir
+#endif // MLIR_INTERFACES_MODULEINTERFACE_H_

--- a/mlir/include/mlir/Target/LLVMIR/LLVMTranslationInterface.h
+++ b/mlir/include/mlir/Target/LLVMIR/LLVMTranslationInterface.h
@@ -45,6 +45,14 @@ public:
     return failure();
   }
 
+  /// Hook for derived dialect interface to provide translation of module
+  /// type operations to LLVM IR where special handling is neccessary.
+  virtual LogicalResult
+  convertModuleOperation(Operation *op, llvm::IRBuilderBase &builder,
+                         LLVM::ModuleTranslation &moduleTranslation) const {
+    return success();
+  }
+
   /// Hook for derived dialect interface to act on an operation that has dialect
   /// attributes from the derived dialect (the operation itself may be from a
   /// different dialect). This gets called after the operation has been
@@ -73,6 +81,17 @@ public:
     if (const LLVMTranslationDialectInterface *iface = getInterfaceFor(op))
       return iface->convertOperation(op, builder, moduleTranslation);
     return failure();
+  }
+
+  /// Translates the given module operation to LLVM IR using the interface
+  /// implemented by the op's dialect. This is invoked after all operations
+  /// within the module have been processed.
+  virtual LogicalResult
+  convertModuleOperation(Operation *op, llvm::IRBuilderBase &builder,
+                         LLVM::ModuleTranslation &moduleTranslation) const {
+    if (const LLVMTranslationDialectInterface *iface = getInterfaceFor(op))
+      return iface->convertModuleOperation(op, builder, moduleTranslation);
+    return success();
   }
 
   /// Acts on the given operation using the interface implemented by the dialect

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -287,6 +287,13 @@ private:
   LogicalResult convertGlobals();
   LogicalResult convertOneFunction(LLVMFuncOp func);
 
+  /// Converts a module operation after all other operations have been handled.
+  /// This is a No-Op for dialects that have no specified interface for module
+  /// operations. This function is invoked after all operations in the module
+  /// have been processed.
+  LogicalResult convertModuleOperation(Operation &op,
+                                       llvm::IRBuilderBase &builder);
+
   /// Process access_group LLVM Metadata operations and create LLVM
   /// metadata nodes.
   LogicalResult createAccessGroupMetadata();

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -81,7 +81,8 @@ LogicalResult MlirOptMain(
 ///   deprecated and will be removed soon.
 LogicalResult MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
                           DialectRegistry &registry,
-                          bool preloadDialectsInContext = false);
+                          bool preloadDialectsInContext = false,
+                          bool noImplicitModule = false);
 
 /// Helper wrapper to return the result of MlirOptMain directly from main.
 ///

--- a/mlir/lib/Conversion/MathToFuncs/CMakeLists.txt
+++ b/mlir/lib/Conversion/MathToFuncs/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_conversion_library(MLIRMathToFuncs
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRLLVMDialect
+  MLIROpenMPDialect
   MLIRMathDialect
   MLIRPass
   MLIRTransforms

--- a/mlir/lib/Conversion/MathToFuncs/MathToFuncs.cpp
+++ b/mlir/lib/Conversion/MathToFuncs/MathToFuncs.cpp
@@ -588,11 +588,6 @@ struct ConvertMathToFuncsPass
   ConvertMathToFuncsPass(const ConvertMathToFuncsOptions &options)
       : impl::ConvertMathToFuncsBase<ConvertMathToFuncsPass>(options) {}
 
-  bool canScheduleOn(mlir::RegisteredOperationName opInfo) const override {
-    return opInfo.getStringRef() == "builtin.module" ||
-           opInfo.getStringRef() == "omp.module";
-  }
-
   void runOnOperation() override;
 
 private:

--- a/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
+++ b/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/Interfaces/ModuleInterface.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
+++ b/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
@@ -171,13 +171,14 @@ void ConvertOpenMPToLLVMPass::runOnOperation() {
   populateOpenMPToLLVMConversionPatterns(converter, patterns);
 
   LLVMConversionTarget target(getContext());
-  target.addLegalOp<omp::TerminatorOp, omp::TaskyieldOp, omp::FlushOp,
-                    omp::BarrierOp, omp::TaskwaitOp>();
+  target.addLegalOp<omp::ModuleOp, omp::TerminatorOp, omp::TaskyieldOp,
+                    omp::FlushOp, omp::BarrierOp, omp::TaskwaitOp>();
   configureOpenMPToLLVMConversionLegality(target, converter);
   if (failed(applyPartialConversion(module, target, std::move(patterns))))
     signalPassFailure();
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> mlir::createConvertOpenMPToLLVMPass() {
+std::unique_ptr<OperationPass<omp::ModuleOp>>
+mlir::createConvertOpenMPToLLVMPass() {
   return std::make_unique<ConvertOpenMPToLLVMPass>();
 }

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -1352,9 +1352,51 @@ public:
   LogicalResult
   convertOperation(Operation *op, llvm::IRBuilderBase &builder,
                    LLVM::ModuleTranslation &moduleTranslation) const final;
+
+  /// Translates the given omp.module to LLVM-IR using the provided IR builder
+  /// and saving the state in 'moduleTranslation'. This is for omp.module
+  /// specific handling, regular builtin.module style handling continues to
+  /// occur elsewhere. NOTE: This occurs after all convertOperation's have been
+  /// processed/
+  LogicalResult convertModuleOperation(
+      Operation *op, llvm::IRBuilderBase &builder,
+      LLVM::ModuleTranslation &moduleTranslation) const final;
 };
 
 } // namespace
+
+LogicalResult OpenMPDialectLLVMIRTranslationInterface::convertModuleOperation(
+    Operation *op, llvm::IRBuilderBase &builder,
+    LLVM::ModuleTranslation &moduleTranslation) const {
+  llvm::OpenMPIRBuilder *ompBuilder = moduleTranslation.getOpenMPBuilder();
+
+  if (auto mod = dyn_cast<mlir::omp::ModuleOp>(op)) {
+    if (mod.getIsDevice()) {
+      // TODO: This is the default settings, still need to create module
+      // attribute/arguments for these alongside flags to pass down from
+      // fc1 and possibly higher driver.
+      // TODO: Might need to extend createGlobalFlag to support address spaces
+      // on the globals to 1:1 mimic Clang which puts these in address space 1
+      ompBuilder->createGlobalFlag(0 /*CGM.getLangOpts().OpenMPTargetDebug*/,
+                                   "__omp_rtl_debug_kind");
+      ompBuilder->createGlobalFlag(
+          0 /*CGM.getLangOpts().OpenMPTeamSubscription*/,
+          "__omp_rtl_assume_teams_oversubscription");
+      ompBuilder->createGlobalFlag(
+          0 /*CGM.getLangOpts().OpenMPThreadSubscription*/,
+          "__omp_rtl_assume_threads_oversubscription");
+      ompBuilder->createGlobalFlag(0 /*CGM.getLangOpts().OpenMPNoThreadState*/,
+                                   "__omp_rtl_assume_no_thread_state");
+      ompBuilder->createGlobalFlag(
+          0 /*CGM.getLangOpts().OpenMPNoNestedParallelism*/,
+          "__omp_rtl_assume_no_nested_parallelism");
+    }
+
+    return success();
+  }
+
+  return failure();
+}
 
 /// Given an OpenMP MLIR operation, create the corresponding LLVM IR
 /// (including OpenMP runtime calls).

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -213,7 +213,8 @@ LogicalResult mlir::MlirOptMain(
 
 LogicalResult mlir::MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
                                 DialectRegistry &registry,
-                                bool preloadDialectsInContext) {
+                                bool preloadDialectsInContext,
+                                bool implicitModule) {
   static cl::opt<std::string> inputFilename(
       cl::Positional, cl::desc("<input file>"), cl::init("-"));
 
@@ -254,7 +255,7 @@ LogicalResult mlir::MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
       "no-implicit-module",
       cl::desc(
           "Disable implicit addition of a top-level module op during parsing"),
-      cl::init(false)};
+      cl::init(implicitModule)};
 
   static cl::opt<bool> dumpPassPipeline{
       "dump-pass-pipeline", cl::desc("Print the pipeline that will be run"),

--- a/mlir/test/Conversion/OpenMPToLLVM/convert-to-llvmir.mlir
+++ b/mlir/test/Conversion/OpenMPToLLVM/convert-to-llvmir.mlir
@@ -1,161 +1,172 @@
-// RUN: mlir-opt -convert-openmp-to-llvm -split-input-file %s | FileCheck %s
+// RUN: mlir-opt --no-implicit-module=true -convert-openmp-to-llvm -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: llvm.func @foo(i64, i64)
-func.func private @foo(index, index)
+omp.module(device_module : false) {
+  // CHECK-LABEL: llvm.func @foo(i64, i64)
+  func.func private @foo(index, index)
 
-// CHECK-LABEL: llvm.func @critical_block_arg
-func.func @critical_block_arg() {
-  // CHECK: omp.critical
-  omp.critical {
-  // CHECK-NEXT: ^[[BB0:.*]](%[[ARG1:.*]]: i64, %[[ARG2:.*]]: i64):
-  ^bb0(%arg1: index, %arg2: index):
-    // CHECK-NEXT: llvm.call @foo(%[[ARG1]], %[[ARG2]]) : (i64, i64) -> ()
-    func.call @foo(%arg1, %arg2) : (index, index) -> ()
-    omp.terminator
+  // CHECK-LABEL: llvm.func @critical_block_arg
+  func.func @critical_block_arg() {
+    // CHECK: omp.critical
+    omp.critical {
+    // CHECK-NEXT: ^[[BB0:.*]](%[[ARG1:.*]]: i64, %[[ARG2:.*]]: i64):
+    ^bb0(%arg1: index, %arg2: index):
+      // CHECK-NEXT: llvm.call @foo(%[[ARG1]], %[[ARG2]]) : (i64, i64) -> ()
+      func.call @foo(%arg1, %arg2) : (index, index) -> ()
+      omp.terminator
+    }
+    return
   }
-  return
+}
+// -----
+omp.module(device_module : false) {
+  // CHECK-LABEL: llvm.func @master_block_arg
+  func.func @master_block_arg() {
+    // CHECK: omp.master
+    omp.master {
+    // CHECK-NEXT: ^[[BB0:.*]](%[[ARG1:.*]]: i64, %[[ARG2:.*]]: i64):
+    ^bb0(%arg1: index, %arg2: index):
+      // CHECK-DAG: %[[CAST_ARG1:.*]] = builtin.unrealized_conversion_cast %[[ARG1]] : i64 to index
+      // CHECK-DAG: %[[CAST_ARG2:.*]] = builtin.unrealized_conversion_cast %[[ARG2]] : i64 to index
+      // CHECK-NEXT: "test.payload"(%[[CAST_ARG1]], %[[CAST_ARG2]]) : (index, index) -> ()
+      "test.payload"(%arg1, %arg2) : (index, index) -> ()
+      omp.terminator
+    }
+    return
+  }
+}
+// -----
+
+omp.module(device_module : false) {
+  // CHECK-LABEL: llvm.func @branch_loop
+  func.func @branch_loop() {
+    %start = arith.constant 0 : index
+    %end = arith.constant 0 : index
+    // CHECK: omp.parallel
+    omp.parallel {
+      // CHECK-NEXT: llvm.br ^[[BB1:.*]](%{{[0-9]+}}, %{{[0-9]+}} : i64, i64
+      cf.br ^bb1(%start, %end : index, index)
+    // CHECK-NEXT: ^[[BB1]](%[[ARG1:[0-9]+]]: i64, %[[ARG2:[0-9]+]]: i64):{{.*}}
+    ^bb1(%0: index, %1: index):
+      // CHECK-NEXT: %[[CMP:[0-9]+]] = llvm.icmp "slt" %[[ARG1]], %[[ARG2]] : i64
+      %2 = arith.cmpi slt, %0, %1 : index
+      // CHECK-NEXT: llvm.cond_br %[[CMP]], ^[[BB2:.*]](%{{[0-9]+}}, %{{[0-9]+}} : i64, i64), ^[[BB3:.*]]
+      cf.cond_br %2, ^bb2(%end, %end : index, index), ^bb3
+    // CHECK-NEXT: ^[[BB2]](%[[ARG3:[0-9]+]]: i64, %[[ARG4:[0-9]+]]: i64):
+    ^bb2(%3: index, %4: index):
+      // CHECK-NEXT: llvm.br ^[[BB1]](%[[ARG3]], %[[ARG4]] : i64, i64)
+      cf.br ^bb1(%3, %4 : index, index)
+    // CHECK-NEXT: ^[[BB3]]:
+    ^bb3:
+      omp.flush
+      omp.barrier
+      omp.taskwait
+      omp.taskyield
+      omp.terminator
+    }
+    return
+  }
+}
+// -----
+
+omp.module(device_module : false) {
+  // CHECK-LABEL: @wsloop
+  // CHECK: (%[[ARG0:.*]]: i64, %[[ARG1:.*]]: i64, %[[ARG2:.*]]: i64, %[[ARG3:.*]]: i64, %[[ARG4:.*]]: i64, %[[ARG5:.*]]: i64)
+  func.func @wsloop(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index) {
+    // CHECK: omp.parallel
+    omp.parallel {
+      // CHECK: omp.wsloop for (%[[ARG6:.*]], %[[ARG7:.*]]) : i64 = (%[[ARG0]], %[[ARG1]]) to (%[[ARG2]], %[[ARG3]]) step (%[[ARG4]], %[[ARG5]]) {
+      "omp.wsloop"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) ({
+      ^bb0(%arg6: index, %arg7: index):
+        // CHECK-DAG: %[[CAST_ARG6:.*]] = builtin.unrealized_conversion_cast %[[ARG6]] : i64 to index
+        // CHECK-DAG: %[[CAST_ARG7:.*]] = builtin.unrealized_conversion_cast %[[ARG7]] : i64 to index
+        // CHECK: "test.payload"(%[[CAST_ARG6]], %[[CAST_ARG7]]) : (index, index) -> ()
+        "test.payload"(%arg6, %arg7) : (index, index) -> ()
+        omp.yield
+      }) {operand_segment_sizes = array<i32: 2, 2, 2, 0, 0, 0, 0>} : (index, index, index, index, index, index) -> ()
+      omp.terminator
+    }
+    return
+  }
+}
+// -----
+
+omp.module(device_module : false) {
+  // CHECK-LABEL: @atomic_write
+  // CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>)
+  // CHECK: %[[VAL0:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK: omp.atomic.write %[[ARG0]] = %[[VAL0]] hint(none) memory_order(relaxed) : !llvm.ptr<i32>, i32
+  func.func @atomic_write(%a: !llvm.ptr<i32>) -> () {
+    %1 = arith.constant 1 : i32
+    omp.atomic.write %a = %1 hint(none) memory_order(relaxed) : !llvm.ptr<i32>, i32
+    return
+  }
 }
 
 // -----
 
-// CHECK-LABEL: llvm.func @master_block_arg
-func.func @master_block_arg() {
-  // CHECK: omp.master
-  omp.master {
-  // CHECK-NEXT: ^[[BB0:.*]](%[[ARG1:.*]]: i64, %[[ARG2:.*]]: i64):
-  ^bb0(%arg1: index, %arg2: index):
-    // CHECK-DAG: %[[CAST_ARG1:.*]] = builtin.unrealized_conversion_cast %[[ARG1]] : i64 to index
-    // CHECK-DAG: %[[CAST_ARG2:.*]] = builtin.unrealized_conversion_cast %[[ARG2]] : i64 to index
-    // CHECK-NEXT: "test.payload"(%[[CAST_ARG1]], %[[CAST_ARG2]]) : (index, index) -> ()
-    "test.payload"(%arg1, %arg2) : (index, index) -> ()
-    omp.terminator
+omp.module(device_module : false) {
+  // CHECK-LABEL: @atomic_read
+  // CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>, %[[ARG1:.*]]: !llvm.ptr<i32>)
+  // CHECK: omp.atomic.read %[[ARG1]] = %[[ARG0]] memory_order(acquire) hint(contended) : !llvm.ptr<i32>
+  func.func @atomic_read(%a: !llvm.ptr<i32>, %b: !llvm.ptr<i32>) -> () {
+    omp.atomic.read %b = %a memory_order(acquire) hint(contended) : !llvm.ptr<i32>
+    return
   }
-  return
+}
+// -----
+
+omp.module(device_module : false) {
+  // CHECK-LABEL: @threadprivate
+  // CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>)
+  // CHECK: %[[VAL0:.*]] = omp.threadprivate %[[ARG0]] : !llvm.ptr<i32> -> !llvm.ptr<i32>
+  func.func @threadprivate(%a: !llvm.ptr<i32>) -> () {
+    %1 = omp.threadprivate %a : !llvm.ptr<i32> -> !llvm.ptr<i32>
+    return
+  }
 }
 
 // -----
 
-// CHECK-LABEL: llvm.func @branch_loop
-func.func @branch_loop() {
-  %start = arith.constant 0 : index
-  %end = arith.constant 0 : index
-  // CHECK: omp.parallel
-  omp.parallel {
-    // CHECK-NEXT: llvm.br ^[[BB1:.*]](%{{[0-9]+}}, %{{[0-9]+}} : i64, i64
-    cf.br ^bb1(%start, %end : index, index)
-  // CHECK-NEXT: ^[[BB1]](%[[ARG1:[0-9]+]]: i64, %[[ARG2:[0-9]+]]: i64):{{.*}}
-  ^bb1(%0: index, %1: index):
-    // CHECK-NEXT: %[[CMP:[0-9]+]] = llvm.icmp "slt" %[[ARG1]], %[[ARG2]] : i64
-    %2 = arith.cmpi slt, %0, %1 : index
-    // CHECK-NEXT: llvm.cond_br %[[CMP]], ^[[BB2:.*]](%{{[0-9]+}}, %{{[0-9]+}} : i64, i64), ^[[BB3:.*]]
-    cf.cond_br %2, ^bb2(%end, %end : index, index), ^bb3
-  // CHECK-NEXT: ^[[BB2]](%[[ARG3:[0-9]+]]: i64, %[[ARG4:[0-9]+]]: i64):
-  ^bb2(%3: index, %4: index):
-    // CHECK-NEXT: llvm.br ^[[BB1]](%[[ARG3]], %[[ARG4]] : i64, i64)
-    cf.br ^bb1(%3, %4 : index, index)
-  // CHECK-NEXT: ^[[BB3]]:
-  ^bb3:
-    omp.flush
-    omp.barrier
-    omp.taskwait
-    omp.taskyield
-    omp.terminator
-  }
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @wsloop
-// CHECK: (%[[ARG0:.*]]: i64, %[[ARG1:.*]]: i64, %[[ARG2:.*]]: i64, %[[ARG3:.*]]: i64, %[[ARG4:.*]]: i64, %[[ARG5:.*]]: i64)
-func.func @wsloop(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index) {
-  // CHECK: omp.parallel
-  omp.parallel {
-    // CHECK: omp.wsloop for (%[[ARG6:.*]], %[[ARG7:.*]]) : i64 = (%[[ARG0]], %[[ARG1]]) to (%[[ARG2]], %[[ARG3]]) step (%[[ARG4]], %[[ARG5]]) {
-    "omp.wsloop"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) ({
-    ^bb0(%arg6: index, %arg7: index):
-      // CHECK-DAG: %[[CAST_ARG6:.*]] = builtin.unrealized_conversion_cast %[[ARG6]] : i64 to index
-      // CHECK-DAG: %[[CAST_ARG7:.*]] = builtin.unrealized_conversion_cast %[[ARG7]] : i64 to index
-      // CHECK: "test.payload"(%[[CAST_ARG6]], %[[CAST_ARG7]]) : (index, index) -> ()
-      "test.payload"(%arg6, %arg7) : (index, index) -> ()
+omp.module(device_module : false) {
+  // CHECK:      llvm.func @simdloop_block_arg(%[[LOWER:.*]]: i32, %[[UPPER:.*]]: i32, %[[ITER:.*]]: i64) {
+  // CHECK:      omp.simdloop   for  (%[[ARG_0:.*]]) : i32 =
+  // CHECK-SAME:     (%[[LOWER]]) to (%[[UPPER]]) inclusive step (%[[LOWER]]) {
+  // CHECK:      llvm.br ^[[BB1:.*]](%[[ITER]] : i64)
+  // CHECK:        ^[[BB1]](%[[VAL_0:.*]]: i64):
+  // CHECK:          %[[VAL_1:.*]] = llvm.icmp "slt" %[[VAL_0]], %[[ITER]] : i64
+  // CHECK:          llvm.cond_br %[[VAL_1]], ^[[BB2:.*]], ^[[BB3:.*]]
+  // CHECK:        ^[[BB2]]:
+  // CHECK:          %[[VAL_2:.*]] = llvm.add %[[VAL_0]], %[[ITER]]  : i64
+  // CHECK:          llvm.br ^[[BB1]](%[[VAL_2]] : i64)
+  // CHECK:        ^[[BB3]]:
+  // CHECK:          omp.yield
+  func.func @simdloop_block_arg(%val : i32, %ub : i32, %i : index) {
+    omp.simdloop   for  (%arg0) : i32 = (%val) to (%ub) inclusive step (%val) {
+      cf.br ^bb1(%i : index)
+    ^bb1(%0: index):
+      %1 = arith.cmpi slt, %0, %i : index
+      cf.cond_br %1, ^bb2, ^bb3
+    ^bb2:
+      %2 = arith.addi %0, %i : index
+      cf.br ^bb1(%2 : index)
+    ^bb3:
       omp.yield
-    }) {operand_segment_sizes = array<i32: 2, 2, 2, 0, 0, 0, 0>} : (index, index, index, index, index, index) -> ()
-    omp.terminator
+    }
+    return
   }
-  return
 }
-
 // -----
 
-// CHECK-LABEL: @atomic_write
-// CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>)
-// CHECK: %[[VAL0:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK: omp.atomic.write %[[ARG0]] = %[[VAL0]] hint(none) memory_order(relaxed) : !llvm.ptr<i32>, i32
-func.func @atomic_write(%a: !llvm.ptr<i32>) -> () {
-  %1 = arith.constant 1 : i32
-  omp.atomic.write %a = %1 hint(none) memory_order(relaxed) : !llvm.ptr<i32>, i32
-  return
-}
+omp.module(device_module : false) {
+  // CHECK-LABEL: @_QPomp_target_data
+  // CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>, %[[ARG1:.*]]: !llvm.ptr<i32>, %[[ARG2:.*]]: !llvm.ptr<i32>, %[[ARG3:.*]]: !llvm.ptr<i32>)
+  // CHECK:         omp.target_enter_data   map((to -> %[[ARG0]] : !llvm.ptr<i32>), (to -> %[[ARG1]] : !llvm.ptr<i32>), (always, alloc -> %[[ARG2]] : !llvm.ptr<i32>))
+  // CHECK:         omp.target_exit_data   map((from -> %[[ARG0]] : !llvm.ptr<i32>), (from -> %[[ARG1]] : !llvm.ptr<i32>), (release -> %[[ARG2]] : !llvm.ptr<i32>), (always, delete -> %[[ARG3]] : !llvm.ptr<i32>))
+  // CHECK:         llvm.return
 
-// -----
-
-// CHECK-LABEL: @atomic_read
-// CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>, %[[ARG1:.*]]: !llvm.ptr<i32>)
-// CHECK: omp.atomic.read %[[ARG1]] = %[[ARG0]] memory_order(acquire) hint(contended) : !llvm.ptr<i32>
-func.func @atomic_read(%a: !llvm.ptr<i32>, %b: !llvm.ptr<i32>) -> () {
-  omp.atomic.read %b = %a memory_order(acquire) hint(contended) : !llvm.ptr<i32>
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @threadprivate
-// CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>)
-// CHECK: %[[VAL0:.*]] = omp.threadprivate %[[ARG0]] : !llvm.ptr<i32> -> !llvm.ptr<i32>
-func.func @threadprivate(%a: !llvm.ptr<i32>) -> () {
-  %1 = omp.threadprivate %a : !llvm.ptr<i32> -> !llvm.ptr<i32>
-  return
-}
-
-// -----
-
-// CHECK:      llvm.func @simdloop_block_arg(%[[LOWER:.*]]: i32, %[[UPPER:.*]]: i32, %[[ITER:.*]]: i64) {
-// CHECK:      omp.simdloop   for  (%[[ARG_0:.*]]) : i32 =
-// CHECK-SAME:     (%[[LOWER]]) to (%[[UPPER]]) inclusive step (%[[LOWER]]) {
-// CHECK:      llvm.br ^[[BB1:.*]](%[[ITER]] : i64)
-// CHECK:        ^[[BB1]](%[[VAL_0:.*]]: i64):
-// CHECK:          %[[VAL_1:.*]] = llvm.icmp "slt" %[[VAL_0]], %[[ITER]] : i64
-// CHECK:          llvm.cond_br %[[VAL_1]], ^[[BB2:.*]], ^[[BB3:.*]]
-// CHECK:        ^[[BB2]]:
-// CHECK:          %[[VAL_2:.*]] = llvm.add %[[VAL_0]], %[[ITER]]  : i64
-// CHECK:          llvm.br ^[[BB1]](%[[VAL_2]] : i64)
-// CHECK:        ^[[BB3]]:
-// CHECK:          omp.yield
-func.func @simdloop_block_arg(%val : i32, %ub : i32, %i : index) {
-  omp.simdloop   for  (%arg0) : i32 = (%val) to (%ub) inclusive step (%val) {
-    cf.br ^bb1(%i : index)
-  ^bb1(%0: index):
-    %1 = arith.cmpi slt, %0, %i : index
-    cf.cond_br %1, ^bb2, ^bb3
-  ^bb2:
-    %2 = arith.addi %0, %i : index
-    cf.br ^bb1(%2 : index)
-  ^bb3:
-    omp.yield
+  llvm.func @_QPomp_target_data(%a : !llvm.ptr<i32>, %b : !llvm.ptr<i32>, %c : !llvm.ptr<i32>, %d : !llvm.ptr<i32>) {
+    omp.target_enter_data   map((to -> %a : !llvm.ptr<i32>), (to -> %b : !llvm.ptr<i32>), (always, alloc -> %c : !llvm.ptr<i32>))
+    omp.target_exit_data   map((from -> %a : !llvm.ptr<i32>), (from -> %b : !llvm.ptr<i32>), (release -> %c : !llvm.ptr<i32>), (always, delete -> %d : !llvm.ptr<i32>))
+    llvm.return
   }
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @_QPomp_target_data
-// CHECK: (%[[ARG0:.*]]: !llvm.ptr<i32>, %[[ARG1:.*]]: !llvm.ptr<i32>, %[[ARG2:.*]]: !llvm.ptr<i32>, %[[ARG3:.*]]: !llvm.ptr<i32>)
-// CHECK:         omp.target_enter_data   map((to -> %[[ARG0]] : !llvm.ptr<i32>), (to -> %[[ARG1]] : !llvm.ptr<i32>), (always, alloc -> %[[ARG2]] : !llvm.ptr<i32>))
-// CHECK:         omp.target_exit_data   map((from -> %[[ARG0]] : !llvm.ptr<i32>), (from -> %[[ARG1]] : !llvm.ptr<i32>), (release -> %[[ARG2]] : !llvm.ptr<i32>), (always, delete -> %[[ARG3]] : !llvm.ptr<i32>))
-// CHECK:         llvm.return
-
-llvm.func @_QPomp_target_data(%a : !llvm.ptr<i32>, %b : !llvm.ptr<i32>, %c : !llvm.ptr<i32>, %d : !llvm.ptr<i32>) {
-  omp.target_enter_data   map((to -> %a : !llvm.ptr<i32>), (to -> %b : !llvm.ptr<i32>), (always, alloc -> %c : !llvm.ptr<i32>))
-  omp.target_exit_data   map((from -> %a : !llvm.ptr<i32>), (from -> %b : !llvm.ptr<i32>), (release -> %c : !llvm.ptr<i32>), (always, delete -> %d : !llvm.ptr<i32>))
-  llvm.return
 }


### PR DESCRIPTION
This is a draft patch for an omp::ModuleOp to see the issues that could arise and to discuss the changes necessary.

Currently this patch creates an omp::ModuleOp with a very slight change from the builtin::ModuleOp, integrates it into Flang utilising a std::variant, and then selects omp ModuleOp when we specify -fopenmp rather than the builtin module op, this is selected as the default when not compiling with -fopenmp.

The integration required a lot of changes in the frontend, primarily just handling of the variant, which I think is a little messy at the moment and could be cleaned up with a wrapper helper class containing the modules.

It also required generalisation of a lot of the MLIR pass infrastructure as it was dependent on builtin::module.

Modifications to the fir-opt and tco tools to support omp::ModuleOp's alongside the builtin::ModuleOp's. The latter works rather non-intrusively, the former is currently a little more intrusive by design, hence the change of all the Fir tests. This doesn't need to be as intrusive (it could be modifications to the OpenMP specific tests instead rather than all of the Fir tests, which would reduce the outward complexity of this patch quite a bit), but this would lead to not ideal behavior when utilising omp::ModuleOp's with fir-opt, you'd have to effectively specify an argument to fir-opt all the time. The main reason for these changes is that these tools and more generally MLIR tools wrap IR in builtin::ModuleOp's if there isn't a top level builtin::ModuleOp and omp::ModuleOp's are of course not builtin::ModuleOp's so it creates some not so fun errors.

In addition this patch has:

> extended the MLIR LLVM lowering infrastructure to
allow dialects to lower module operations that are "specialised" if they desire
> added an fopenmp-is-device flag (which
 someone may already have a patch for, this isn't intended
 to conflict it was mainly for test purposes and doesn't
 need to be upstreamed)
 > slightly modified the MlirOpt tool framework to allow the
 specification of an optional argument for implicitModules to
 one of the constructors

After this patch -fopenmp will generate something like:

omp.module(is_device : false) attrbutes(...) {
  mix of fir, builtin and omp operations
}

Specifying -fopenmp-is-device to -fc1 will toggle is_device to true and then subsequently lower extra information from the omp.module to llvm.ir (global information that is currently just defaulted, but will need Flags for them like in Clang + module arguments to carry the information down).

But yes... I promise this looks scarier than it actually is! It's largely just generalising certain functionality... 

Please do feed in your opinions, and if anyone has better ways of doing things or thinks I've over complicated certain things please do mention it, I am wanting to simplify certain things/clean it up if this is the route we wish to take and it's a first pass so I have been a tad "lazy" as I've been aiming to get something working rather than working and nice! One clean-up example In particular is that I would like to have an alternative to the std::variant, all of the std::holds_alternative etc. is a little ugly to me, I think a wrapper class might fix this. And yes, this misses a lot of additional tests, which will be added when this gets packaged into smaller phab patches if we decide this is the correct direction.