### PR TITLE
Revert setting main-file-name flag

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6254,7 +6254,7 @@ def version : Flag<["-"], "version">,
 
 def main_file_name : Separate<["-"], "main-file-name">,
   HelpText<"Main file name to use for debug info and source if missing">,
-  Flags<[CC1Option, CC1AsOption, NoDriverOption, FC1Option]>,
+  Flags<[CC1Option, CC1AsOption, NoDriverOption]>,
   MarshallingInfoString<CodeGenOpts<"MainFileName">>;
 def split_dwarf_output : Separate<["-"], "split-dwarf-output">,
   HelpText<"File name to use for split dwarf debug info output">,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -429,10 +429,6 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   const InputInfo &Input = Inputs[0];
-  if (Input.isFilename()) {
-    CmdArgs.push_back("-main-file-name");
-    CmdArgs.push_back(Args.MakeArgString(Input.getBaseInput()));
-  }
   types::ID InputType = Input.getType();
 
   // Add preprocessing options like -I, -D, etc. if we are using the

--- a/flang/include/flang/Frontend/FrontendOptions.h
+++ b/flang/include/flang/Frontend/FrontendOptions.h
@@ -296,8 +296,6 @@ struct FrontendOptions {
   /// \return The input kind for the extension, or Language::Unknown if the
   /// extension is not recognized.
   static InputKind getInputKindForExtension(llvm::StringRef extension);
-
-  std::string mainFileName;
 };
 } // namespace Fortran::frontend
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -927,9 +927,6 @@ bool CompilerInvocation::createFromArgs(
   res.frontendOpts.mlirArgs =
       args.getAllArgValues(clang::driver::options::OPT_mmlir);
 
-  res.frontendOpts.mainFileName = std::string(
-      args.getLastArgValue(clang::driver::options::OPT_main_file_name));
-
   success &= parseFloatingPointArgs(res, args, diags);
 
   return success;

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -276,10 +276,7 @@ bool CodeGenAction::beginSourceFileAction() {
 
   // Fetch module from lb, so we can set
   mlirModule = std::make_unique<mlir::ModuleOp>(lb.getModule());
-  llvm::StringRef mainFileName =
-      ci.getInvocation().getFrontendOpts().mainFileName;
-  if (!mainFileName.empty())
-    mlirModule->setName(ci.getInvocation().getFrontendOpts().mainFileName);
+
   if (!setUpTargetMachine())
     return false;
 

--- a/flang/test/Driver/driver-help.f90
+++ b/flang/test/Driver/driver-help.f90
@@ -174,7 +174,6 @@
 ! HELP-FC1-NEXT: -init-only             Only execute frontend initialization
 ! HELP-FC1-NEXT: -I <dir>               Add directory to the end of the list of include search paths
 ! HELP-FC1-NEXT: -load <dsopath>        Load the named plugin (dynamic shared object)
-! HELP-FC1-NEXT: -main-file-name <value> Main file name to use for debug info and source if missing
 ! HELP-FC1-NEXT: -menable-no-infs       Allow optimization to assume there are no infinities.
 ! HELP-FC1-NEXT: -menable-no-nans       Allow optimization to assume there are no NaNs.
 ! HELP-FC1-NEXT: -mllvm <value>         Additional arguments to forward to LLVM's option processing

--- a/flang/test/Driver/mllvm.f90
+++ b/flang/test/Driver/mllvm.f90
@@ -2,14 +2,14 @@
 
 ! 1. Test typical usage.
 ! RUN: %flang -S -mllvm -print-before-all %s -o - 2>&1 | FileCheck %s --check-prefix=OUTPUT
-! RUN: %flang_fc1 -S -mllvm -print-before-all -main-file-name mllvm.f90 %s -o - 2>&1 | FileCheck %s --check-prefix=OUTPUT
+! RUN: %flang_fc1 -S -mllvm -print-before-all %s -o - 2>&1 | FileCheck %s --check-prefix=OUTPUT
 
 ! 2. Test invalid usage (`-print-before` requires an argument)
 ! RUN: not %flang -S -mllvm -print-before %s -o - 2>&1 | FileCheck %s --check-prefix=INVALID_USAGE
 
 ! OUTPUT: *** IR Dump Before Pre-ISel Intrinsic Lowering (pre-isel-intrinsic-lowering) ***
-! OUTPUT-NEXT: ; ModuleID = 'mllvm.f90'
-! OUTPUT-NEXT: source_filename = "mllvm.f90"
+! OUTPUT-NEXT: ; ModuleID = 'FIRModule'
+! OUTPUT-NEXT: source_filename = "FIRModule"
 
 ! INVALID_USAGE: flang (LLVM option parsing): for the --print-before option: requires a value!
 

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -1562,16 +1562,15 @@ LogicalResult convertFlagsAttr(Operation *op, mlir::omp::FlagsAttr attribute,
 
 static bool getTargetEntryUniqueInfo(llvm::TargetRegionEntryInfo &targetInfo,
                                      omp::TargetOp targetOp,
-                                     llvm::StringRef parentName = "",
-                                     llvm::StringRef hostFileName = "") {
+                                     llvm::StringRef parentName = "") {
   auto fileLoc = targetOp.getLoc()->findInstanceOf<FileLineColLoc>();
+
   assert(fileLoc && "No file found from location");
-  StringRef fileName =
-      (!hostFileName.empty()) ? hostFileName : fileLoc.getFilename().getValue();
+  StringRef fileName = fileLoc.getFilename().getValue();
 
   llvm::sys::fs::UniqueID id;
   if (auto ec = llvm::sys::fs::getUniqueID(fileName, id)) {
-    targetOp.emitError("Unable to get unique ID for file: ") << fileName;
+    targetOp.emitError("Unable to get unique ID for file");
     return false;
   }
 
@@ -1665,12 +1664,9 @@ convertOmpTarget(Operation &opInst, llvm::IRBuilderBase &builder,
 
   llvm::OpenMPIRBuilder::LocationDescription ompLoc(builder);
   StringRef parentName = opInst.getParentOfType<LLVM::LLVMFuncOp>().getName();
-  StringRef fileName = "";
   llvm::TargetRegionEntryInfo entryInfo;
-  auto moduleOp = opInst.getParentOfType<mlir::ModuleOp>();
-  fileName = moduleOp.getName().value_or("");
 
-  if (!getTargetEntryUniqueInfo(entryInfo, targetOp, parentName, fileName))
+  if (!getTargetEntryUniqueInfo(entryInfo, targetOp, parentName))
     return failure();
 
   int32_t defaultValTeams = -1;


### PR DESCRIPTION
main-file-name flag is no longer needed for flang-new. Added handling of line directive in trunk version of flang ( D153910 ) solves issues connected with OpenMP function name mismatch for -save-temps flag.