### PR TITLE
[WIP][Flang][MLIR][OpenMP][Driver] OpenMP RTL flag attribute and lowering and omp.is_device attribute

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6440,9 +6440,13 @@ def fno_cuda_host_device_constexpr : Flag<["-"], "fno-cuda-host-device-constexpr
 // OpenMP Options
 //===----------------------------------------------------------------------===//
 
+let Flags = [CC1Option, FC1Option, NoDriverOption] in {
+
 def fopenmp_is_device : Flag<["-"], "fopenmp-is-device">,
-  HelpText<"Generate code only for an OpenMP target device.">,
-  Flags<[CC1Option, NoDriverOption]>;
+  HelpText<"Generate code only for an OpenMP target device.">;
+
+} // let Flags = [CC1Option, FC1Option, NoDriverOption]
+
 def fopenmp_host_ir_file_path : Separate<["-"], "fopenmp-host-ir-file-path">,
   HelpText<"Path to the IR file produced by the frontend for the host.">,
   Flags<[CC1Option, NoDriverOption]>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2636,24 +2636,24 @@ def fopenmp_cuda_blocks_per_sm_EQ : Joined<["-"], "fopenmp-cuda-blocks-per-sm=">
   Flags<[CC1Option, NoArgumentUnused, HelpHidden]>;
 def fopenmp_cuda_teams_reduction_recs_num_EQ : Joined<["-"], "fopenmp-cuda-teams-reduction-recs-num=">, Group<f_Group>,
   Flags<[CC1Option, NoArgumentUnused, HelpHidden]>;
-def fopenmp_target_debug : Flag<["-"], "fopenmp-target-debug">, Group<f_Group>, Flags<[CC1Option, NoArgumentUnused]>,
+def fopenmp_target_debug : Flag<["-"], "fopenmp-target-debug">, Group<f_Group>, Flags<[CC1Option, FC1Option, NoArgumentUnused]>,
   HelpText<"Enable debugging in the OpenMP offloading device RTL">;
-def fno_openmp_target_debug : Flag<["-"], "fno-openmp-target-debug">, Group<f_Group>, Flags<[NoArgumentUnused]>;
-def fopenmp_target_debug_EQ : Joined<["-"], "fopenmp-target-debug=">, Group<f_Group>, Flags<[CC1Option, NoArgumentUnused, HelpHidden]>;
+def fno_openmp_target_debug : Flag<["-"], "fno-openmp-target-debug">, Group<f_Group>, Flags<[NoArgumentUnused, FC1Option]>;
+def fopenmp_target_debug_EQ : Joined<["-"], "fopenmp-target-debug=">, Group<f_Group>, Flags<[CC1Option, FC1Option, NoArgumentUnused, HelpHidden]>;
 def fopenmp_assume_teams_oversubscription : Flag<["-"], "fopenmp-assume-teams-oversubscription">,
-  Group<f_Group>, Flags<[CC1Option, NoArgumentUnused, HelpHidden]>;
+  Group<f_Group>, Flags<[CC1Option, FC1Option, NoArgumentUnused, HelpHidden]>;
 def fopenmp_assume_threads_oversubscription : Flag<["-"], "fopenmp-assume-threads-oversubscription">,
-  Group<f_Group>, Flags<[CC1Option, NoArgumentUnused, HelpHidden]>;
+  Group<f_Group>, Flags<[CC1Option, FC1Option, NoArgumentUnused, HelpHidden]>;
 def fno_openmp_assume_teams_oversubscription : Flag<["-"], "fno-openmp-assume-teams-oversubscription">,
-  Group<f_Group>, Flags<[CC1Option, NoArgumentUnused, HelpHidden]>;
+  Group<f_Group>, Flags<[CC1Option, FC1Option, NoArgumentUnused, HelpHidden]>;
 def fno_openmp_assume_threads_oversubscription : Flag<["-"], "fno-openmp-assume-threads-oversubscription">,
-  Group<f_Group>, Flags<[CC1Option, NoArgumentUnused, HelpHidden]>;
+  Group<f_Group>, Flags<[CC1Option, FC1Option, NoArgumentUnused, HelpHidden]>;
 def fopenmp_assume_no_thread_state : Flag<["-"], "fopenmp-assume-no-thread-state">, Group<f_Group>,
-  Flags<[CC1Option, NoArgumentUnused, HelpHidden]>,
+  Flags<[CC1Option, FC1Option, NoArgumentUnused, HelpHidden]>,
   HelpText<"Assert no thread in a parallel region modifies an ICV">,
   MarshallingInfoFlag<LangOpts<"OpenMPNoThreadState">>;
 def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">, Group<f_Group>,
-  Flags<[CC1Option, NoArgumentUnused, HelpHidden]>,
+  Flags<[CC1Option, FC1Option, NoArgumentUnused, HelpHidden]>,
   HelpText<"Assert no nested parallel regions in the GPU">,
   MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
 def fopenmp_offload_mandatory : Flag<["-"], "fopenmp-offload-mandatory">, Group<f_Group>,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -106,6 +106,18 @@ void Flang::addTargetOptions(const ArgList &Args,
   // TODO: Add target specific flags, ABI, mtune option etc.
 }
 
