### PR TITLE
[flang][mlir] Initial lowering support to MLIR of `target teams distribute parallel do`

### DIFF
--- a/flang/lib/Semantics/canonicalize-omp.cpp
+++ b/flang/lib/Semantics/canonicalize-omp.cpp
@@ -91,6 +91,9 @@ private:
 
     nextIt = it;
     if (++nextIt != block.end()) {
+      // FIXME This fails to find the 'do' loop if the 'distribute' construct
+      // is specified separately from 'parallel do' or, generally, any time
+      // the are multiple loop constructs associated to the same loop
       if (auto *doCons{GetConstructIf<parser::DoConstruct>(*nextIt)}) {
         if (doCons->GetLoopControl()) {
           // move DoConstruct

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -2269,6 +2269,17 @@ OpenMPIRBuilder::applyStaticWorkshareLoop(DebugLoc DL, CanonicalLoopInfo *CLI,
   Value *PUpperBound = Builder.CreateAlloca(IVTy, nullptr, "p.upperbound");
   Value *PStride = Builder.CreateAlloca(IVTy, nullptr, "p.stride");
 
+  // Cast address spaces of loop variables to default, so that the static init
+  // runtime call can succeed.
+  if (M.getDataLayout().getAllocaAddrSpace() != 0) {
+    Type *I32PtrType = PointerType::get(I32Type, 0);
+    Type *IVPtrType = PointerType::get(IVTy, 0);
+    PLastIter = Builder.CreateAddrSpaceCast(PLastIter, I32PtrType);
+    PLowerBound = Builder.CreateAddrSpaceCast(PLowerBound, IVPtrType);
+    PUpperBound = Builder.CreateAddrSpaceCast(PLowerBound, IVPtrType);
+    PStride = Builder.CreateAddrSpaceCast(PStride, IVPtrType);
+  }
+
   // At the end of the preheader, prepare for calling the "init" function by
   // storing the current loop bounds into the allocated space. A canonical loop
   // always iterates from 0 to trip-count with step 1. Note that "init" expects


### PR DESCRIPTION
Basic definition of the missing MLIR operators `omp.distribute` and `omp.teams` and processing of all loop-related combined directives using either these or `omp.target` operations. The structure of the MLIR representation generated for this Fortran code:
```fortran
!$omp target teams distribute parallel do map(tofrom:int_array(1:10))
do index_ = 1, 10
  int_array(index_) = index_
end do
!$omp end target teams distribute parallel do
```
Is currently as follows:
```mlir
omp.target {
  omp.teams {
    omp.distribute {
      omp.parallel {
        %1 = fir.alloca i32 {adapt.valuebyref, pinned}
        %c1_i32 = arith.constant 1 : i32
        %c10_i32 = arith.constant 10 : i32
        %c1_i32_0 = arith.constant 1 : i32
        omp.wsloop   for  (%arg2) : i32 = (%c1_i32) to (%c10_i32) inclusive step (%c1_i32_0) {
          fir.store %arg2 to %1 : !fir.ref<i32>
          %2 = fir.load %1 : !fir.ref<i32>
          %3 = fir.load %1 : !fir.ref<i32>
          %4 = fir.convert %3 : (i32) -> i64
          %c1_i64 = arith.constant 1 : i64
          %5 = arith.subi %4, %c1_i64 : i64
          %6 = fir.coordinate_of %arg0, %5 : (!fir.ref<!fir.array<?xi32>>, i64) -> !fir.ref<i32>
          fir.store %2 to %6 : !fir.ref<i32>
          omp.yield
        }
      }
    }
  }
}
```
No translation from MLIR to LLVM IR is implemented in this patch, and the `map` clause in the example should be attached to the `omp.target` operation, which is not done yet.