### PR TITLE
[OpenMP][OMPIRBuilder] Set num_teams, thread_limit and trip_count arguments in call to `__tgt_target_kernel`

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -6027,8 +6027,12 @@ void CGOpenMPRuntime::emitTargetOutlinedFunctionHelper(
   getNumThreadsExprForTargetDirective(CGF, D, DefaultValThreads,
                                       /*UpperBoundOnly=*/true);
 
+  OMPBuilder.CurrentTargetInfo.emplace();
+  OMPBuilder.CurrentTargetInfo->NumTeams =
+      CGF.Builder.getInt32(DefaultValTeams);
+  OMPBuilder.CurrentTargetInfo->ThreadLimit =
+      CGF.Builder.getInt32(DefaultValThreads);
   OMPBuilder.emitTargetRegionFunction(EntryInfo, GenerateOutlinedFunction,
-                                      DefaultValTeams, DefaultValThreads,
                                       IsOffloadEntry, OutlinedFn, OutlinedFnID);
 
   if (!OutlinedFn)

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -89,8 +89,13 @@ public:
   /// Flag for specifying if the compilation is done for an accelerator.
   std::optional<bool> IsGPU;
 
-  // Flag for specifying if offloading is mandatory.
+  /// Flag for specifying if offloading is mandatory.
   std::optional<bool> OpenMPOffloadMandatory;
+
+  /// Name of the target processor.
+  StringRef TargetCPU;
+  /// String representation of the target processor's features.
+  StringRef TargetFeatures;
 
   /// First separator used between the initial two parts of a name.
   std::optional<StringRef> FirstSeparator;

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -1610,6 +1610,27 @@ public:
           MapNamesArray(MapNamesArray) {}
   };
 
+  /// Container for target information, gathered from the target region body,
+  /// needed to populate some __tgt_target_kernel arguments.
+  struct TargetRegionInfo {
+    bool HasTeamsRegion = false;
+    int NumDistributeRegions = 0;
+    int NumParallelRegions = 0;
+    int NumLoopRegions = 0;
+    Value *NumTeams = nullptr;
+    Value *ThreadLimit = nullptr;
+    Value *LoopTripCount = nullptr;
+
+    /// Whether this target region defines a single parallel loop.
+    bool isLoop() const {
+      return NumLoopRegions == 1 && NumParallelRegions == 1 &&
+             (!HasTeamsRegion || NumDistributeRegions == 1);
+    }
+  };
+
+  /// Information for the target region being currently translated.
+  std::optional<TargetRegionInfo> CurrentTargetInfo;
+
   /// Data structure that contains the needed information to construct the
   /// kernel args vector.
   struct TargetKernelArgs {
@@ -1618,11 +1639,11 @@ public:
     /// Arguments passed to the runtime library
     TargetDataRTArgs RTArgs;
     /// The number of iterations
-    Value *NumIterations;
+    Value *TripCount;
     /// The number of teams.
     Value *NumTeams;
     /// The number of threads.
-    Value *NumThreads;
+    Value *ThreadLimit;
     /// The size of the dynamic shared memory.
     Value *DynCGGroupMem;
     /// True if the kernel has 'no wait' clause.
@@ -1630,12 +1651,11 @@ public:
 
     /// Constructor for TargetKernelArgs
     TargetKernelArgs(unsigned NumTargetItems, TargetDataRTArgs RTArgs,
-                     Value *NumIterations, Value *NumTeams, Value *NumThreads,
+                     Value *TripCount, Value *NumTeams, Value *ThreadLimit,
                      Value *DynCGGroupMem, bool HasNoWait)
-        : NumTargetItems(NumTargetItems), RTArgs(RTArgs),
-          NumIterations(NumIterations), NumTeams(NumTeams),
-          NumThreads(NumThreads), DynCGGroupMem(DynCGGroupMem),
-          HasNoWait(HasNoWait) {}
+        : NumTargetItems(NumTargetItems), RTArgs(RTArgs), TripCount(TripCount),
+          NumTeams(NumTeams), ThreadLimit(ThreadLimit),
+          DynCGGroupMem(DynCGGroupMem), HasNoWait(HasNoWait) {}
   };
 
   /// Create the kernel args vector used by emitTargetKernel. This function