+void Flang::addOffloadOptions(const JobAction &JA,
+                              ArgStringList &CmdArgs) const {
+  bool IsOpenMPDevice = JA.isDeviceOffloading(Action::OFK_OpenMP);
+
+  if (IsOpenMPDevice) {
+    // -fopenmp-is-device is passed along to tell the frontend that it is
+    // generating code for a device, so that only the relevant declarations are
+    // emitted.
+    CmdArgs.push_back("-fopenmp-is-device");
+  }
+}
+
 static void addFloatingPointOptions(const Driver &D, const ArgList &Args,
                                     ArgStringList &CmdArgs) {
   StringRef FPContract;
@@ -302,6 +314,9 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Add target args, features, etc.
   addTargetOptions(Args, CmdArgs);
+
+  // Offloading related options
+  addOffloadOptions(JA, CmdArgs);
 
   // Add other compile options
   addOtherOptions(Args, CmdArgs);

--- a/clang/lib/Driver/ToolChains/Flang.h
+++ b/clang/lib/Driver/ToolChains/Flang.h
@@ -56,6 +56,14 @@ private:
   void addTargetOptions(const llvm::opt::ArgList &Args,
                         llvm::opt::ArgStringList &CmdArgs) const;
 
+  /// Extract offload options from the driver arguments and add them to
+  /// the command arguments.
+  ///
+  /// \param [in] JA The job action
+  /// \param [out] CmdArgs The list of output command arguments
+  void addOffloadOptions(const JobAction &JA,
+                         llvm::opt::ArgStringList &CmdArgs) const;
+
   /// Extract other compilation options from the driver arguments and add them
   /// to the command arguments.
   ///

--- a/clang/lib/Driver/ToolChains/Flang.h
+++ b/clang/lib/Driver/ToolChains/Flang.h
@@ -61,7 +61,7 @@ private:
   ///
   /// \param [in] JA The job action
   /// \param [out] CmdArgs The list of output command arguments
-  void addOffloadOptions(const JobAction &JA,
+  void addOffloadOptions(const JobAction &JA,  const llvm::opt::ArgList &Args,
                          llvm::opt::ArgStringList &CmdArgs) const;
 
   /// Extract other compilation options from the driver arguments and add them

--- a/flang/include/flang/Frontend/LangOptions.def
+++ b/flang/include/flang/Frontend/LangOptions.def
@@ -34,6 +34,8 @@ LANGOPT(NoSignedZeros, 1, false)
 LANGOPT(AssociativeMath, 1, false)
 /// Allow division operations to be reassociated
 LANGOPT(ReciprocalMath, 1, false)
+/// Generate code only for OpenMP target device
+LANGOPT(OpenMPIsDevice, 1, 0)
 
 #undef LANGOPT
 #undef ENUM_LANGOPT

--- a/flang/include/flang/Frontend/LangOptions.def
+++ b/flang/include/flang/Frontend/LangOptions.def
@@ -36,6 +36,16 @@ LANGOPT(AssociativeMath, 1, false)
 LANGOPT(ReciprocalMath, 1, false)
 /// Generate code only for OpenMP target device
 LANGOPT(OpenMPIsDevice, 1, 0)
+/// Enable debugging in the OpenMP offloading device RTL
+LANGOPT(OpenMPTargetDebug, 32, 0)
+/// Assume work-shared loops do not have more iterations than participating threads.
+LANGOPT(OpenMPThreadSubscription, 1, 0)
+/// Assume distributed loops do not have more iterations than participating teams.
+LANGOPT(OpenMPTeamSubscription, 1, 0)
+/// Assume that no thread in a parallel region will modify an ICV.
+LANGOPT(OpenMPNoThreadState, 1, 0)
+/// Assume that no thread in a parallel region will encounter a parallel region
+LANGOPT(OpenMPNoNestedParallelism, 1, 0)
 
 #undef LANGOPT
 #undef ENUM_LANGOPT

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -29,6 +29,10 @@ public:
   /// The name of the target triple to compile for.
   std::string triple;
 
+  /// When compiling for the device side, contains the triple used to compile
+  /// for the host.
+  std::string hostTriple;
+
   /// If given, the name of the target CPU to generate code for.
   std::string cpu;
 

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -29,10 +29,6 @@ public:
   /// The name of the target triple to compile for.
   std::string triple;
 
-  /// When compiling for the device side, contains the triple used to compile
-  /// for the host.
-  std::string hostTriple;
-
   /// If given, the name of the target CPU to generate code for.
   std::string cpu;
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -659,6 +659,37 @@ static bool parseDialectArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
 
     if (args.hasArg(clang::driver::options::OPT_fopenmp_is_device)) {
       res.getLangOpts().OpenMPIsDevice = 1;
+
+      if (args.hasFlag(
+              clang::driver::options::OPT_fopenmp_assume_teams_oversubscription,
+              clang::driver::options::
+                  OPT_fno_openmp_assume_teams_oversubscription,
+              /*Default=*/false))
+        res.getLangOpts().OpenMPTeamSubscription = true;
+
+      if (args.hasArg(clang::driver::options::OPT_fopenmp_assume_no_thread_state))
+        res.getLangOpts().OpenMPNoThreadState = 1;
+      
+      if (args.hasArg(clang::driver::options::OPT_fopenmp_assume_no_nested_parallelism))
+        res.getLangOpts().OpenMPNoNestedParallelism = 1;
+            
+      if (args.hasFlag(clang::driver::options::
+                           OPT_fopenmp_assume_threads_oversubscription,
+                       clang::driver::options::
+                           OPT_fno_openmp_assume_threads_oversubscription,
+                       /*Default=*/false))
+        res.getLangOpts().OpenMPThreadSubscription = true;
+
+      if ((args.hasArg(clang::driver::options::OPT_fopenmp_target_debug) ||
+           args.hasArg(clang::driver::options::OPT_fopenmp_target_debug_EQ))) {
+        res.getLangOpts().OpenMPTargetDebug = getLastArgIntValue(
+            args, clang::driver::options::OPT_fopenmp_target_debug_EQ,
+            res.getLangOpts().OpenMPTargetDebug, diags);
+
+        if (!res.getLangOpts().OpenMPTargetDebug &&
+            args.hasArg(clang::driver::options::OPT_fopenmp_target_debug))
+          res.getLangOpts().OpenMPTargetDebug = 1;
+      }
     }
   }
 
@@ -806,10 +837,6 @@ bool CompilerInvocation::createFromArgs(
       args.getAllArgValues(clang::driver::options::OPT_mmlir);
 
   success &= parseFloatingPointArgs(res, args, diags);
-
-  // if (res.getLangOpts().OpenMPIsDevice) {
-  //   res.getTargetOpts().hostTriple = res.getFrontendOpts().auxTriple;
-  // }
 
   return success;
 }

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -807,9 +807,9 @@ bool CompilerInvocation::createFromArgs(
 
   success &= parseFloatingPointArgs(res, args, diags);
 
-  if (res.getLangOpts().OpenMPIsDevice) {
-    res.getTargetOpts().hostTriple = res.getFrontendOpts().auxTriple;
-  }
+  // if (res.getLangOpts().OpenMPIsDevice) {
+  //   res.getTargetOpts().hostTriple = res.getFrontendOpts().auxTriple;
+  // }
 
   return success;
 }

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -656,6 +656,10 @@ static bool parseDialectArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
   if (args.hasArg(clang::driver::options::OPT_fopenmp)) {
     res.getFrontendOpts().features.Enable(
         Fortran::common::LanguageFeature::OpenMP);
+
+    if (args.hasArg(clang::driver::options::OPT_fopenmp_is_device)) {
+      res.getLangOpts().OpenMPIsDevice = 1;
+    }
   }
 
   // -pedantic
@@ -802,6 +806,10 @@ bool CompilerInvocation::createFromArgs(
       args.getAllArgValues(clang::driver::options::OPT_mmlir);
 
   success &= parseFloatingPointArgs(res, args, diags);
+
+  if (res.getLangOpts().OpenMPIsDevice) {
+    res.getTargetOpts().hostTriple = res.getFrontendOpts().auxTriple;
+  }
 
   return success;
 }

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -180,6 +180,8 @@ bool CodeGenAction::beginSourceFileAction() {
 
   if (ci.getInvocation().getFrontendOpts().features.IsEnabled(
           Fortran::common::LanguageFeature::OpenMP)) {
+    mlir::omp::OpenMPDialect::setRTLFlags(*mlirModule, false, false, false,
+                                          false, false);
     mlir::omp::OpenMPDialect::setIsDevice(
         *mlirModule, ci.getInvocation().getLangOpts().OpenMPIsDevice);
   }

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -180,12 +180,13 @@ bool CodeGenAction::beginSourceFileAction() {
 
   if (ci.getInvocation().getFrontendOpts().features.IsEnabled(
           Fortran::common::LanguageFeature::OpenMP)) {
-    mlir::omp::OpenMPDialect::setRTLFlags(
-        *mlirModule, ci.getInvocation().getLangOpts().OpenMPTargetDebug,
-        ci.getInvocation().getLangOpts().OpenMPTeamSubscription,
-        ci.getInvocation().getLangOpts().OpenMPThreadSubscription,
-        ci.getInvocation().getLangOpts().OpenMPNoThreadState,
-        ci.getInvocation().getLangOpts().OpenMPNoNestedParallelism);
+    if (ci.getInvocation().getLangOpts().OpenMPIsDevice)
+      mlir::omp::OpenMPDialect::setRTLFlags(
+          *mlirModule, ci.getInvocation().getLangOpts().OpenMPTargetDebug,
+          ci.getInvocation().getLangOpts().OpenMPTeamSubscription,
+          ci.getInvocation().getLangOpts().OpenMPThreadSubscription,
+          ci.getInvocation().getLangOpts().OpenMPNoThreadState,
+          ci.getInvocation().getLangOpts().OpenMPNoNestedParallelism);
 
     mlir::omp::OpenMPDialect::setIsDevice(
         *mlirModule, ci.getInvocation().getLangOpts().OpenMPIsDevice);

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -180,8 +180,8 @@ bool CodeGenAction::beginSourceFileAction() {
 
   if (ci.getInvocation().getFrontendOpts().features.IsEnabled(
           Fortran::common::LanguageFeature::OpenMP)) {
-    mlir::omp::setIsDevice(*mlirModule,
-                           ci.getInvocation().getLangOpts().OpenMPIsDevice);
+    mlir::omp::OpenMPDialect::setIsDevice(
+        *mlirModule, ci.getInvocation().getLangOpts().OpenMPIsDevice);
   }
 
   setUpTargetMachine();

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -177,6 +177,13 @@ bool CodeGenAction::beginSourceFileAction() {
 
   // Fetch module from lb, so we can set
   mlirModule = std::make_unique<mlir::ModuleOp>(lb.getModule());
+
+  if (ci.getInvocation().getFrontendOpts().features.IsEnabled(
+          Fortran::common::LanguageFeature::OpenMP)) {
+    mlir::omp::setIsDevice(*mlirModule,
+                           ci.getInvocation().getLangOpts().OpenMPIsDevice);
+  }
+
   setUpTargetMachine();
   const llvm::DataLayout &dl = tm->createDataLayout();
   setMLIRDataLayout(*mlirModule, dl);

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -180,8 +180,13 @@ bool CodeGenAction::beginSourceFileAction() {
 
   if (ci.getInvocation().getFrontendOpts().features.IsEnabled(
           Fortran::common::LanguageFeature::OpenMP)) {
-    mlir::omp::OpenMPDialect::setRTLFlags(*mlirModule, false, false, false,
-                                          false, false);
+    mlir::omp::OpenMPDialect::setRTLFlags(
+        *mlirModule, ci.getInvocation().getLangOpts().OpenMPTargetDebug,
+        ci.getInvocation().getLangOpts().OpenMPTeamSubscription,
+        ci.getInvocation().getLangOpts().OpenMPThreadSubscription,
+        ci.getInvocation().getLangOpts().OpenMPNoThreadState,
+        ci.getInvocation().getLangOpts().OpenMPNoNestedParallelism);
+
     mlir::omp::OpenMPDialect::setIsDevice(
         *mlirModule, ci.getInvocation().getLangOpts().OpenMPIsDevice);
   }

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -134,6 +134,7 @@
 ! HELP-FC1-NEXT: -fno-signed-zeros      Allow optimizations that ignore the sign of floating point zeros
 ! HELP-FC1-NEXT: -fopenacc              Enable OpenACC
 ! HELP-FC1-NEXT: -fopenmp-is-device     Generate code only for an OpenMP target device.
+! HELP-FC1-NEXT: -fopenmp-target-debug  Enable debugging in the OpenMP offloading device RTL
 ! HELP-FC1-NEXT: -fopenmp               Parse OpenMP pragmas and generate parallel code.
 ! HELP-FC1-NEXT: -fpass-plugin=<dsopath> Load pass plugin from a dynamic shared object file (only with new pass manager).
 ! HELP-FC1-NEXT: -freciprocal-math      Allow division operations to be reassociated

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -133,6 +133,7 @@
 ! HELP-FC1-NEXT: -fno-reformat          Dump the cooked character stream in -E mode
 ! HELP-FC1-NEXT: -fno-signed-zeros      Allow optimizations that ignore the sign of floating point zeros
 ! HELP-FC1-NEXT: -fopenacc              Enable OpenACC
+! HELP-FC1-NEXT: -fopenmp-is-device     Generate code only for an OpenMP target device.
 ! HELP-FC1-NEXT: -fopenmp               Parse OpenMP pragmas and generate parallel code.
 ! HELP-FC1-NEXT: -fpass-plugin=<dsopath> Load pass plugin from a dynamic shared object file (only with new pass manager).
 ! HELP-FC1-NEXT: -freciprocal-math      Allow division operations to be reassociated

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -38,6 +38,7 @@
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/unparse-with-symbols.h"
 #include "flang/Version.inc"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -122,6 +123,11 @@ static llvm::cl::opt<bool> enableOpenMP("fopenmp",
                                         llvm::cl::desc("enable openmp"),
                                         llvm::cl::init(false));
 
+static llvm::cl::opt<bool>
+    enableOpenMPDevice("fopenmp-is-device",
+                       llvm::cl::desc("enable openmp device compilation"),
+                       llvm::cl::init(false));
+
 static llvm::cl::opt<bool> enableOpenACC("fopenacc",
                                          llvm::cl::desc("enable openacc"),
                                          llvm::cl::init(false));
@@ -142,11 +148,10 @@ static llvm::cl::opt<bool> useHLFIR("hlfir",
 
 using ProgramName = std::string;
 
-// Print the module without the "module { ... }" wrapper.
+// Print the module with the "module { ... }" wrapper, preventing 
+// information loss from attribute information appended to the module
 static void printModule(mlir::ModuleOp mlirModule, llvm::raw_ostream &out) {
-  for (auto &op : *mlirModule.getBody())
-    out << op << '\n';
-  out << '\n';
+  out << mlirModule << '\n';
 }
 
 static void registerAllPasses() {
@@ -238,6 +243,10 @@ static mlir::LogicalResult convertFortranSourceToMLIR(
       kindMap, loweringOptions, {});
   burnside.lower(parseTree, semanticsContext);
   mlir::ModuleOp mlirModule = burnside.getModule();
+
+  if (enableOpenMP)
+    mlir::omp::OpenMPDialect::setIsDevice(mlirModule, enableOpenMPDevice);
+
   std::error_code ec;
   std::string outputName = outputFilename;
   if (!outputName.size())

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
@@ -13,6 +13,10 @@
 #ifndef MLIR_DIALECT_OPENMP_OPENMPDIALECT_H_
 #define MLIR_DIALECT_OPENMP_OPENMPDIALECT_H_
 
+namespace mlir::omp {
+class RTLModuleFlagsAttr;
+} // namespace mlir::omp
+
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
@@ -32,4 +32,12 @@
 #define GET_OP_CLASSES
 #include "mlir/Dialect/OpenMP/OpenMPOps.h.inc"
 
+namespace mlir::omp {
+// Set the omp.is_device attribute on the module with the specified boolean
+void setIsDevice(mlir::ModuleOp module, bool isDevice);
+// Return the value of the omp.is_device attribute stored in the module if it
+// exists, otherwise return false by default
+bool getIsDevice(mlir::ModuleOp module);
+} // namespace mlir::omp
+
 #endif // MLIR_DIALECT_OPENMP_OPENMPDIALECT_H_

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
@@ -32,12 +32,4 @@
 #define GET_OP_CLASSES
 #include "mlir/Dialect/OpenMP/OpenMPOps.h.inc"
 
-namespace mlir::omp {
-// Set the omp.is_device attribute on the module with the specified boolean
-void setIsDevice(mlir::ModuleOp module, bool isDevice);
-// Return the value of the omp.is_device attribute stored in the module if it
-// exists, otherwise return false by default
-bool getIsDevice(mlir::ModuleOp module);
-} // namespace mlir::omp
-
 #endif // MLIR_DIALECT_OPENMP_OPENMPDIALECT_H_

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -29,6 +29,15 @@ def OpenMP_Dialect : Dialect {
   let dependentDialects = ["::mlir::LLVM::LLVMDialect"];
   let useDefaultAttributePrinterParser = 1;
   let useFoldAPI = kEmitFoldAdaptorFolder;
+
+  let extraClassDeclaration = [{
+    // Set the omp.is_device attribute on the module with the specified boolean
+    static void setIsDevice(mlir::ModuleOp module, bool isDevice);
+    
+    // Return the value of the omp.is_device attribute stored in the module if it
+    // exists, otherwise return false by default
+    static bool getIsDevice(mlir::ModuleOp module);
+  }];
 }
 
 // OmpCommon requires definition of OpenACC_Dialect.

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -33,15 +33,49 @@ def OpenMP_Dialect : Dialect {
   let extraClassDeclaration = [{
     // Set the omp.is_device attribute on the module with the specified boolean
     static void setIsDevice(mlir::ModuleOp module, bool isDevice);
-    
+
     // Return the value of the omp.is_device attribute stored in the module if it
     // exists, otherwise return false by default
     static bool getIsDevice(mlir::ModuleOp module);
+
+    // Apply an omp.RTLModuleFlagsAttr to a module with the specified values for the 
+    // flags
+    static void setRTLFlags(mlir::ModuleOp module, uint32_t debugKind, 
+      bool assumeTeamsOversubscription, bool assumeThreadsOversubscription, 
+      bool assumeNoThreadState, bool assumeNoNestedParallelism);
+
+    // Return an omp.RTLModuleFlagsAttr from a given module, if it exists
+    static mlir::omp::RTLModuleFlagsAttr getRTLFlags(mlir::ModuleOp module);
   }];
 }
 
 // OmpCommon requires definition of OpenACC_Dialect.
 include "mlir/Dialect/OpenMP/OmpCommon.td"
+
+
+// All of the attributes will extend this class.
+class OpenMP_Attr<string name, string attrMnemonic,
+                list<Trait> traits = [],
+                string baseCppClass = "::mlir::Attribute">
+    : AttrDef<OpenMP_Dialect, name, traits, baseCppClass> {
+  let mnemonic = attrMnemonic;
+}
+
+def RTLModuleFlagsAttr : OpenMP_Attr<"RTLModuleFlags", "rtlmoduleflags"> {
+  let parameters = (ins 
+    "uint32_t":$debug_kind,
+    "bool":$assume_teams_oversubscription,
+    "bool":$assume_threads_oversubscription,
+    "bool":$assume_no_thread_state,
+    "bool":$assume_no_nested_parallelism
+  );
+  
+  let assemblyFormat =  "`<` `debug_kind` `:` $debug_kind `,`"
+   " `assume_teams_oversubscription` `:` $assume_teams_oversubscription `,`"
+   " `assume_threads_oversubscription` `:` $assume_threads_oversubscription `,`"
+   " `assume_no_thread_state` `:` $assume_no_thread_state `,`"
+   " `assume_no_nested_parallelism` `:` $assume_no_nested_parallelism `>`";
+}
 
 class OpenMP_Op<string mnemonic, list<Trait> traits = []> :
       Op<OpenMP_Dialect, mnemonic, traits>;

--- a/mlir/include/mlir/Target/LLVMIR/LLVMTranslationInterface.h
+++ b/mlir/include/mlir/Target/LLVMIR/LLVMTranslationInterface.h
@@ -45,6 +45,14 @@ public:
     return failure();
   }
 
+  /// Hook for derived dialect interface to provide translation of module
+  /// type operations to LLVM IR where special handling is neccessary.
+  virtual LogicalResult
+  convertModuleOperation(Operation *op, llvm::IRBuilderBase &builder,
+                         LLVM::ModuleTranslation &moduleTranslation) const {
+    return success();
+  }
+
   /// Hook for derived dialect interface to act on an operation that has dialect
   /// attributes from the derived dialect (the operation itself may be from a
   /// different dialect). This gets called after the operation has been
@@ -73,6 +81,17 @@ public:
     if (const LLVMTranslationDialectInterface *iface = getInterfaceFor(op))
       return iface->convertOperation(op, builder, moduleTranslation);
     return failure();
+  }
+
+  /// Translates the given module operation to LLVM IR using the interface
+  /// implemented by the op's dialect. This is invoked after all operations
+  /// within the module have been processed.
+  virtual LogicalResult
+  convertModuleOperation(Operation *op, llvm::IRBuilderBase &builder,
+                         LLVM::ModuleTranslation &moduleTranslation) const {
+    if (const LLVMTranslationDialectInterface *iface = getInterfaceFor(op))
+      return iface->convertModuleOperation(op, builder, moduleTranslation);
+    return success();
   }
 
   /// Acts on the given operation using the interface implemented by the dialect

--- a/mlir/include/mlir/Target/LLVMIR/LLVMTranslationInterface.h
+++ b/mlir/include/mlir/Target/LLVMIR/LLVMTranslationInterface.h
@@ -45,14 +45,6 @@ public:
     return failure();
   }
 
-  /// Hook for derived dialect interface to provide translation of module
-  /// type operations to LLVM IR where special handling is neccessary.
-  virtual LogicalResult
-  convertModuleOperation(Operation *op, llvm::IRBuilderBase &builder,
-                         LLVM::ModuleTranslation &moduleTranslation) const {
-    return success();
-  }
-
   /// Hook for derived dialect interface to act on an operation that has dialect
   /// attributes from the derived dialect (the operation itself may be from a
   /// different dialect). This gets called after the operation has been
@@ -81,17 +73,6 @@ public:
     if (const LLVMTranslationDialectInterface *iface = getInterfaceFor(op))
       return iface->convertOperation(op, builder, moduleTranslation);
     return failure();
-  }
-
-  /// Translates the given module operation to LLVM IR using the interface
-  /// implemented by the op's dialect. This is invoked after all operations
-  /// within the module have been processed.
-  virtual LogicalResult
-  convertModuleOperation(Operation *op, llvm::IRBuilderBase &builder,
-                         LLVM::ModuleTranslation &moduleTranslation) const {
-    if (const LLVMTranslationDialectInterface *iface = getInterfaceFor(op))
-      return iface->convertModuleOperation(op, builder, moduleTranslation);
-    return success();
   }
 
   /// Acts on the given operation using the interface implemented by the dialect

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -287,13 +287,6 @@ private:
   LogicalResult convertGlobals();
   LogicalResult convertOneFunction(LLVMFuncOp func);
 
-  /// Converts a module operation after all other operations have been handled.
-  /// This is a No-Op for dialects that have no specified interface for module
-  /// operations. This function is invoked after all operations in the module
-  /// have been processed.
-  LogicalResult convertModuleOperation(Operation &op,
-                                       llvm::IRBuilderBase &builder);
-
   /// Process access_group LLVM Metadata operations and create LLVM
   /// metadata nodes.
   LogicalResult createAccessGroupMetadata();

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -287,6 +287,13 @@ private:
   LogicalResult convertGlobals();
   LogicalResult convertOneFunction(LLVMFuncOp func);
 
+  /// Converts a module operation after all other operations have been handled.
+  /// This is a No-Op for dialects that have no specified interface for module
+  /// operations. This function is invoked after all operations in the module
+  /// have been processed.
+  LogicalResult convertModuleOperation(Operation &op,
+                                       llvm::IRBuilderBase &builder);
+
   /// Process access_group LLVM Metadata operations and create LLVM
   /// metadata nodes.
   LogicalResult createAccessGroupMetadata();

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -1346,6 +1346,28 @@ LogicalResult CancellationPointOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// Helpers for custom OMP Attributes for builtin.module
+//===----------------------------------------------------------------------===//
+
+namespace mlir::omp {
+// Set the omp.is_device attribute on the module with the specified boolean
+void setIsDevice(mlir::ModuleOp module, bool isDevice) {
+  module->setAttr(
+      mlir::StringAttr::get(module->getContext(), llvm::Twine{"omp.is_device"}),
+      mlir::BoolAttr::get(module->getContext(), isDevice));
+}
+
+// Return the value of the omp.is_device attribute stored in the module if it
+// exists, otherwise return false by default
+bool getIsDevice(mlir::ModuleOp module) {
+  if (Attribute isDevice = module->getAttr("omp.is_device"))
+    if (isDevice.isa<mlir::BoolAttr>())
+      return isDevice.dyn_cast<BoolAttr>().getValue();
+  return false;
+}
+} // namespace mlir::omp
+
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/OpenMP/OpenMPOpsAttributes.cpp.inc"
 

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -1347,7 +1347,7 @@ LogicalResult CancellationPointOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// OpenMPDialect functions
+// OpenMPDialect helper functions
 //===----------------------------------------------------------------------===//
 
 // Set the omp.is_device attribute on the module with the specified boolean
@@ -1364,6 +1364,28 @@ bool OpenMPDialect::getIsDevice(mlir::ModuleOp module) {
     if (isDevice.isa<mlir::BoolAttr>())
       return isDevice.dyn_cast<BoolAttr>().getValue();
   return false;
+}
+
+// Apply an omp.RTLModuleFlagsAttr to a module with the specified values for the
+// flags
+void OpenMPDialect::setRTLFlags(mlir::ModuleOp module, uint32_t debugKind,
+                                bool assumeTeamsOversubscription,
+                                bool assumeThreadsOversubscription,
+                                bool assumeNoThreadState,
+                                bool assumeNoNestedParallelism) {
+  module->setAttr(("omp." + mlir::omp::RTLModuleFlagsAttr::getMnemonic()).str(),
+                  mlir::omp::RTLModuleFlagsAttr::get(
+                      module->getContext(), debugKind,
+                      assumeTeamsOversubscription,
+                      assumeThreadsOversubscription, assumeNoThreadState,
+                      assumeNoNestedParallelism));
+}
+
+// Return an omp.RTLModuleFlagsAttr from a given module, if it exists
+RTLModuleFlagsAttr OpenMPDialect::getRTLFlags(mlir::ModuleOp module) {
+  if (Attribute isDevice = module->getAttr("omp.rtlmoduleflags"))
+    return isDevice.dyn_cast_or_null<mlir::omp::RTLModuleFlagsAttr>();
+  return nullptr;
 }
 
 #define GET_ATTRDEF_CLASSES

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -1347,12 +1347,11 @@ LogicalResult CancellationPointOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// Helpers for custom OMP Attributes for builtin.module
+// OpenMPDialect functions
 //===----------------------------------------------------------------------===//
 
-namespace mlir::omp {
 // Set the omp.is_device attribute on the module with the specified boolean
-void setIsDevice(mlir::ModuleOp module, bool isDevice) {
+void OpenMPDialect::setIsDevice(mlir::ModuleOp module, bool isDevice) {
   module->setAttr(
       mlir::StringAttr::get(module->getContext(), llvm::Twine{"omp.is_device"}),
       mlir::BoolAttr::get(module->getContext(), isDevice));
@@ -1360,13 +1359,12 @@ void setIsDevice(mlir::ModuleOp module, bool isDevice) {
 
 // Return the value of the omp.is_device attribute stored in the module if it
 // exists, otherwise return false by default
-bool getIsDevice(mlir::ModuleOp module) {
+bool OpenMPDialect::getIsDevice(mlir::ModuleOp module) {
   if (Attribute isDevice = module->getAttr("omp.is_device"))
     if (isDevice.isa<mlir::BoolAttr>())
       return isDevice.dyn_cast<BoolAttr>().getValue();
   return false;
 }
-} // namespace mlir::omp
 
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/OpenMP/OpenMPOpsAttributes.cpp.inc"

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -1366,40 +1366,31 @@ convertRTLModuleFlagsAttr(Operation *op,
                           LLVM::ModuleTranslation &moduleTranslation) {
   llvm::OpenMPIRBuilder *ompBuilder = moduleTranslation.getOpenMPBuilder();
 
-  if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
-    if (mlir::omp::OpenMPDialect::getIsDevice(mod)) {
-      // TODO: This is the default settings, still need to create module
-      // attribute/arguments for these alongside flags to pass down from
-      // fc1 and possibly higher driver.
-      // TODO: Might need to extend createGlobalFlag to support address spaces
-      // on the globals to 1:1 mimic Clang which puts these in address space 1
-      ompBuilder->createGlobalFlag(
-          attribute.getDebugKind() /*LangOpts().OpenMPTargetDebug*/,
-          "__omp_rtl_debug_kind");
-      ompBuilder->createGlobalFlag(
-          attribute
-              .getAssumeTeamsOversubscription() /*LangOpts().OpenMPTeamSubscription*/
-          ,
-          "__omp_rtl_assume_teams_oversubscription");
-      ompBuilder->createGlobalFlag(
-          attribute
-              .getAssumeThreadsOversubscription() /*LangOpts().OpenMPThreadSubscription*/
-          ,
-          "__omp_rtl_assume_threads_oversubscription");
-      ompBuilder->createGlobalFlag(
-          attribute.getAssumeNoThreadState() /*LangOpts().OpenMPNoThreadState*/,
-          "__omp_rtl_assume_no_thread_state");
-      ompBuilder->createGlobalFlag(
-          attribute
-              .getAssumeNoNestedParallelism() /*LangOpts().OpenMPNoNestedParallelism*/
-          ,
-          "__omp_rtl_assume_no_nested_parallelism");
-    }
+  // TODO: Might need to extend createGlobalFlag to support address spaces
+  // on the globals to 1:1 mimic Clang which puts these in address space 1
+  ompBuilder->createGlobalFlag(
+      attribute.getDebugKind() /*LangOpts().OpenMPTargetDebug*/,
+      "__omp_rtl_debug_kind");
+  ompBuilder->createGlobalFlag(
+      attribute
+          .getAssumeTeamsOversubscription() /*LangOpts().OpenMPTeamSubscription*/
+      ,
+      "__omp_rtl_assume_teams_oversubscription");
+  ompBuilder->createGlobalFlag(
+      attribute
+          .getAssumeThreadsOversubscription() /*LangOpts().OpenMPThreadSubscription*/
+      ,
+      "__omp_rtl_assume_threads_oversubscription");
+  ompBuilder->createGlobalFlag(
+      attribute.getAssumeNoThreadState() /*LangOpts().OpenMPNoThreadState*/,
+      "__omp_rtl_assume_no_thread_state");
+  ompBuilder->createGlobalFlag(
+      attribute
+          .getAssumeNoNestedParallelism() /*LangOpts().OpenMPNoNestedParallelism*/
+      ,
+      "__omp_rtl_assume_no_nested_parallelism");
 
-    return success();
-  }
-
-  return failure();
+  return success();
 }
 
 LogicalResult OpenMPDialectLLVMIRTranslationInterface::amendOperation(

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -1352,9 +1352,51 @@ public:
   LogicalResult
   convertOperation(Operation *op, llvm::IRBuilderBase &builder,
                    LLVM::ModuleTranslation &moduleTranslation) const final;
+
+  /// Translates the given omp.module to LLVM-IR using the provided IR builder
+  /// and saving the state in 'moduleTranslation'. This is for omp.module
+  /// specific handling, regular builtin.module style handling continues to
+  /// occur elsewhere. NOTE: This occurs after all convertOperation's have been
+  /// processed/
+  LogicalResult convertModuleOperation(
+      Operation *op, llvm::IRBuilderBase &builder,
+      LLVM::ModuleTranslation &moduleTranslation) const final;
 };
 
 } // namespace
+
+LogicalResult OpenMPDialectLLVMIRTranslationInterface::convertModuleOperation(
+    Operation *op, llvm::IRBuilderBase &builder,
+    LLVM::ModuleTranslation &moduleTranslation) const {
+  llvm::OpenMPIRBuilder *ompBuilder = moduleTranslation.getOpenMPBuilder();
+
+  if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
+    if (mlir::omp::getIsDevice(mod)) {
+      // TODO: This is the default settings, still need to create module
+      // attribute/arguments for these alongside flags to pass down from
+      // fc1 and possibly higher driver.
+      // TODO: Might need to extend createGlobalFlag to support address spaces
+      // on the globals to 1:1 mimic Clang which puts these in address space 1
+      ompBuilder->createGlobalFlag(0 /*CGM.getLangOpts().OpenMPTargetDebug*/,
+                                   "__omp_rtl_debug_kind");
+      ompBuilder->createGlobalFlag(
+          0 /*CGM.getLangOpts().OpenMPTeamSubscription*/,
+          "__omp_rtl_assume_teams_oversubscription");
+      ompBuilder->createGlobalFlag(
+          0 /*CGM.getLangOpts().OpenMPThreadSubscription*/,
+          "__omp_rtl_assume_threads_oversubscription");
+      ompBuilder->createGlobalFlag(0 /*CGM.getLangOpts().OpenMPNoThreadState*/,
+                                   "__omp_rtl_assume_no_thread_state");
+      ompBuilder->createGlobalFlag(
+          0 /*CGM.getLangOpts().OpenMPNoNestedParallelism*/,
+          "__omp_rtl_assume_no_nested_parallelism");
+    }
+
+    return success();
+  }
+
+  return failure();
+}
 
 /// Given an OpenMP MLIR operation, create the corresponding LLVM IR
 /// (including OpenMP runtime calls).

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -1353,47 +1353,69 @@ public:
   convertOperation(Operation *op, llvm::IRBuilderBase &builder,
                    LLVM::ModuleTranslation &moduleTranslation) const final;
 
-  /// Translates the given omp.module to LLVM-IR using the provided IR builder
-  /// and saving the state in 'moduleTranslation'. This is for omp.module
-  /// specific handling, regular builtin.module style handling continues to
-  /// occur elsewhere. NOTE: This occurs after all convertOperation's have been
-  /// processed/
-  LogicalResult convertModuleOperation(
-      Operation *op, llvm::IRBuilderBase &builder,
-      LLVM::ModuleTranslation &moduleTranslation) const final;
+  LogicalResult
+  amendOperation(Operation *op, NamedAttribute attribute,
+                 LLVM::ModuleTranslation &moduleTranslation) const final;
 };
 
 } // namespace
 
-LogicalResult OpenMPDialectLLVMIRTranslationInterface::convertModuleOperation(
-    Operation *op, llvm::IRBuilderBase &builder,
-    LLVM::ModuleTranslation &moduleTranslation) const {
+LogicalResult
+convertRTLModuleFlagsAttr(Operation *op,
+                          mlir::omp::RTLModuleFlagsAttr attribute,
+                          LLVM::ModuleTranslation &moduleTranslation) {
   llvm::OpenMPIRBuilder *ompBuilder = moduleTranslation.getOpenMPBuilder();
 
   if (auto mod = dyn_cast<mlir::ModuleOp>(op)) {
-    if (mlir::omp::getIsDevice(mod)) {
+    if (mlir::omp::OpenMPDialect::getIsDevice(mod)) {
       // TODO: This is the default settings, still need to create module
       // attribute/arguments for these alongside flags to pass down from
       // fc1 and possibly higher driver.
       // TODO: Might need to extend createGlobalFlag to support address spaces
       // on the globals to 1:1 mimic Clang which puts these in address space 1
-      ompBuilder->createGlobalFlag(0 /*CGM.getLangOpts().OpenMPTargetDebug*/,
-                                   "__omp_rtl_debug_kind");
       ompBuilder->createGlobalFlag(
-          0 /*CGM.getLangOpts().OpenMPTeamSubscription*/,
+          attribute.getDebugKind() /*LangOpts().OpenMPTargetDebug*/,
+          "__omp_rtl_debug_kind");
+      ompBuilder->createGlobalFlag(
+          attribute
+              .getAssumeTeamsOversubscription() /*LangOpts().OpenMPTeamSubscription*/
+          ,
           "__omp_rtl_assume_teams_oversubscription");
       ompBuilder->createGlobalFlag(
-          0 /*CGM.getLangOpts().OpenMPThreadSubscription*/,
+          attribute
+              .getAssumeThreadsOversubscription() /*LangOpts().OpenMPThreadSubscription*/
+          ,
           "__omp_rtl_assume_threads_oversubscription");
-      ompBuilder->createGlobalFlag(0 /*CGM.getLangOpts().OpenMPNoThreadState*/,
-                                   "__omp_rtl_assume_no_thread_state");
       ompBuilder->createGlobalFlag(
-          0 /*CGM.getLangOpts().OpenMPNoNestedParallelism*/,
+          attribute.getAssumeNoThreadState() /*LangOpts().OpenMPNoThreadState*/,
+          "__omp_rtl_assume_no_thread_state");
+      ompBuilder->createGlobalFlag(
+          attribute
+              .getAssumeNoNestedParallelism() /*LangOpts().OpenMPNoNestedParallelism*/
+          ,
           "__omp_rtl_assume_no_nested_parallelism");
     }
 
     return success();
   }
+
+  return failure();
+}
+
+LogicalResult OpenMPDialectLLVMIRTranslationInterface::amendOperation(
+    Operation *op, NamedAttribute attribute,
+    LLVM::ModuleTranslation &moduleTranslation) const {
+
+  return llvm::TypeSwitch<Attribute, LogicalResult>(attribute.getValue())
+      .Case([&](mlir::omp::RTLModuleFlagsAttr rtlAttr) {
+        return convertRTLModuleFlagsAttr(op, rtlAttr, moduleTranslation);
+      })
+      .Default([&](Attribute attr) {
+        // fall through for omp attributes that do not require lowering and/or
+        // have no concrete definition and thus no type to define a case on
+        // e.g. omp.is_device
+        return success();
+      });
 
   return failure();
 }

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -585,10 +585,8 @@ ModuleTranslation::convertModuleOperation(Operation &op,
           iface.getInterfaceFor(&op)) {
     if (failed(opIface->convertModuleOperation(&op, builder, *this)))
       return failure();
-    return convertDialectAttributes(&op);
   }
-
-  return success();
+  return convertDialectAttributes(&op);
 }
 
 /// Convert block to LLVM IR.  Unless `ignoreArguments` is set, emit PHI nodes

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -573,24 +573,6 @@ ModuleTranslation::convertOperation(Operation &op,
   return convertDialectAttributes(&op);
 }
 
-/// Given a single MLIR module, create the corresponding LLVM IR operations
-/// using the `builder`, this lowering is defined by the dialect and for dialect
-/// specific modules e.g. omp.module from the OpenMP dialect. This is a
-/// completely optional hook for a dialect. This function is invoked after all
-/// operations in the module have been processed.
-LogicalResult
-ModuleTranslation::convertModuleOperation(Operation &op,
-                                          llvm::IRBuilderBase &builder) {
-  if (const LLVMTranslationDialectInterface *opIface =
-          iface.getInterfaceFor(&op)) {
-    if (failed(opIface->convertModuleOperation(&op, builder, *this)))
-      return failure();
-    return convertDialectAttributes(&op);
-  }
-
-  return success();
-}
-
 /// Convert block to LLVM IR.  Unless `ignoreArguments` is set, emit PHI nodes
 /// to define values corresponding to the MLIR block arguments.  These nodes
 /// are not connected to the source basic blocks, which may not exist yet.  Uses
@@ -1341,11 +1323,6 @@ mlir::translateModuleToLLVMIR(Operation *module, llvm::LLVMContext &llvmContext,
       return nullptr;
     }
   }
-
-  // Convert a dialect specific module with dialect specific lowering if
-  // neccessary, otherwise this is a no-op
-  if (failed(translator.convertModuleOperation(*module, llvmBuilder)))
-    return nullptr;
 
   if (llvm::verifyModule(*translator.llvmModule, &llvm::errs()))
     return nullptr;

--- a/mlir/test/Dialect/OpenMP/attr.mlir
+++ b/mlir/test/Dialect/OpenMP/attr.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-opt %s | mlir-opt | FileCheck %s
+
+// CHECK: module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 20, assume_teams_oversubscription : false, assume_threads_oversubscription : false, assume_no_thread_state : false, assume_no_nested_parallelism : false>} {
+module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 20, assume_teams_oversubscription : false, assume_threads_oversubscription : false, assume_no_thread_state : false, assume_no_nested_parallelism : false>} {}
+
+// -----
+
+// CHECK: module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 0, assume_teams_oversubscription : true, assume_threads_oversubscription : false, assume_no_thread_state : false, assume_no_nested_parallelism : false>} {
+module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 0, assume_teams_oversubscription : true, assume_threads_oversubscription : false, assume_no_thread_state : false, assume_no_nested_parallelism : false>} {}
+
+// -----
+
+// CHECK: module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 100, assume_teams_oversubscription : true, assume_threads_oversubscription : true, assume_no_thread_state : false, assume_no_nested_parallelism : false>} {
+module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 100, assume_teams_oversubscription : true, assume_threads_oversubscription : true, assume_no_thread_state : false, assume_no_nested_parallelism : false>} {}
+
+// -----
+
+// CHECK: module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 200, assume_teams_oversubscription : true, assume_threads_oversubscription : true, assume_no_thread_state : true, assume_no_nested_parallelism : false>} {
+module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 200, assume_teams_oversubscription : true, assume_threads_oversubscription : true, assume_no_thread_state : true, assume_no_nested_parallelism : false>} {}
+
+// -----
+
+// CHECK: module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 300, assume_teams_oversubscription : true, assume_threads_oversubscription : true, assume_no_thread_state : true, assume_no_nested_parallelism : true>} {
+module attributes {omp.rtlmoduleflags = #omp.rtlmoduleflags<debug_kind : 300, assume_teams_oversubscription : true, assume_threads_oversubscription : true, assume_no_thread_state : true, assume_no_nested_parallelism : true>} {}


### PR DESCRIPTION
This PR builds on the following:

- Sergio's work in: https://github.com/ROCm-Developer-Tools/llvm-project/pull/197 (although it excludes the triple changes as it caused some compilation issues without the triple patch too)
- The previous closed omp.is_device PR: https://github.com/ROCm-Developer-Tools/llvm-project/pull/201

It adds handling and lowering to LLVM-IR of the flags:
- fopenmp-target-debug
- fopenmp-assume-threads-oversubscription
- fopenmp-assume-teams-oversubscription
- fopenmp-assume-no-nested-parallelism
- fopenmp-assume-no-thread-state

Which are emitted to LLVM-IR as globals when device offloading OpenMP in Clang, in the case of Flang we lower it from the frontend to an MLIR attribute that is applied to the module, so that it can be carried down to the OpenMPToLLVMIRTranslation step to be lowered to LLVM-IR as globals.

It adds further handling of the omp.is_device attribute to the bbc tool, so that it can be used to test lowering of Fortran to OpenMP FIR device IR (but it currently doesn't support the RTL flags, as the tool seems intended to be a lightweight Fortran -> FIR test tool). 

It adds full module emission to the bbc tool rather than removing the module on emission of FIR IR, this keeps attributes that have been applied in the bbc lowering process. The issue is that things like omp.is_device or any other attributes will be discarded on emission from the tool. This change does not appear to break any existing tests, but it is something that perhaps needs discussion with the tool author when this is submitted upstream. It seems like a lot of Flang's tooling and testing infrastructure relies on the fact that MLIR tools will implicitly wrap things in a module, this doesn't seem ideal imo.

The addition of module lowering (OMP/LLVM Dialect -> LLVM-IR) infrastructure to the LLVM Translation Interface, this is required for lowering/handling of specialised attributes on modules. But it also enables specialisation of modules for a dialect. There may be an alternative method of lowering the RTL Flags attribute that I'm unaware of, so please do point out if there is a better way to do this!

A lot of tests are still required to be added, but these will be added as I fracture this into smaller phabricator patches as that seems like it'll need to be done if we wish to go ahead with upstreaming this!