### PR TITLE
[flang][parser] Add parser support for 'target teams distribute parallel do'

### DIFF
--- a/flang/lib/Lower/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP.cpp
@@ -1527,7 +1527,8 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
       std::get<Fortran::parser::OmpLoopDirective>(
           std::get<Fortran::parser::OmpBeginLoopDirective>(loopConstruct.t).t)
           .v;
-  if (llvm::omp::OMPD_parallel_do == ompDirective) {
+  if (llvm::omp::OMPD_parallel_do == ompDirective ||
+      llvm::omp::OMPD_target_teams_distribute_parallel_do == ompDirective) {
     createCombinedParallelOp<Fortran::parser::OmpBeginLoopDirective>(
         converter, eval,
         std::get<Fortran::parser::OmpBeginLoopDirective>(loopConstruct.t));
@@ -1719,6 +1720,22 @@ static void genOMP(Fortran::lower::AbstractConverter &converter,
     createBodyOfOp<omp::SimdLoopOp>(simdLoopOp, converter, currentLocation,
                                     eval, &loopOpClauseList, iv);
     return;
+  }
+
+  if (llvm::omp::OMPD_target_teams_distribute_parallel_do == ompDirective) {
+    // TODO Should probably create something like the following:
+    // omp.target {
+    //   omp.teams {
+    //     omp.distribute {
+    //       omp.parallel { [already generated]
+    //         omp.wsloop { [already generated]
+    //           ...
+    //         }
+    //       }
+    //     }
+    //   }
+    // }
+    TODO(currentLocation, "target teams distribute parallel do");
   }
 
   // FIXME: Add support for following clauses:

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -2262,6 +2262,17 @@ OpenMPIRBuilder::applyStaticWorkshareLoop(DebugLoc DL, CanonicalLoopInfo *CLI,
   Value *PUpperBound = Builder.CreateAlloca(IVTy, nullptr, "p.upperbound");
   Value *PStride = Builder.CreateAlloca(IVTy, nullptr, "p.stride");
 
+  // Cast address spaces of loop variables to default, so that the static init
+  // runtime call can succeed.
+  if (M.getDataLayout().getAllocaAddrSpace() != 0) {
+    Type *I32PtrType = PointerType::get(I32Type, 0);
+    Type *IVPtrType = PointerType::get(IVTy, 0);
+    PLastIter = Builder.CreateAddrSpaceCast(PLastIter, I32PtrType);
+    PLowerBound = Builder.CreateAddrSpaceCast(PLowerBound, IVPtrType);
+    PUpperBound = Builder.CreateAddrSpaceCast(PLowerBound, IVPtrType);
+    PStride = Builder.CreateAddrSpaceCast(PStride, IVPtrType);
+  }
+
   // At the end of the preheader, prepare for calling the "init" function by
   // storing the current loop bounds into the allocated space. A canonical loop
   // always iterates from 0 to trip-count with step 1. Note that "init" expects


### PR DESCRIPTION
This patch only adds parser support and triggers MLIR code generation for the "parallel do" part of the combined directive. If the `TODO` statement in OpenMP.cpp is removed, the compilation process crashes later in the flow, still to be investigated.