### PR TITLE
[MLIR][Flang] Prevent CSE and constant materialization from crossing some OpenMP region boundaries

### DIFF
--- a/clang/docs/tools/clang-formatted-files.txt
+++ b/clang/docs/tools/clang-formatted-files.txt
@@ -7770,6 +7770,7 @@ mlir/include/mlir/Interfaces/CallInterfaces.h
 mlir/include/mlir/Interfaces/CastInterfaces.h
 mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
 mlir/include/mlir/Interfaces/CopyOpInterface.h
+mlir/include/mlir/Interfaces/CSEInterfaces.h
 mlir/include/mlir/Interfaces/DataLayoutInterfaces.h
 mlir/include/mlir/Interfaces/DecodeAttributesInterfaces.h
 mlir/include/mlir/Interfaces/DerivedAttributeOpInterface.h

--- a/flang/test/Lower/OpenMP/hlfir-wsloop.f90
+++ b/flang/test/Lower/OpenMP/hlfir-wsloop.f90
@@ -6,10 +6,10 @@
 !CHECK-LABEL: func @_QPsimple_loop()
 subroutine simple_loop
   integer :: i
-  ! CHECK-DAG:     %[[WS_ST:.*]] = arith.constant 1 : i32
-  ! CHECK-DAG:     %[[WS_END:.*]] = arith.constant 9 : i32
   ! CHECK:  omp.parallel
   !$OMP PARALLEL
+  ! CHECK-DAG:     %[[WS_ST:.*]] = arith.constant 1 : i32
+  ! CHECK-DAG:     %[[WS_END:.*]] = arith.constant 9 : i32
   ! CHECK-DAG:     %[[ALLOCA_IV:.*]] = fir.alloca i32 {{{.*}}, pinned}
   ! CHECK:     %[[IV:.*]]    = fir.declare %[[ALLOCA_IV]] {uniq_name = "_QFsimple_loopEi"} : (!fir.ref<i32>) -> !fir.ref<i32>
   ! CHECK:     omp.wsloop for (%[[I:.*]]) : i32 = (%[[WS_ST]]) to (%[[WS_END]]) inclusive step (%[[WS_ST]])

--- a/mlir/include/mlir/Interfaces/CSEInterfaces.h
+++ b/mlir/include/mlir/Interfaces/CSEInterfaces.h
@@ -1,0 +1,32 @@
+//===- CSEInterfaces.h ------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef MLIR_INTERFACES_CSEINTERFACES_H_
+#define MLIR_INTERFACES_CSEINTERFACES_H_
+
+#include "mlir/IR/DialectInterface.h"
+
+namespace mlir {
+class Operation;
+
+/// Define an interface to allow for dialects to control specific aspects of
+/// common subexpression elimination behavior for operations they define.
+class DialectCSEInterface : public DialectInterface::Base<DialectCSEInterface> {
+public:
+  DialectCSEInterface(Dialect *dialect) : Base(dialect) {}
+
+  /// Registered hook to check if an operation that is *not* isolated from
+  /// above, should allow common subexpressions to be extracted out of its
+  /// regions.
+  virtual bool subexpressionExtractionAllowed(Operation *op) const {
+    return true;
+  }
+};
+
+} // namespace mlir
+
+#endif // MLIR_INTERFACES_CSEINTERFACES_H_

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -52,7 +52,7 @@ struct OpenMPDialectCSEInterface : public DialectCSEInterface {
 
   bool subexpressionExtractionAllowed(Operation *op) const final {
     // Avoid extracting common subexpressions across op boundaries
-    return !isa<TargetOp, TeamsOp, ParallelOp>(op);
+    return !isa<TargetOp, TeamsOp, DistributeOp, ParallelOp>(op);
   }
 };
 
@@ -61,7 +61,8 @@ struct OpenMPDialectFoldInterface : public DialectFoldInterface {
 
   bool shouldMaterializeInto(Region *region) const final {
     // Avoid folding constants across target regions
-    return isa<TargetOp, TeamsOp, ParallelOp>(region->getParentOp());
+    return isa<TargetOp, TeamsOp, DistributeOp, ParallelOp>(
+        region->getParentOp());
   }
 };
 } // namespace

