### PR TITLE
Tripcount to i32

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -2834,7 +2834,9 @@ OpenMPIRBuilder::applyWorkshareLoopDevice(DebugLoc DL, CanonicalLoopInfo *CLI) {
         /*identifier*/ Ident,
         /*loop body func*/ Builder.CreateBitCast(&OutlinedFn, ParallelTaskPtr),
         /*loop body args*/ LoopBodyArg,
-        /*num of iters*/ TripCount,
+        /*num of iters*/
+        Builder.CreateZExtOrTrunc(TripCount, Type::getInt32Ty(M.getContext()),
+                                  "TripCountTrunc"),
         /*num of threads*/ NumThreads,
         /*block chunk*/ Builder.getInt32(1)};
 


### PR DESCRIPTION
kmpc_for_static_loop_4 expects type (ptr, ptr, ptr, i32,i32,i32) but tripcount is created as i64.  This fixes that problem which gets the stream_no_teams test case closer to working. 