### PR TITLE
[flang][driver] Add support for -fopenmp-host-ir-file-path option to …

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6440,11 +6440,16 @@ def fno_cuda_host_device_constexpr : Flag<["-"], "fno-cuda-host-device-constexpr
 // OpenMP Options
 //===----------------------------------------------------------------------===//
 
-def fopenmp_is_device : Flag<["-"], "fopenmp-is-device">,
-  HelpText<"Generate code only for an OpenMP target device.">,
-  Flags<[CC1Option, NoDriverOption]>;
+let Flags = [CC1Option, FC1Option, NoDriverOption] in {
+
 def fopenmp_host_ir_file_path : Separate<["-"], "fopenmp-host-ir-file-path">,
   HelpText<"Path to the IR file produced by the frontend for the host.">,
+  Flags<[CC1Option, NoDriverOption]>;
+
+} // let Flags = [CC1Option, FC1Option, NoDriverOption]
+
+def fopenmp_is_device : Flag<["-"], "fopenmp-is-device">,
+  HelpText<"Generate code only for an OpenMP target device.">,
   Flags<[CC1Option, NoDriverOption]>;
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/Driver/ToolChains/Flang.h
+++ b/clang/lib/Driver/ToolChains/Flang.h
@@ -56,6 +56,19 @@ private:
   void addTargetOptions(const llvm::opt::ArgList &Args,
                         llvm::opt::ArgStringList &CmdArgs) const;
 
+  /// Extract offload options from the driver arguments and add them to
+  /// the command arguments.
+  ///
+  /// \param [in] C The set of tasks of the driver invocation
+  /// \param [in] JA The job action
+  /// \param [in] Inputs The list of input informations
+  /// \param [in] Args The list of input driver arguments
+  /// \param [out] CmdArgs The list of output command arguments
+  void addOffloadOptions(const Compilation &C, const JobAction &JA,
+                         const InputInfoList &Inputs,
+                         const llvm::opt::ArgList &Args,
+                         llvm::opt::ArgStringList &CmdArgs) const;
+
   /// Extract other compilation options from the driver arguments and add them
   /// to the command arguments.
   ///

--- a/flang/include/flang/Frontend/LangOptions.h
+++ b/flang/include/flang/Frontend/LangOptions.h
@@ -15,6 +15,8 @@
 #ifndef LLVM_FLANG_FRONTEND_LANGOPTIONS_H
 #define LLVM_FLANG_FRONTEND_LANGOPTIONS_H
 
+#include <string>
+
 namespace Fortran::frontend {
 
 /// Bitfields of LangOptions, split out from LangOptions to ensure
@@ -29,6 +31,10 @@ public:
     // Aggressively fuse FP ops (E.g. FMA).
     FPM_Fast,
   };
+
+  /// Name of the IR file that contains the result of the OpenMP target
+  /// host code generation.
+  std::string ompHostIRFile;
 
 #define LANGOPT(Name, Bits, Default) unsigned Name : Bits;
 #define ENUM_LANGOPT(Name, Type, Bits, Default)

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -658,6 +658,16 @@ static bool parseDialectArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
         Fortran::common::LanguageFeature::OpenMP);
   }
 
+  // Get OpenMP host file path if any and report if a non existent file is
+  // found
+  if (llvm::opt::Arg *a = args.getLastArg(
+          clang::driver::options::OPT_fopenmp_host_ir_file_path)) {
+    const char *irPath = a->getValue();
+    res.getLangOpts().ompHostIRFile = irPath;
+    if (!llvm::sys::fs::exists(irPath))
+      diags.Report(clang::diag::err_drv_omp_host_ir_file_not_found) << irPath;
+  }
+
   // -pedantic
   if (args.hasArg(clang::driver::options::OPT_pedantic)) {
     res.setEnableConformanceChecks();

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -133,6 +133,8 @@
 ! HELP-FC1-NEXT: -fno-reformat          Dump the cooked character stream in -E mode
 ! HELP-FC1-NEXT: -fno-signed-zeros      Allow optimizations that ignore the sign of floating point zeros
 ! HELP-FC1-NEXT: -fopenacc              Enable OpenACC
+! HELP-FC1-NEXT: -fopenmp-host-ir-file-path
+! HELP-FC1-NEXT:                        Path to the IR file produced by the frontend for the host.
 ! HELP-FC1-NEXT: -fopenmp               Parse OpenMP pragmas and generate parallel code.
 ! HELP-FC1-NEXT: -fpass-plugin=<dsopath> Load pass plugin from a dynamic shared object file (only with new pass manager).
 ! HELP-FC1-NEXT: -freciprocal-math      Allow division operations to be reassociated


### PR DESCRIPTION
Make the flang driver generate the `-fopenmp-host-ir-file-path` option for the offloading device pass, and make the frontend accept and store the new option for later use. Also, refactor the addition of the `-fembed-offload-object` option to the `addOffloadOptions()` function introduced to replicate clang behavior.