--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -15,6 +15,7 @@
 
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/CSEInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/Passes.h"
@@ -61,7 +62,8 @@ namespace {
 class CSEDriver {
 public:
   CSEDriver(RewriterBase &rewriter, DominanceInfo *domInfo)
-      : rewriter(rewriter), domInfo(domInfo) {}
+      : rewriter(rewriter), domInfo(domInfo),
+        interfaces(rewriter.getContext()) {}
 
   /// Simplify all operations within the given op.
   void simplify(Operation *op, bool *changed = nullptr);
@@ -121,6 +123,9 @@ private:
   std::vector<Operation *> opsToErase;
   DominanceInfo *domInfo = nullptr;
   MemEffectsCache memEffectsCache;
+
+  /// CSE interfaces in the present context that can modify CSE behavior.
+  DialectInterfaceCollection<DialectCSEInterface> interfaces;
 
   // Various statistics.
   int64_t numCSE = 0;
@@ -289,7 +294,12 @@ void CSEDriver::simplifyBlock(ScopedMapTy &knownValues, Block *bb,
       // If this operation is isolated above, we can't process nested regions
       // with the given 'knownValues' map. This would cause the insertion of
       // implicit captures in explicit capture only regions.
-      if (op.mightHaveTrait<OpTrait::IsIsolatedFromAbove>()) {
+      // Also, avoid capturing known values from parent regions if this behavior
+      // is explicitly disabled for the given operation.
+      const DialectCSEInterface *cseInterface = interfaces.getInterfaceFor(&op);
+      if (op.mightHaveTrait<OpTrait::IsIsolatedFromAbove>() ||
+          LLVM_UNLIKELY(cseInterface &&
+                        !cseInterface->subexpressionExtractionAllowed(&op))) {
         ScopedMapTy nestedKnownValues;
         for (auto &region : op.getRegions())
           simplifyRegion(nestedKnownValues, region);

--- a/mlir/test/Transforms/cse.mlir
+++ b/mlir/test/Transforms/cse.mlir
@@ -520,3 +520,23 @@ func.func @cse_recursive_effects_failure() -> (i32, i32, i32) {
   %2 = "test.op_with_memread"() : () -> (i32)
   return %0, %2, %1 : i32, i32, i32
 }
+
+// CHECK-LABEL: @no_cse_across_disabled_op
+func.func @no_cse_across_disabled_op() -> (i32) {
+  // CHECK-NEXT: %[[CONST1:.+]] = arith.constant 1 : i32
+  %0 = arith.constant 1 : i32
+
+  // CHECK-NEXT: test.no_cse_one_region_op
+  "test.no_cse_one_region_op"() ({
+    %1 = arith.constant 1 : i32
+    %2 = arith.addi %1, %1 : i32
+    "foo.yield"(%2) : (i32) -> ()
+
+    // CHECK-NEXT: %[[CONST2:.+]] = arith.constant 1 : i32
+    // CHECK-NEXT: %[[SUM:.+]] = arith.addi %[[CONST2]], %[[CONST2]] : i32
+    // CHECK-NEXT: "foo.yield"(%[[SUM]]) : (i32) -> ()
+  }) : () -> ()
+
+  // CHECK: return %[[CONST1]] : i32
+  return %0 : i32
+}

--- a/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
+++ b/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TestDialect.h"
+#include "mlir/Interfaces/CSEInterfaces.h"
 #include "mlir/Interfaces/FoldInterfaces.h"
 #include "mlir/Reducer/ReductionPatternInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
@@ -269,6 +270,16 @@ struct TestDialectFoldInterface : public DialectFoldInterface {
   }
 };
 
+struct TestDialectCSEInterface : public DialectCSEInterface {
+  using DialectCSEInterface::DialectCSEInterface;
+
+  bool subexpressionExtractionAllowed(Operation *op) const final {
+    // Don't allow extracting common subexpressions from the region of these
+    // operations.
+    return !isa<NoCSEOneRegionOp>(op);
+  }
+};
+
 /// This class defines the interface for handling inlining with standard
 /// operations.
 struct TestInlinerInterface : public DialectInlinerInterface {
@@ -381,6 +392,7 @@ void TestDialect::registerInterfaces() {
   auto &blobInterface = addInterface<TestResourceBlobManagerInterface>();
   addInterface<TestOpAsmInterface>(blobInterface);
 
-  addInterfaces<TestDialectFoldInterface, TestInlinerInterface,
-                TestReductionPatternInterface, TestBytecodeDialectInterface>();
+  addInterfaces<TestDialectFoldInterface, TestDialectCSEInterface,
+                TestInlinerInterface, TestReductionPatternInterface,
+                TestBytecodeDialectInterface>();
 }

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2623,6 +2623,10 @@ def TestCSEOfSingleBlockOp : TEST_Op<"cse_of_single_block_op",
   }];
 }
 
+def NoCSEOneRegionOp : TEST_Op<"no_cse_one_region_op", []> {
+  let regions = (region AnyRegion);
+}
+
 //===----------------------------------------------------------------------===//
 // Test Ops to upgrade base on the dialect versions
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Operations this patch prevents constants and common sub-expressions being extracted from:
- omp.target
- omp.teams
- omp.parallel