@@ -2078,9 +2098,7 @@ public:
 
 private:
   // Sets the function attributes expected for the outlined function
-  void setOutlinedTargetRegionFunctionAttributes(Function *OutlinedFn,
-                                                 int32_t NumTeams,
-                                                 int32_t NumThreads);
+  void setOutlinedTargetRegionFunctionAttributes(Function *OutlinedFn);
 
   // Creates the function ID/Address for the given outlined function.
   // In the case of an embedded device function the address of the function is
@@ -2125,13 +2143,10 @@ public:
   /// \param InfoManager The info manager keeping track of the offload entries
   /// \param EntryInfo The entry information about the function
   /// \param GenerateFunctionCallback The callback function to generate the code
-  /// \param NumTeams Number default teams
-  /// \param NumThreads Number default threads
   /// \param OutlinedFunction Pointer to the outlined function
   /// \param EntryFnIDName Name of the ID o be created
   void emitTargetRegionFunction(TargetRegionEntryInfo &EntryInfo,
                                 FunctionGenCallback &GenerateFunctionCallback,
-                                int32_t NumTeams, int32_t NumThreads,
                                 bool IsOffloadEntry, Function *&OutlinedFn,
                                 Constant *&OutlinedFnID);
 
@@ -2143,13 +2158,10 @@ public:
   /// \param OutlinedFunction Pointer to the outlined function
   /// \param EntryFnName Name of the outlined function
   /// \param EntryFnIDName Name of the ID o be created
-  /// \param NumTeams Number default teams
-  /// \param NumThreads Number default threads
   Constant *registerTargetRegionFunction(TargetRegionEntryInfo &EntryInfo,
                                          Function *OutlinedFunction,
                                          StringRef EntryFnName,
-                                         StringRef EntryFnIDName,
-                                         int32_t NumTeams, int32_t NumThreads);
+                                         StringRef EntryFnIDName);
   /// Type of BodyGen to use for region codegen
   ///
   /// Priv: If device pointer privatization is required, emit the body of the
@@ -2211,8 +2223,6 @@ public:
   /// \param CodeGenIP The insertion point where the call to the outlined
   /// function should be emitted.
   /// \param EntryInfo The entry information about the function.
-  /// \param NumTeams Number of teams specified in the num_teams clause.
-  /// \param NumThreads Number of teams specified in the thread_limit clause.
   /// \param Inputs The input values to the region that will be passed.
   /// as arguments to the outlined function.
   /// \param BodyGenCB Callback that will generate the region code.
