### PR TITLE
[Flang][OpenMP][MLIR] Create lifetime markers for allocations only used within OpenMP loop regions

### DIFF
--- a/flang/test/Lower/OpenMP/loop-lifetime.f90
+++ b/flang/test/Lower/OpenMP/loop-lifetime.f90
@@ -1,0 +1,87 @@
+! This test checks the insertion of lifetime information for loop indices of
+! OpenMP loop operations.
+! RUN: %flang_fc1 -flang-experimental-hlfir -emit-llvm -fopenmp %s -o - | FileCheck %s
+
+! CHECK-LABEL: define void @wsloop_i32
+subroutine wsloop_i32()
+  ! CHECK-DAG:  %[[LASTITER:.*]] = alloca i32
+  ! CHECK-DAG:  %[[LB:.*]] = alloca i32
+  ! CHECK-DAG:  %[[UB:.*]] = alloca i32
+  ! CHECK-DAG:  %[[STRIDE:.*]] = alloca i32
+  ! CHECK-DAG:  %[[I:.*]] = alloca i32
+  integer :: i
+
+  ! CHECK:      call void @llvm.lifetime.start.p0(i64 4, ptr %[[I]])
+  ! CHECK-NEXT: br label %[[WSLOOP_BLOCK:.*]]
+  ! CHECK:      [[WSLOOP_BLOCK]]:
+  ! CHECK-NOT:  {{^.*}}:
+  ! CHECK:      br label %[[CONT_BLOCK:.*]]
+  ! CHECK:      [[CONT_BLOCK]]:
+  ! CHECK-NEXT: call void @llvm.lifetime.end.p0(i64 4, ptr %[[I]])
+  !$omp do
+  do i = 1, 10
+    print *, i
+  end do
+  !$omp end do
+end subroutine
+
+! CHECK-LABEL: define void @wsloop_i64
+subroutine wsloop_i64()
+  ! CHECK-DAG:  %[[LASTITER:.*]] = alloca i32
+  ! CHECK-DAG:  %[[LB:.*]] = alloca i64
+  ! CHECK-DAG:  %[[UB:.*]] = alloca i64
+  ! CHECK-DAG:  %[[STRIDE:.*]] = alloca i64
+  ! CHECK-DAG:  %[[I:.*]] = alloca i64
+  integer*8 :: i
+
+  ! CHECK:      call void @llvm.lifetime.start.p0(i64 8, ptr %[[I]])
+  ! CHECK-NEXT: br label %[[WSLOOP_BLOCK:.*]]
+  ! CHECK:      [[WSLOOP_BLOCK]]:
+  ! CHECK-NOT:  {{^.*}}:
+  ! CHECK:      br label %[[CONT_BLOCK:.*]]
+  ! CHECK:      [[CONT_BLOCK]]:
+  ! CHECK-NEXT: call void @llvm.lifetime.end.p0(i64 8, ptr %[[I]])
+  !$omp do
+  do i = 1, 10
+    print *, i
+  end do
+  !$omp end do
+end subroutine
+
+! CHECK-LABEL: define void @simdloop_i32
+subroutine simdloop_i32()
+  ! CHECK:      %[[I:.*]] = alloca i32
+  integer :: i
+
+  ! CHECK:      call void @llvm.lifetime.start.p0(i64 4, ptr %[[I]])
+  ! CHECK-NEXT: br label %[[SIMDLOOP_BLOCK:.*]]
+  ! CHECK:      [[SIMDLOOP_BLOCK]]:
+  ! CHECK-NOT:  {{^.*}}:
+  ! CHECK:      br label %[[CONT_BLOCK:.*]]
+  ! CHECK:      [[CONT_BLOCK]]:
+  ! CHECK-NEXT: call void @llvm.lifetime.end.p0(i64 4, ptr %[[I]])
+  !$omp simd
+  do i=1, 9
+    print *, i
+  end do
+  !$omp end simd 
+end subroutine
+
+! CHECK-LABEL: define void @simdloop_i64
+subroutine simdloop_i64()
+  ! CHECK:      %[[I:.*]] = alloca i64
+  integer*8 :: i
+
+  ! CHECK:      call void @llvm.lifetime.start.p0(i64 8, ptr %[[I]])
+  ! CHECK-NEXT: br label %[[SIMDLOOP_BLOCK:.*]]
+  ! CHECK:      [[SIMDLOOP_BLOCK]]:
+  ! CHECK-NOT:  {{^.*}}:
+  ! CHECK:      br label %[[CONT_BLOCK:.*]]
+  ! CHECK:      [[CONT_BLOCK]]:
+  ! CHECK-NEXT: call void @llvm.lifetime.end.p0(i64 8, ptr %[[I]])
+  !$omp simd
+  do i=1, 9
+    print *, i
+  end do
+  !$omp end simd 
+end subroutine


### PR DESCRIPTION
By creating `llvm.lifetime.start` and `llvm.lifetime.end` markers for outside allocations around the body of the loop produced for `omp.wsloop` and `omp.simdloop` MLIR operations, later uses of the LLVM `CodeExtractor` class to potentially outline the body of these loops into independent functions will be able to see the reduced scope of use of these allocations and sink them into the outlined function's body rather than to unnecessarily pass them as arguments. This can also help later optimization stages to detect cases where allocations for loop indices are redundant.

Currently it doesn't provide any benefits if applied on its own, but it improves the code generated for target worksharing loop in PR #231.