### PR TITLE
[flang][driver] Add support for misc. offloading options to flang -fc1

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5140,8 +5140,6 @@ def tune_cpu : Separate<["-"], "tune-cpu">,
 def target_abi : Separate<["-"], "target-abi">,
   HelpText<"Target a particular ABI type">,
   MarshallingInfoString<TargetOpts<"ABI">>;
-def target_sdk_version_EQ : Joined<["-"], "target-sdk-version=">,
-  HelpText<"The version of target SDK used for compilation">;
 def darwin_target_variant_sdk_version_EQ : Joined<["-"],
   "darwin-target-variant-sdk-version=">,
   HelpText<"The version of darwin target variant SDK used for compilation">;
@@ -5169,6 +5167,8 @@ def target_cpu : Separate<["-"], "target-cpu">,
 def target_feature : Separate<["-"], "target-feature">,
   HelpText<"Target specific attributes">,
   MarshallingInfoStringVector<TargetOpts<"FeaturesAsWritten">>;
+def target_sdk_version_EQ : Joined<["-"], "target-sdk-version=">,
+  HelpText<"The version of target SDK used for compilation">;
 def triple : Separate<["-"], "triple">,
   HelpText<"Specify target triple (e.g. i686-apple-darwin9)">,
   MarshallingInfoString<TargetOpts<"Triple">, "llvm::Triple::normalize(llvm::sys::getDefaultTargetTriple())">,