@@ -2221,8 +2231,7 @@ public:
   InsertPointTy createTarget(const LocationDescription &Loc,
                              OpenMPIRBuilder::InsertPointTy AllocaIP,
                              OpenMPIRBuilder::InsertPointTy CodeGenIP,
-                             TargetRegionEntryInfo &EntryInfo, int32_t NumTeams,
-                             int32_t NumThreads,
+                             TargetRegionEntryInfo &EntryInfo,
                              SmallVectorImpl<Value *> &Inputs,
                              GenMapInfoCallbackTy GenMapInfoCB,
                              TargetBodyGenCallbackTy BodyGenCB,

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -4994,7 +4994,6 @@ static Function *createOutlinedFunction(
         ArgAccessorFuncCB(Arg, Input, InputCopy, AllocaIP, Builder.saveIP()));
 
     // Collect all the instructions
-    assert(InputCopy->getType()->isPointerTy() && "Not Pointer Type");
     for (User *User : make_early_inc_range(Input->users()))
       if (auto Instr = dyn_cast<Instruction>(User))
         if (Instr->getFunction() == Func)

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -4560,6 +4560,10 @@ void OpenMPIRBuilder::setOutlinedTargetRegionFunctionAttributes(
     OutlinedFn->setVisibility(GlobalValue::ProtectedVisibility);
     if (Triple(M.getTargetTriple()).isAMDGCN())
       OutlinedFn->setCallingConv(CallingConv::AMDGPU_KERNEL);
+    if (!Config.TargetCPU.empty())
+      OutlinedFn->addFnAttr("target-cpu", Config.TargetCPU);
+    if (!Config.TargetFeatures.empty())
+      OutlinedFn->addFnAttr("target-features", Config.TargetFeatures);
   }
 
   // Try to get constant values for NumTeams and ThreadLimit, and set default

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -485,8 +485,8 @@ void OpenMPIRBuilder::getKernelArgsVector(TargetKernelArgs &KernelArgs,
 
   Value *NumTeams3D =
       Builder.CreateInsertValue(ZeroArray, KernelArgs.NumTeams, {0});
-  Value *NumThreads3D =
-      Builder.CreateInsertValue(ZeroArray, KernelArgs.NumThreads, {0});
+  Value *ThreadLimit3D =
+      Builder.CreateInsertValue(ZeroArray, KernelArgs.ThreadLimit, {0});
 
   ArgsVector = {Version,
                 PointerNum,
@@ -496,10 +496,10 @@ void OpenMPIRBuilder::getKernelArgsVector(TargetKernelArgs &KernelArgs,
                 KernelArgs.RTArgs.MapTypesArray,
                 KernelArgs.RTArgs.MapNamesArray,
                 KernelArgs.RTArgs.MappersArray,
-                KernelArgs.NumIterations,
+                KernelArgs.TripCount,
                 Flags,
                 NumTeams3D,
-                NumThreads3D,
+                ThreadLimit3D,
                 KernelArgs.DynCGGroupMem};
 }
 
@@ -1076,7 +1076,7 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::emitKernelLaunch(
   // of teams and threads so no additional calls to the runtime are required.
   // Check the error code and execute the host version if required.
   Builder.restoreIP(emitTargetKernel(Builder, AllocaIP, Return, RTLoc, DeviceID,
-                                     Args.NumTeams, Args.NumThreads,
+                                     Args.NumTeams, Args.ThreadLimit,
                                      OutlinedFnID, ArgsVector));
 
   BasicBlock *OffloadFailedBlock =
@@ -4552,7 +4552,7 @@ static const omp::GV &getGridValue(Function *Kernel) {
 }
 
 void OpenMPIRBuilder::setOutlinedTargetRegionFunctionAttributes(
-    Function *OutlinedFn, int32_t NumTeams, int32_t NumThreads) {
+    Function *OutlinedFn) {
   if (Config.isTargetDevice()) {
     OutlinedFn->setLinkage(GlobalValue::WeakODRLinkage);
     // TODO: Determine if DSO local can be set to true.
@@ -4562,16 +4562,32 @@ void OpenMPIRBuilder::setOutlinedTargetRegionFunctionAttributes(
       OutlinedFn->setCallingConv(CallingConv::AMDGPU_KERNEL);
   }
 
-  if (NumTeams > 0)
-    OutlinedFn->addFnAttr("omp_target_num_teams", std::to_string(NumTeams));
+  // Try to get constant values for NumTeams and ThreadLimit, and set default
+  // values if they are not constant.
+  int32_t NumTeamsValue = -1;
+  int32_t ThreadLimitValue = -1;
 
-  if (NumThreads == -1 && Config.isGPU())
-    NumThreads = getGridValue(OutlinedFn).GV_Default_WG_Size;
+  if (auto *NumTeamsConst =
+          dyn_cast_if_present<llvm::Constant>(CurrentTargetInfo->NumTeams))
+    NumTeamsValue = NumTeamsConst->getUniqueInteger().getSExtValue();
+  else if (CurrentTargetInfo->HasTeamsRegion)
+    NumTeamsValue = 0;
 
-  if (NumThreads > 0) {
+  if (auto *ThreadLimitConst =
+          dyn_cast_if_present<llvm::Constant>(CurrentTargetInfo->ThreadLimit))
+    ThreadLimitValue = ThreadLimitConst->getUniqueInteger().getSExtValue();
+
+  if (NumTeamsValue > 0)
+    OutlinedFn->addFnAttr("omp_target_num_teams",
+                          std::to_string(NumTeamsValue));
+
+  if (ThreadLimitValue == -1 && Config.isGPU())
+    ThreadLimitValue = getGridValue(OutlinedFn).GV_Default_WG_Size;
+
+  if (ThreadLimitValue > 0) {
     if (OutlinedFn->getCallingConv() == CallingConv::AMDGPU_KERNEL) {
       OutlinedFn->addFnAttr("amdgpu-flat-work-group-size",
-                            "1," + llvm::utostr(NumThreads));
+                            "1," + llvm::utostr(ThreadLimitValue));
     } else {
       // Update the "maxntidx" metadata for NVIDIA, or add it.
       NamedMDNode *MD = M.getOrInsertNamedMetadata("nvvm.annotations");
@@ -4595,19 +4611,19 @@ void OpenMPIRBuilder::setOutlinedTargetRegionFunctionAttributes(
         ExistingOp->replaceOperandWith(
             2, ConstantAsMetadata::get(
                    ConstantInt::get(OldVal->getValue()->getType(),
-                                    std::min(OldLimit, NumThreads))));
+                                    std::min(OldLimit, ThreadLimitValue))));
       } else {
         LLVMContext &Ctx = M.getContext();
         Metadata *MDVals[] = {ConstantAsMetadata::get(OutlinedFn),
                               MDString::get(Ctx, "maxntidx"),
                               ConstantAsMetadata::get(ConstantInt::get(
-                                  Type::getInt32Ty(Ctx), NumThreads))};
+                                  Type::getInt32Ty(Ctx), ThreadLimitValue))};
         // Append metadata to nvvm.annotations
         MD->addOperand(MDNode::get(Ctx, MDVals));
       }
     }
     OutlinedFn->addFnAttr("omp_target_thread_limit",
-                          std::to_string(NumThreads));
+                          std::to_string(ThreadLimitValue));
   }
 }
 
