### PR TITLE
Migrate setPropertyExecutionMode() from CGOpenMPRuntimeGPU to OMPIRBuilder.

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -1005,6 +1005,10 @@ public:
     return EmittedGlobalBlocks.lookup(BE);
   }
 
+  std::vector<llvm::WeakTrackingVH> *getLLVMCompilerUsed() {
+    return &LLVMCompilerUsed;
+  }
+
   /// Notes that BE's global block is available via Addr. Asserts that BE
   /// isn't already emitted.
   void setAddrOfGlobalBlock(const BlockExpr *BE, llvm::Constant *Addr);

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -1496,6 +1496,8 @@ public:
   void emitIfClause(Value *Cond, BodyGenCallbackTy ThenGen,
                     BodyGenCallbackTy ElseGen, InsertPointTy AllocaIP = {});
 
+  void setPropertyExecutionMode(StringRef Name, bool Mode, std::vector<llvm::WeakTrackingVH> *LLVMCompilerUsed);
+
   /// Create the global variable holding the offload mappings information.
   GlobalVariable *createOffloadMaptypes(SmallVectorImpl<uint64_t> &Mappings,
                                         std::string VarName);


### PR DESCRIPTION
Currently, this pull request is for review process only.