@@ -6133,6 +6133,9 @@ def split_dwarf_output : Separate<["-"], "split-dwarf-output">,
 
 let Flags = [CC1Option, FC1Option, NoDriverOption] in {
 
+def fapply_global_visibility_to_externs : Flag<["-"], "fapply-global-visibility-to-externs">,
+  HelpText<"Apply global symbol visibility to external declarations without an explicit visibility">,
+  MarshallingInfoFlag<LangOpts<"SetVisibilityForExternDecls">>;
 def mreassociate : Flag<["-"], "mreassociate">,
   HelpText<"Allow reassociation transformations for floating-point instructions">,
   MarshallingInfoFlag<LangOpts<"AllowFPReassoc">>, ImpliedByAnyOf<[funsafe_math_optimizations.KeyPath]>;
@@ -6235,9 +6238,6 @@ def stack_protector_buffer_size : Separate<["-"], "stack-protector-buffer-size">
 def ftype_visibility : Joined<["-"], "ftype-visibility=">,
   HelpText<"Default type visibility">,
   MarshallingInfoVisibility<LangOpts<"TypeVisibilityMode">, fvisibility_EQ.KeyPath>;
-def fapply_global_visibility_to_externs : Flag<["-"], "fapply-global-visibility-to-externs">,
-  HelpText<"Apply global symbol visibility to external declarations without an explicit visibility">,
-  MarshallingInfoFlag<LangOpts<"SetVisibilityForExternDecls">>;
 def ftemplate_depth : Separate<["-"], "ftemplate-depth">,
   HelpText<"Maximum depth of recursive template instantiation">,
   MarshallingInfoInt<LangOpts<"InstantiationDepth">, "1024">;
@@ -6419,11 +6419,16 @@ def source_date_epoch : Separate<["-"], "source-date-epoch">,
 // CUDA Options
 //===----------------------------------------------------------------------===//
 
-let Flags = [CC1Option, NoDriverOption] in {
+let Flags = [CC1Option, FC1Option, NoDriverOption] in {
 
 def fcuda_is_device : Flag<["-"], "fcuda-is-device">,
   HelpText<"Generate code for CUDA device">,
   MarshallingInfoFlag<LangOpts<"CUDAIsDevice">>;
+
+} // let Flags = [CC1Option, FC1Option, NoDriverOption]
+
+let Flags = [CC1Option, NoDriverOption] in {
+
 def fcuda_include_gpubinary : Separate<["-"], "fcuda-include-gpubinary">,
   HelpText<"Incorporate CUDA device-side binary into host object file.">,
   MarshallingInfoString<CodeGenOpts<"CudaGpuBinaryFileName">>;
@@ -6471,7 +6476,7 @@ def sycl_std_EQ : Joined<["-"], "sycl-std=">, Group<sycl_Group>,
 
 defm cuda_approx_transcendentals : BoolFOption<"cuda-approx-transcendentals",
   LangOpts<"CUDADeviceApproxTranscendentals">, DefaultFalse,
-  PosFlag<SetTrue, [CC1Option], "Use">, NegFlag<SetFalse, [], "Don't use">,
+  PosFlag<SetTrue, [CC1Option, FC1Option], "Use">, NegFlag<SetFalse, [], "Don't use">,
   BothFlags<[], " approximate transcendental functions">>,
   ShouldParseIf<fcuda_is_device.KeyPath>;
 

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -106,6 +106,14 @@ void Flang::addTargetOptions(const ArgList &Args,
   // TODO: Add target specific flags, ABI, mtune option etc.
 }
 
+void Flang::addOffloadOptions(const JobAction &JA, const ArgList &Args,
+                              ArgStringList &CmdArgs) const {
+  const ToolChain &TC = getToolChain();
+
+  Action::OffloadKind OffloadKind = JA.getOffloadingDeviceKind();
+  TC.addClangTargetOptions(Args, CmdArgs, OffloadKind);
+}
+
 static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
                                     ArgStringList &CmdArgs) {
   StringRef FPContract;
@@ -302,6 +310,9 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Add target args, features, etc.
   addTargetOptions(Args, CmdArgs);
+
+  // Offloading related options
+  addOffloadOptions(JA, Args, CmdArgs);
 
   // Add other compile options
   addOtherOptions(Args, CmdArgs);

--- a/clang/lib/Driver/ToolChains/Flang.h
+++ b/clang/lib/Driver/ToolChains/Flang.h
@@ -56,6 +56,15 @@ private:
   void addTargetOptions(const llvm::opt::ArgList &Args,
                         llvm::opt::ArgStringList &CmdArgs) const;
 
+  /// Extract offload options from the driver arguments and add them to
+  /// the command arguments.
+  ///
+  /// \param [in] JA The job action
+  /// \param [in] Args The list of input driver arguments
+  /// \param [out] CmdArgs The list of output command arguments
+  void addOffloadOptions(const JobAction &JA, const llvm::opt::ArgList &Args,
+                         llvm::opt::ArgStringList &CmdArgs) const;
+
   /// Extract other compilation options from the driver arguments and add them
   /// to the command arguments.
   ///

--- a/flang/include/flang/Frontend/LangOptions.def
+++ b/flang/include/flang/Frontend/LangOptions.def
@@ -35,5 +35,13 @@ LANGOPT(AssociativeMath, 1, false)
 /// Allow division operations to be reassociated
 LANGOPT(ReciprocalMath, 1, false)
 
+/// Compiling for CUDA device
+LANGOPT(CUDAIsDevice, 1, false)
+/// Allow using approximate transcendental functions
+LANGOPT(CUDADeviceApproxTranscendentals, 1, false)
+/// Apply global symbol visibility to external declarations without an explicit
+/// visibility
+LANGOPT(SetVisibilityForExternDecls, 1, false)
+
 #undef LANGOPT
 #undef ENUM_LANGOPT

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -18,6 +18,7 @@
 #ifndef FORTRAN_FRONTEND_TARGETOPTIONS_H
 #define FORTRAN_FRONTEND_TARGETOPTIONS_H
 
+#include "llvm/Support/VersionTuple.h"
 #include <string>
 #include <vector>
 
@@ -35,6 +36,9 @@ public:
   /// The list of target specific features to enable or disable, as written on
   /// the command line.
   std::vector<std::string> featuresAsWritten;
+
+  /// The version of the SDK which was used during the compilation.
+  llvm::VersionTuple sdkVersion;
 };
 
 } // end namespace Fortran::frontend

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -84,10 +84,15 @@
 ! HELP-FC1-NEXT: -E                     Only run the preprocessor
 ! HELP-FC1-NEXT: -falternative-parameter-statement
 ! HELP-FC1-NEXT: Enable the old style PARAMETER statement
+! HELP-FC1-NEXT: -fapply-global-visibility-to-externs
+! HELP-FC1-NEXT:                        Apply global symbol visibility to external declarations without an explicit visibility
 ! HELP-FC1-NEXT: -fapprox-func          Allow certain math function calls to be replaced with an approximately equivalent calculation
 ! HELP-FC1-NEXT: -fbackslash            Specify that backslash in string introduces an escape character
 ! HELP-FC1-NEXT: -fcolor-diagnostics     Enable colors in diagnostics
 ! HELP-FC1-NEXT: -fconvert=<value>      Set endian conversion of data for unformatted files
+! HELP-FC1-NEXT: -fcuda-approx-transcendentals
+! HELP-FC1-NEXT:                        Use approximate transcendental functions
+! HELP-FC1-NEXT: -fcuda-is-device       Generate code for CUDA device
 ! HELP-FC1-NEXT: -fdebug-dump-all       Dump symbols and the parse tree after the semantic checks
 ! HELP-FC1-NEXT: -fdebug-dump-parse-tree-no-sema
 ! HELP-FC1-NEXT:                        Dump the parse tree (skips the semantic checks)
@@ -162,6 +167,8 @@
 ! HELP-FC1-NEXT: -S                     Only run preprocess and compilation steps
 ! HELP-FC1-NEXT: -target-cpu <value>    Target a specific cpu type
 ! HELP-FC1-NEXT: -target-feature <value> Target specific attributes
+! HELP-FC1-NEXT: -target-sdk-version=<value>
+! HELP-FC1-NEXT:                        The version of target SDK used for compilation
 ! HELP-FC1-NEXT: -test-io               Run the InputOuputTest action. Use for development and testing only.
 ! HELP-FC1-NEXT: -triple <value>        Specify target triple (e.g. i686-apple-darwin9)
 ! HELP-FC1-NEXT: -U <macro>             Undefine macro <macro>


### PR DESCRIPTION
Make the flang driver generate toolchain-specific offloading-related flags, and make the flang frontend accept and store these new options for later use. This patch includes the flags that would be generated by the AMDGPU and CUDA-related toolchains:
  - -fapply-global-visibility-to-externs
  - -fcuda-is-device
  - -fcuda-approx-transcendentals
  - -target-sdk-version

Depends on: #195, #199