@@ -4637,9 +4653,8 @@ Constant *OpenMPIRBuilder::createTargetRegionEntryAddr(Function *OutlinedFn,
 
 void OpenMPIRBuilder::emitTargetRegionFunction(
     TargetRegionEntryInfo &EntryInfo,
-    FunctionGenCallback &GenerateFunctionCallback, int32_t NumTeams,
-    int32_t NumThreads, bool IsOffloadEntry, Function *&OutlinedFn,
-    Constant *&OutlinedFnID) {
+    FunctionGenCallback &GenerateFunctionCallback, bool IsOffloadEntry,
+    Function *&OutlinedFn, Constant *&OutlinedFnID) {
 
   SmallString<64> EntryFnName;
   OffloadInfoManager.getTargetRegionEntryFnName(EntryFnName, EntryInfo);
@@ -4659,16 +4674,15 @@ void OpenMPIRBuilder::emitTargetRegionFunction(
           ? std::string(EntryFnName)
           : createPlatformSpecificName({EntryFnName, "region_id"});
 
-  OutlinedFnID = registerTargetRegionFunction(
-      EntryInfo, OutlinedFn, EntryFnName, EntryFnIDName, NumTeams, NumThreads);
+  OutlinedFnID = registerTargetRegionFunction(EntryInfo, OutlinedFn,
+                                              EntryFnName, EntryFnIDName);
 }
 
 Constant *OpenMPIRBuilder::registerTargetRegionFunction(
     TargetRegionEntryInfo &EntryInfo, Function *OutlinedFn,
-    StringRef EntryFnName, StringRef EntryFnIDName, int32_t NumTeams,
-    int32_t NumThreads) {
+    StringRef EntryFnName, StringRef EntryFnIDName) {
   if (OutlinedFn)
-    setOutlinedTargetRegionFunctionAttributes(OutlinedFn, NumTeams, NumThreads);
+    setOutlinedTargetRegionFunctionAttributes(OutlinedFn);
   auto OutlinedFnID = createOutlinedFunctionID(OutlinedFn, EntryFnIDName);
   auto EntryAddr = createTargetRegionEntryAddr(OutlinedFn, EntryFnName);
   OffloadInfoManager.registerTargetRegionEntryInfo(
@@ -4992,27 +5006,23 @@ static Function *createOutlinedFunction(
 static void emitTargetOutlinedFunction(
     OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
     TargetRegionEntryInfo &EntryInfo, Function *&OutlinedFn,
-    Constant *&OutlinedFnID, int32_t NumTeams, int32_t NumThreads,
-    SmallVectorImpl<Value *> &Inputs,
+    Constant *&OutlinedFnID, SmallVectorImpl<Value *> &Inputs,
     OpenMPIRBuilder::TargetBodyGenCallbackTy &CBFunc,
     OpenMPIRBuilder::TargetGenArgAccessorsCallbackTy &ArgAccessorFuncCB) {
 
   OpenMPIRBuilder::FunctionGenCallback &&GenerateOutlinedFunction =
-      [&OMPBuilder, &Builder, &Inputs, &CBFunc,
-       &ArgAccessorFuncCB](StringRef EntryFnName) {
+      [&](StringRef EntryFnName) {
         return createOutlinedFunction(OMPBuilder, Builder, EntryFnName, Inputs,
                                       CBFunc, ArgAccessorFuncCB);
       };
 
-  OMPBuilder.emitTargetRegionFunction(EntryInfo, GenerateOutlinedFunction,
-                                      NumTeams, NumThreads, true, OutlinedFn,
-                                      OutlinedFnID);
+  OMPBuilder.emitTargetRegionFunction(EntryInfo, GenerateOutlinedFunction, true,
+                                      OutlinedFn, OutlinedFnID);
 }
 
 static void emitTargetCall(OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
                            OpenMPIRBuilder::InsertPointTy AllocaIP,
                            Function *OutlinedFn, Constant *OutlinedFnID,
-                           int32_t NumTeams, int32_t NumThreads,
                            SmallVectorImpl<Value *> &Args,
                            OpenMPIRBuilder::GenMapInfoCallbackTy GenMapInfoCB) {
 
@@ -5039,22 +5049,33 @@ static void emitTargetCall(OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
   unsigned NumTargetItems = MapInfo.BasePointers.size();
   // TODO: Use correct device ID
   Value *DeviceID = Builder.getInt64(OMP_DEVICEID_UNDEF);
-  Value *NumTeamsVal = Builder.getInt32(NumTeams);
-  Value *NumThreadsVal = Builder.getInt32(NumThreads);
   uint32_t SrcLocStrSize;
   Constant *SrcLocStr = OMPBuilder.getOrCreateDefaultSrcLocStr(SrcLocStrSize);
   Value *RTLoc = OMPBuilder.getOrCreateIdent(SrcLocStr, SrcLocStrSize,
                                              llvm::omp::IdentFlag(0), 0);
-  // TODO: Use correct NumIterations
-  Value *NumIterations = Builder.getInt64(0);
+
+  OpenMPIRBuilder::TargetRegionInfo &TRI = OMPBuilder.CurrentTargetInfo.value();
+
+  // Set to -1 if there is no teams directive, and 0 if clause unspecified.
+  Value *NumTeams = !TRI.HasTeamsRegion ? Builder.getInt32(-1)
+                    : TRI.NumTeams      ? TRI.NumTeams
+                                        : Builder.getInt32(0);
+
+  // Set to 0 if clause unspecified.
+  Value *ThreadLimit = TRI.ThreadLimit ? TRI.ThreadLimit : Builder.getInt32(0);
+
+  // Set to 0 if this is not a teams + single distribute loop.
+  Value *TripCount = TRI.isLoop() ? TRI.LoopTripCount : nullptr;
+  if (!TripCount)
+    TripCount = Builder.getInt64(0);
+
   // TODO: Use correct DynCGGroupMem
   Value *DynCGGroupMem = Builder.getInt32(0);
-
   bool HasNoWait = false;
 
-  OpenMPIRBuilder::TargetKernelArgs KArgs(NumTargetItems, RTArgs, NumIterations,
-                                          NumTeamsVal, NumThreadsVal,
-                                          DynCGGroupMem, HasNoWait);
+  OpenMPIRBuilder::TargetKernelArgs KArgs(NumTargetItems, RTArgs, TripCount,
+                                          NumTeams, ThreadLimit, DynCGGroupMem,
+                                          HasNoWait);
 
   Builder.restoreIP(OMPBuilder.emitKernelLaunch(
       Builder, OutlinedFn, OutlinedFnID, EmitTargetCallFallbackCB, KArgs,
@@ -5063,9 +5084,8 @@ static void emitTargetCall(OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
 
 OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTarget(
     const LocationDescription &Loc, InsertPointTy AllocaIP,
-    InsertPointTy CodeGenIP, TargetRegionEntryInfo &EntryInfo, int32_t NumTeams,
-    int32_t NumThreads, SmallVectorImpl<Value *> &Args,
-    GenMapInfoCallbackTy GenMapInfoCB,
+    InsertPointTy CodeGenIP, TargetRegionEntryInfo &EntryInfo,
+    SmallVectorImpl<Value *> &Args, GenMapInfoCallbackTy GenMapInfoCB,
     OpenMPIRBuilder::TargetBodyGenCallbackTy CBFunc,
     OpenMPIRBuilder::TargetGenArgAccessorsCallbackTy ArgAccessorFuncCB) {
   if (!updateToLocation(Loc))
@@ -5076,11 +5096,10 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTarget(
   Function *OutlinedFn;
   Constant *OutlinedFnID;
   emitTargetOutlinedFunction(*this, Builder, EntryInfo, OutlinedFn,
-                             OutlinedFnID, NumTeams, NumThreads, Args, CBFunc,
-                             ArgAccessorFuncCB);
+                             OutlinedFnID, Args, CBFunc, ArgAccessorFuncCB);
   if (!Config.isTargetDevice())
-    emitTargetCall(*this, Builder, AllocaIP, OutlinedFn, OutlinedFnID, NumTeams,
-                   NumThreads, Args, GenMapInfoCB);
+    emitTargetCall(*this, Builder, AllocaIP, OutlinedFn, OutlinedFnID, Args,
+                   GenMapInfoCB);
 
   return Builder.saveIP();
 }

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -5587,8 +5587,9 @@ TEST_F(OpenMPIRBuilderTest, TargetRegion) {
 
   TargetRegionEntryInfo EntryInfo("func", 42, 4711, 17);
   OpenMPIRBuilder::LocationDescription OmpLoc({Builder.saveIP(), DL});
+  OMPBuilder.CurrentTargetInfo.emplace();
   Builder.restoreIP(OMPBuilder.createTarget(
-      OmpLoc, Builder.saveIP(), Builder.saveIP(), EntryInfo, -1, 0, Inputs,
+      OmpLoc, Builder.saveIP(), Builder.saveIP(), EntryInfo, Inputs,
       GenMapInfoCB, BodyGenCB, SimpleArgAccessorCB));
   OMPBuilder.finalize();
   Builder.CreateRetVoid();
@@ -5691,10 +5692,10 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
   TargetRegionEntryInfo EntryInfo("parent", /*DeviceID=*/1, /*FileID=*/2,
                                   /*Line=*/3, /*Count=*/0);
 
-  Builder.restoreIP(
-      OMPBuilder.createTarget(Loc, EntryIP, EntryIP, EntryInfo, /*NumTeams=*/-1,
-                              /*NumThreads=*/0, CapturedArgs, GenMapInfoCB,
-                              BodyGenCB, SimpleArgAccessorCB));
+  OMPBuilder.CurrentTargetInfo.emplace();
+  Builder.restoreIP(OMPBuilder.createTarget(Loc, EntryIP, EntryIP, EntryInfo,
+                                            CapturedArgs, GenMapInfoCB,
+                                            BodyGenCB, SimpleArgAccessorCB));
 
   Builder.CreateRetVoid();
   OMPBuilder.finalize();

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -1410,6 +1410,9 @@ def TargetOp : OpenMP_Op<"target",[OutlineableOpenMPOpInterface, AttrSizedOperan
 
     The optional $thread_limit specifies the limit on the number of threads
 
+    The optional $trip_count indicates the total number of loop iterations, only if this
+    target region represents a single teams+distribute+parallel worksharing loop.
+
     The optional $nowait elliminates the implicit barrier so the parent task can make progress
     even if the target task is not yet completed.
 
@@ -1420,6 +1423,7 @@ def TargetOp : OpenMP_Op<"target",[OutlineableOpenMPOpInterface, AttrSizedOperan
   let arguments = (ins Optional<I1>:$if_expr,
                        Optional<AnyInteger>:$device,
                        Optional<AnyInteger>:$thread_limit,
+                       Optional<AnyInteger>:$trip_count,
                        UnitAttr:$nowait,
                        Variadic<OpenMP_PointerLikeType>:$map_operands);
 
@@ -1429,12 +1433,19 @@ def TargetOp : OpenMP_Op<"target",[OutlineableOpenMPOpInterface, AttrSizedOperan
     oilist( `if` `(` $if_expr `)`
     | `device` `(` $device `:` type($device) `)`
     | `thread_limit` `(` $thread_limit `:` type($thread_limit) `)`
+    | `trip_count` `(` $trip_count `:` type($trip_count) `)`
     | `nowait` $nowait
     | `map_entries` `(` $map_operands `:` type($map_operands) `)`
     ) $region attr-dict
   }];
 
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Tells whether this target region represents a single worksharing loop
+    /// wrapped by omp.teams omp.distribute and omp.parallel constructs.
+    bool isTargetSPMDLoop();
+  }];
 }
 
 

--- a/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
+++ b/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
@@ -199,10 +199,11 @@ void mlir::configureOpenMPToLLVMConversionLegality(
     ConversionTarget &target, LLVMTypeConverter &typeConverter) {
   target.addDynamicallyLegalOp<
       mlir::omp::AtomicUpdateOp, mlir::omp::CriticalOp, mlir::omp::TargetOp,
-      mlir::omp::DataOp, mlir::omp::OrderedRegionOp, mlir::omp::ParallelOp,
-      mlir::omp::WsLoopOp, mlir::omp::SimdLoopOp, mlir::omp::MasterOp,
-      mlir::omp::SectionOp, mlir::omp::SectionsOp, mlir::omp::SingleOp,
-      mlir::omp::TaskGroupOp, mlir::omp::TaskOp>([&](Operation *op) {
+      mlir::omp::TeamsOp, mlir::omp::DistributeOp, mlir::omp::DataOp,
+      mlir::omp::OrderedRegionOp, mlir::omp::ParallelOp, mlir::omp::WsLoopOp,
+      mlir::omp::SimdLoopOp, mlir::omp::MasterOp, mlir::omp::SectionOp,
+      mlir::omp::SectionsOp, mlir::omp::SingleOp, mlir::omp::TaskGroupOp,
+      mlir::omp::TaskOp>([&](Operation *op) {
     return typeConverter.isLegal(&op->getRegion(0)) &&
            typeConverter.isLegal(op->getOperandTypes()) &&
            typeConverter.isLegal(op->getResultTypes());
@@ -246,6 +247,7 @@ void mlir::populateOpenMPToLLVMConversionPatterns(LLVMTypeConverter &converter,
       RegionOpConversion<omp::SimdLoopOp>, RegionOpConversion<omp::SingleOp>,
       RegionOpConversion<omp::TaskGroupOp>, RegionOpConversion<omp::TaskOp>,
       RegionOpConversion<omp::DataOp>, RegionOpConversion<omp::TargetOp>,
+      RegionOpConversion<omp::TeamsOp>, RegionOpConversion<omp::DistributeOp>,
       RegionLessOpWithVarOperandsConversion<omp::AtomicWriteOp>,
       RegionOpWithVarOperandsConversion<omp::AtomicUpdateOp>,
       RegionLessOpWithVarOperandsConversion<omp::FlushOp>,

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -688,8 +688,6 @@ convertOmpTeams(omp::TeamsOp op, llvm::IRBuilderBase &builder,
     // child op is allowed. Here we just assume this is the case.
     ompBuilder->CurrentTargetInfo->HasTeamsRegion = true;
 
-    // FIXME Later uses of NumTeams and ThreadLimit can crash the compiler, if
-    // they are not compile-time constants.
     if (Value numTeamsUpper = op.getNumTeamsUpper())
       ompBuilder->CurrentTargetInfo->NumTeams =
           moduleTranslation.lookupValue(numTeamsUpper);
@@ -2216,10 +2214,6 @@ convertOmpTarget(Operation &opInst, llvm::IRBuilderBase &builder,
     // The thread_limit clause of the omp.teams operation takes precedence. Set
     // it here if not already set and present in the omp.target operation.
     if (!ompBuilder->CurrentTargetInfo->ThreadLimit) {
-      // FIXME Currently, adding the thread_limit clause to omp.target results
-      // in a compiler error due to deleting an arith.constant operation before
-      // all uses are removed. This might be related to implicit mapping, since
-      // the constant is created outside of omp.target.
       if (Value threadLimit = targetOp.getThreadLimit())
         ompBuilder->CurrentTargetInfo->ThreadLimit =
             moduleTranslation.lookupValue(threadLimit);

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -2527,6 +2527,17 @@ LogicalResult OpenMPDialectLLVMIRTranslationInterface::amendOperation(
             }
             return failure();
           })
+      .Case("omp.target",
+            [&](Attribute attr) {
+              if (auto targetAttr = attr.dyn_cast<omp::TargetAttr>()) {
+                llvm::OpenMPIRBuilderConfig &config =
+                    moduleTranslation.getOpenMPBuilder()->Config;
+                config.TargetCPU = targetAttr.getTargetCpu();
+                config.TargetFeatures = targetAttr.getTargetFeatures();
+                return success();
+              }
+              return failure();
+            })
       .Default([](Attribute) {
         // Fall through for omp attributes that do not require lowering.
         return success();


### PR DESCRIPTION
This patch gathers the information during translation to LLVM IR about the values for num_teams, thread_limit and trip count to later use them to set up the RTL call to `__tgt_target_kernel`. It takes into account different allowed combinations of the teams, distribute, parallel and do directives inside a target region and it does not impact device codegen.

However, this approach has some known issues:
  - If the thread_limit clause is set for the omp.target operation, it will result in a compiler error due to an attempt to remove the operation from which it is initialized. It complains about removing it while there are uses remaining. This seems likely to be related to the implicit mapping, but we can ignore this limitation for milestone2b.
  - The LLVM values for the num_teams and thread_limit clauses of the omp.teams operation must be compile-time constants, as well as the calculated trip count of the omp.wsloop at the core of the kernel. Otherwise, it will result in a compiler crash. The reason for this is that these values are defined in an inner scope, so they are not visible to the parent omp.target that tries to access them after. This results in the num_teams and thread_limit clauses being defined after their use, as well as the trip count produced by the CanonicalLoopInfo class. In addition, the definition of many of these values ends up outlined to a different function.

The parallel_test application can be compiled with these limitations, but it's likely real applications won't due to the need for a constant trip count (i.e. `do i=1,n` will crash whereas `do i=1,10` will not).

Even though the arguments passed to `__tgt_target_kernel` now match between flang-new and clang, switching on libomptarget traces shows that the number of teams and threads with which the kernel is launched does not match. It's likely that some kernel attributes that are only set by clang are impacting the defaults for num_teams and thread_limit. As a workaround, the num_teams and thread_limit clauses of the teams directive can be used to set these values by hand.