### PR TITLE
[WIP] Device support for num_teams, thread_limit and num_threads clauses

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -5928,20 +5928,6 @@ void CGOpenMPRuntime::emitTargetOutlinedFunctionHelper(
         return CGF.GenerateOpenMPCapturedStmtFunction(CS, D.getBeginLoc());
       };
 
-  // Get NumTeams and ThreadLimit attributes
-  int32_t DefaultMinTeams = -1;
-  int32_t DefaultMaxTeams = INT32_MAX;
-  int32_t DefaultMinThreads = -1;
-  int32_t DefaultMaxThreads = INT32_MAX;
-
-  computeMinAndMaxThreadsAndTeams(D, CGF, DefaultMinThreads, DefaultMaxThreads,
-                                  DefaultMinTeams, DefaultMaxTeams);
-
-  OMPBuilder.CurrentTargetInfo = llvm::OpenMPIRBuilder::TargetRegionInfo();
-  OMPBuilder.CurrentTargetInfo->NumTeams =
-      CGF.Builder.getInt32(DefaultMinTeams);
-  OMPBuilder.CurrentTargetInfo->ThreadLimit =
-      CGF.Builder.getInt32(DefaultMaxThreads);
   OMPBuilder.emitTargetRegionFunction(EntryInfo, GenerateOutlinedFunction,
                                       IsOffloadEntry, OutlinedFn, OutlinedFnID);
 

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -765,14 +765,13 @@ void CGOpenMPRuntimeGPU::emitNonSPMDKernel(const OMPExecutableDirective &D,
 void CGOpenMPRuntimeGPU::emitKernelInit(const OMPExecutableDirective &D,
                                         CodeGenFunction &CGF,
                                         EntryFunctionState &EST, bool IsSPMD) {
-  int32_t MinThreadsVal = 1, MaxThreadsVal = -1, MinTeamsVal = 1,
-          MaxTeamsVal = -1;
-  computeMinAndMaxThreadsAndTeams(D, CGF, MinThreadsVal, MaxThreadsVal,
-                                  MinTeamsVal, MaxTeamsVal);
+  // Get NumTeams and ThreadLimit attributes.
+  llvm::OpenMPIRBuilder::TargetKernelDefaultBounds Bounds;
+  computeMinAndMaxThreadsAndTeams(D, CGF, Bounds.MinThreads, Bounds.MaxThreads,
+                                  Bounds.MinTeams, Bounds.MaxTeams);
 
   CGBuilderTy &Bld = CGF.Builder;
-  Bld.restoreIP(OMPBuilder.createTargetInit(
-      Bld, IsSPMD, MinThreadsVal, MaxThreadsVal, MinTeamsVal, MaxTeamsVal));
+  Bld.restoreIP(OMPBuilder.createTargetInit(Bld, IsSPMD, Bounds));
   if (!IsSPMD)
     emitGenericVarsProlog(CGF, EST.Loc);
 }

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -499,8 +499,8 @@ void OpenMPIRBuilder::getKernelArgsVector(TargetKernelArgs &KernelArgs,
 
   Value *NumTeams3D =
       Builder.CreateInsertValue(ZeroArray, KernelArgs.NumTeams, {0});
-  Value *ThreadLimit3D =
-      Builder.CreateInsertValue(ZeroArray, KernelArgs.ThreadLimit, {0});
+  Value *NumThreads3D =
+      Builder.CreateInsertValue(ZeroArray, KernelArgs.NumThreads, {0});
 
   ArgsVector = {Version,
                 PointerNum,
@@ -513,7 +513,7 @@ void OpenMPIRBuilder::getKernelArgsVector(TargetKernelArgs &KernelArgs,
                 KernelArgs.TripCount,
                 Flags,
                 NumTeams3D,
-                ThreadLimit3D,
+                NumThreads3D,
                 KernelArgs.DynCGGroupMem};
 }
 
@@ -1051,7 +1051,7 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::emitKernelLaunch(
   // of teams and threads so no additional calls to the runtime are required.
   // Check the error code and execute the host version if required.
   Builder.restoreIP(emitTargetKernel(Builder, AllocaIP, Return, RTLoc, DeviceID,
-                                     Args.NumTeams, Args.ThreadLimit,
+                                     Args.NumTeams, Args.NumThreads,
                                      OutlinedFnID, ArgsVector));
 
   BasicBlock *OffloadFailedBlock =
@@ -4440,10 +4440,9 @@ CallInst *OpenMPIRBuilder::createCachedThreadPrivate(
   return Builder.CreateCall(Fn, Args);
 }
 
-OpenMPIRBuilder::InsertPointTy
-OpenMPIRBuilder::createTargetInit(const LocationDescription &Loc, bool IsSPMD,
-                                  int32_t MinThreadsVal, int32_t MaxThreadsVal,
-                                  int32_t MinTeamsVal, int32_t MaxTeamsVal) {
+OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
+    const LocationDescription &Loc, bool IsSPMD,
+    const llvm::OpenMPIRBuilder::TargetKernelDefaultBounds &Bounds) {
   if (!updateToLocation(Loc))
     return Loc.IP;
 
@@ -4460,21 +4459,23 @@ OpenMPIRBuilder::createTargetInit(const LocationDescription &Loc, bool IsSPMD,
 
   // Manifest the launch configuration in the metadata matching the kernel
   // environment.
-  if (MinTeamsVal > 1 || MaxTeamsVal > 0)
-    writeTeamsForKernel(T, *Kernel, MinTeamsVal, MaxTeamsVal);
+  if (Bounds.MinTeams > 1 || Bounds.MaxTeams > 0)
+    writeTeamsForKernel(T, *Kernel, Bounds.MinTeams, Bounds.MaxTeams);
 
-  // For max values, < 0 means unset, == 0 means set but unknown.
-  if (MaxThreadsVal < 0)
-    MaxThreadsVal = std::max(
-        int32_t(getGridValue(T, Kernel).GV_Default_WG_Size), MinThreadsVal);
+  // If MaxThreads not set, select the maximum between the default workgroup
+  // size and the MinThreads value.
+  int32_t MaxThreadsValue = Bounds.MaxThreads;
+  if (MaxThreadsValue < 0)
+    MaxThreadsValue = std::max(
+        int32_t(getGridValue(T, Kernel).GV_Default_WG_Size), Bounds.MinThreads);
 
-  if (MaxThreadsVal > 0)
-    writeThreadBoundsForKernel(T, *Kernel, MinThreadsVal, MaxThreadsVal);
+  if (MaxThreadsValue > 0)
+    writeThreadBoundsForKernel(T, *Kernel, Bounds.MinThreads, MaxThreadsValue);
 
-  Constant *MinThreads = ConstantInt::getSigned(Int32, MinThreadsVal);
-  Constant *MaxThreads = ConstantInt::getSigned(Int32, MaxThreadsVal);
-  Constant *MinTeams = ConstantInt::getSigned(Int32, MinTeamsVal);
-  Constant *MaxTeams = ConstantInt::getSigned(Int32, MaxTeamsVal);
+  Constant *MinThreads = ConstantInt::getSigned(Int32, Bounds.MinThreads);
+  Constant *MaxThreads = ConstantInt::getSigned(Int32, MaxThreadsValue);
+  Constant *MinTeams = ConstantInt::getSigned(Int32, Bounds.MinTeams);
+  Constant *MaxTeams = ConstantInt::getSigned(Int32, Bounds.MaxTeams);
   Constant *ReductionDataSize = ConstantInt::getSigned(Int32, 0);
   Constant *ReductionBufferLength = ConstantInt::getSigned(Int32, 0);
 
@@ -4710,75 +4711,12 @@ void OpenMPIRBuilder::setOutlinedTargetRegionFunctionAttributes(
     OutlinedFn->setVisibility(GlobalValue::ProtectedVisibility);
     if (T.isAMDGCN())
       OutlinedFn->setCallingConv(CallingConv::AMDGPU_KERNEL);
-    if (!Config.TargetCPU.empty())
-      OutlinedFn->addFnAttr("target-cpu", Config.TargetCPU);
-    if (!Config.TargetFeatures.empty())
-      OutlinedFn->addFnAttr("target-features", Config.TargetFeatures);
   }
 
-  // Try to get constant values for NumTeams and ThreadLimit, and set default
-  // values if they are not constant.
-  int32_t NumTeamsValue = -1;
-  int32_t ThreadLimitValue = -1;
-
-  if (auto *NumTeamsConst =
-          dyn_cast_if_present<llvm::Constant>(CurrentTargetInfo->NumTeams))
-    NumTeamsValue = NumTeamsConst->getUniqueInteger().getSExtValue();
-  else if (CurrentTargetInfo->HasTeamsRegion)
-    NumTeamsValue = 0;
-
-  if (auto *ThreadLimitConst =
-          dyn_cast_if_present<llvm::Constant>(CurrentTargetInfo->ThreadLimit))
-    ThreadLimitValue = ThreadLimitConst->getUniqueInteger().getSExtValue();
-
-  if (NumTeamsValue > 0)
-    OutlinedFn->addFnAttr("omp_target_num_teams",
-                          std::to_string(NumTeamsValue));
-
-  if (ThreadLimitValue == -1 && Config.isGPU())
-    ThreadLimitValue = getGridValue(T, OutlinedFn).GV_Default_WG_Size;
-
-  if (ThreadLimitValue > 0) {
-    if (OutlinedFn->getCallingConv() == CallingConv::AMDGPU_KERNEL) {
-      OutlinedFn->addFnAttr("amdgpu-flat-work-group-size",
-                            "1," + llvm::utostr(ThreadLimitValue));
-    } else {
-      // Update the "maxntidx" metadata for NVIDIA, or add it.
-      NamedMDNode *MD = M.getOrInsertNamedMetadata("nvvm.annotations");
-      MDNode *ExistingOp = nullptr;
-      for (auto *Op : MD->operands()) {
-        if (Op->getNumOperands() != 3)
-          continue;
-        auto *Kernel = dyn_cast<ConstantAsMetadata>(Op->getOperand(0));
-        if (!Kernel || Kernel->getValue() != OutlinedFn)
-          continue;
-        auto *Prop = dyn_cast<MDString>(Op->getOperand(1));
-        if (!Prop || Prop->getString() != "maxntidx")
-          continue;
-        ExistingOp = Op;
-        break;
-      }
-      if (ExistingOp) {
-        auto *OldVal = dyn_cast<ConstantAsMetadata>(ExistingOp->getOperand(2));
-        int32_t OldLimit =
-            cast<ConstantInt>(OldVal->getValue())->getZExtValue();
-        ExistingOp->replaceOperandWith(
-            2, ConstantAsMetadata::get(
-                   ConstantInt::get(OldVal->getValue()->getType(),
-                                    std::min(OldLimit, ThreadLimitValue))));
-      } else {
-        LLVMContext &Ctx = M.getContext();
-        Metadata *MDVals[] = {ConstantAsMetadata::get(OutlinedFn),
-                              MDString::get(Ctx, "maxntidx"),
-                              ConstantAsMetadata::get(ConstantInt::get(
-                                  Type::getInt32Ty(Ctx), ThreadLimitValue))};
-        // Append metadata to nvvm.annotations
-        MD->addOperand(MDNode::get(Ctx, MDVals));
-      }
-    }
-    OutlinedFn->addFnAttr("omp_target_thread_limit",
-                          std::to_string(ThreadLimitValue));
-  }
+  if (!Config.TargetCPU.empty())
+    OutlinedFn->addFnAttr("target-cpu", Config.TargetCPU);
+  if (!Config.TargetFeatures.empty())
+    OutlinedFn->addFnAttr("target-features", Config.TargetFeatures);
 }
 
 Constant *OpenMPIRBuilder::createOutlinedFunctionID(Function *OutlinedFn,
@@ -5100,6 +5038,7 @@ static void replaceConstantValueUsesInFuncWithInstr(llvm::Value *Input,
 
 static Function *createOutlinedFunction(
     OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder, bool IsSPMD,
+    const OpenMPIRBuilder::TargetKernelDefaultBounds &DefaultBounds,
     StringRef FuncName, SmallVectorImpl<Value *> &Inputs,
     OpenMPIRBuilder::TargetBodyGenCallbackTy &CBFunc,
     OpenMPIRBuilder::TargetGenArgAccessorsCallbackTy &ArgAccessorFuncCB) {
@@ -5141,7 +5080,8 @@ static Function *createOutlinedFunction(
 
   // Insert target init call in the device compilation pass.
   if (OMPBuilder.Config.isTargetDevice())
-    Builder.restoreIP(OMPBuilder.createTargetInit(Builder, IsSPMD));
+    Builder.restoreIP(
+        OMPBuilder.createTargetInit(Builder, IsSPMD, DefaultBounds));
 
   BasicBlock *UserCodeEntryBB = Builder.GetInsertBlock();
 
@@ -5203,26 +5143,32 @@ static Function *createOutlinedFunction(
 
 static void emitTargetOutlinedFunction(
     OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder, bool IsSPMD,
-    TargetRegionEntryInfo &EntryInfo, Function *&OutlinedFn,
-    Constant *&OutlinedFnID, SmallVectorImpl<Value *> &Inputs,
+    TargetRegionEntryInfo &EntryInfo,
+    const OpenMPIRBuilder::TargetKernelDefaultBounds &DefaultBounds,
+    Function *&OutlinedFn, Constant *&OutlinedFnID,
+    SmallVectorImpl<Value *> &Inputs,
     OpenMPIRBuilder::TargetBodyGenCallbackTy &CBFunc,
     OpenMPIRBuilder::TargetGenArgAccessorsCallbackTy &ArgAccessorFuncCB) {
 
   OpenMPIRBuilder::FunctionGenCallback &&GenerateOutlinedFunction =
       [&](StringRef EntryFnName) {
-        return createOutlinedFunction(OMPBuilder, Builder, IsSPMD, EntryFnName,
-                                      Inputs, CBFunc, ArgAccessorFuncCB);
+        return createOutlinedFunction(OMPBuilder, Builder, IsSPMD,
+                                      DefaultBounds, EntryFnName, Inputs,
+                                      CBFunc, ArgAccessorFuncCB);
       };
 
   OMPBuilder.emitTargetRegionFunction(EntryInfo, GenerateOutlinedFunction, true,
                                       OutlinedFn, OutlinedFnID);
 }
 
-static void emitTargetCall(OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
-                           OpenMPIRBuilder::InsertPointTy AllocaIP,
-                           Function *OutlinedFn, Constant *OutlinedFnID,
-                           SmallVectorImpl<Value *> &Args,
-                           OpenMPIRBuilder::GenMapInfoCallbackTy GenMapInfoCB) {
+static void
+emitTargetCall(OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
+               OpenMPIRBuilder::InsertPointTy AllocaIP,
+               const OpenMPIRBuilder::TargetKernelDefaultBounds &DefaultBounds,
+               const OpenMPIRBuilder::TargetKernelRuntimeBounds &RuntimeBounds,
+               Function *OutlinedFn, Constant *OutlinedFnID,
+               SmallVectorImpl<Value *> &Args,
+               OpenMPIRBuilder::GenMapInfoCallbackTy GenMapInfoCB) {
 
   OpenMPIRBuilder::TargetDataInfo Info(
       /*RequiresDevicePointerInfo=*/false,
@@ -5252,27 +5198,50 @@ static void emitTargetCall(OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
   Value *RTLoc = OMPBuilder.getOrCreateIdent(SrcLocStr, SrcLocStrSize,
                                              llvm::omp::IdentFlag(0), 0);
 
-  OpenMPIRBuilder::TargetRegionInfo &TRI = OMPBuilder.CurrentTargetInfo.value();
+  Value *TripCount = RuntimeBounds.LoopTripCount
+                         ? Builder.CreateIntCast(RuntimeBounds.LoopTripCount,
+                                                 Builder.getInt64Ty(),
+                                                 /*isSigned=*/false)
+                         : Builder.getInt64(0);
 
-  // Set to -1 if there is no teams directive, and 0 if clause unspecified.
-  Value *NumTeams = !TRI.HasTeamsRegion ? Builder.getInt32(-1)
-                    : TRI.NumTeams      ? TRI.NumTeams
-                                        : Builder.getInt32(0);
+  Value *NumTeams = RuntimeBounds.MaxTeams
+                        ? RuntimeBounds.MaxTeams
+                        : Builder.getInt32(DefaultBounds.MaxTeams);
 
-  // Set to 0 if clause unspecified.
-  Value *ThreadLimit = TRI.ThreadLimit ? TRI.ThreadLimit : Builder.getInt32(0);
+  // Calculate number of threads: 0 if no clauses specified, otherwise it is the
+  // minimum between optional THREAD_LIMIT and MAX_THREADS clauses. Perform a
+  // type cast to uint32.
+  auto InitMaxThreadsClause = [&Builder](Value *Clause) {
+    if (Clause)
+      Clause = Builder.CreateIntCast(Clause, Builder.getInt32Ty(),
+                                     /*isSigned=*/false);
+    return Clause;
+  };
 
-  // Set to 0 if this is not a teams + single distribute loop.
-  Value *TripCount = TRI.isLoop() ? TRI.LoopTripCount : nullptr;
-  if (!TripCount)
-    TripCount = Builder.getInt64(0);
+  auto CombineMaxThreadsClauses = [&Builder](Value *Clause, Value *&Result) {
+    if (Clause)
+      Result = Result
+                   ? Builder.CreateSelect(Builder.CreateICmpULT(Result, Clause),
+                                          Result, Clause)
+                   : Clause;
+  };
+
+  Value *MaxThreadsClause = InitMaxThreadsClause(RuntimeBounds.MaxThreads);
+  Value *TeamsThreadLimitClause =
+      InitMaxThreadsClause(RuntimeBounds.TeamsThreadLimit);
+  Value *NumThreads = InitMaxThreadsClause(RuntimeBounds.TargetThreadLimit);
+  CombineMaxThreadsClauses(TeamsThreadLimitClause, NumThreads);
+  CombineMaxThreadsClauses(MaxThreadsClause, NumThreads);
+
+  if (!NumThreads)
+    NumThreads = Builder.getInt32(0);
 
   // TODO: Use correct DynCGGroupMem
   Value *DynCGGroupMem = Builder.getInt32(0);
   bool HasNoWait = false;
 
   OpenMPIRBuilder::TargetKernelArgs KArgs(NumTargetItems, RTArgs, TripCount,
-                                          NumTeams, ThreadLimit, DynCGGroupMem,
+                                          NumTeams, NumThreads, DynCGGroupMem,
                                           HasNoWait);
 
   Builder.restoreIP(OMPBuilder.emitKernelLaunch(
@@ -5283,6 +5252,8 @@ static void emitTargetCall(OpenMPIRBuilder &OMPBuilder, IRBuilderBase &Builder,
 OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTarget(
     const LocationDescription &Loc, bool IsSPMD, InsertPointTy AllocaIP,
     InsertPointTy CodeGenIP, TargetRegionEntryInfo &EntryInfo,
+    const TargetKernelDefaultBounds &DefaultBounds,
+    const TargetKernelRuntimeBounds &RuntimeBounds,
     SmallVectorImpl<Value *> &Args, GenMapInfoCallbackTy GenMapInfoCB,
     OpenMPIRBuilder::TargetBodyGenCallbackTy CBFunc,
     OpenMPIRBuilder::TargetGenArgAccessorsCallbackTy ArgAccessorFuncCB) {
@@ -5293,11 +5264,12 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTarget(
 
   Function *OutlinedFn;
   Constant *OutlinedFnID;
-  emitTargetOutlinedFunction(*this, Builder, IsSPMD, EntryInfo, OutlinedFn,
-                             OutlinedFnID, Args, CBFunc, ArgAccessorFuncCB);
+  emitTargetOutlinedFunction(*this, Builder, IsSPMD, EntryInfo, DefaultBounds,
+                             OutlinedFn, OutlinedFnID, Args, CBFunc,
+                             ArgAccessorFuncCB);
   if (!Config.isTargetDevice())
-    emitTargetCall(*this, Builder, AllocaIP, OutlinedFn, OutlinedFnID, Args,
-                   GenMapInfoCB);
+    emitTargetCall(*this, Builder, AllocaIP, DefaultBounds, RuntimeBounds,
+                   OutlinedFn, OutlinedFnID, Args, GenMapInfoCB);
 
   return Builder.saveIP();
 }
@@ -6394,8 +6366,9 @@ OpenMPIRBuilder::createTeams(const LocationDescription &Loc,
   BasicBlock *AllocaBB =
       splitBB(Builder, /*CreateBranch=*/true, "teams.alloca");
 
-  // Push num_teams
-  if (NumTeamsLower || NumTeamsUpper || ThreadLimit || IfExpr) {
+  // Push num_teams if generating host fallback function
+  if (!Config.isTargetDevice() &&
+      (NumTeamsLower || NumTeamsUpper || ThreadLimit || IfExpr)) {
     assert((NumTeamsLower == nullptr || NumTeamsUpper != nullptr) &&
            "if lowerbound is non-null, then upperbound must also be non-null "
            "for bounds on num_teams");
@@ -6450,42 +6423,43 @@ OpenMPIRBuilder::createTeams(const LocationDescription &Loc,
 
   // Prevent unresolved __kmpc_fork_teams when device linking
   if (!Config.isTargetDevice()) {
-  OI.PostOutlineCB = [this, Ident, ToBeDeleted](Function &OutlinedFn) mutable {
-    // The stale call instruction will be replaced with a new call instruction
-    // for runtime call with the outlined function.
+    OI.PostOutlineCB = [this, Ident,
+                        ToBeDeleted](Function &OutlinedFn) mutable {
+      // The stale call instruction will be replaced with a new call instruction
+      // for runtime call with the outlined function.
 
-    assert(OutlinedFn.getNumUses() == 1 &&
-           "there must be a single user for the outlined function");
-    CallInst *StaleCI = cast<CallInst>(OutlinedFn.user_back());
-    ToBeDeleted.push(StaleCI);
+      assert(OutlinedFn.getNumUses() == 1 &&
+             "there must be a single user for the outlined function");
+      CallInst *StaleCI = cast<CallInst>(OutlinedFn.user_back());
+      ToBeDeleted.push(StaleCI);
 
-    assert((OutlinedFn.arg_size() == 2 || OutlinedFn.arg_size() == 3) &&
-           "Outlined function must have two or three arguments only");
+      assert((OutlinedFn.arg_size() == 2 || OutlinedFn.arg_size() == 3) &&
+             "Outlined function must have two or three arguments only");
 
-    bool HasShared = OutlinedFn.arg_size() == 3;
+      bool HasShared = OutlinedFn.arg_size() == 3;
 
-    OutlinedFn.getArg(0)->setName("global.tid.ptr");
-    OutlinedFn.getArg(1)->setName("bound.tid.ptr");
-    if (HasShared)
-      OutlinedFn.getArg(2)->setName("data");
+      OutlinedFn.getArg(0)->setName("global.tid.ptr");
+      OutlinedFn.getArg(1)->setName("bound.tid.ptr");
+      if (HasShared)
+        OutlinedFn.getArg(2)->setName("data");
 
-    // Call to the runtime function for teams in the current function.
-    assert(StaleCI && "Error while outlining - no CallInst user found for the "
-                      "outlined function.");
-    Builder.SetInsertPoint(StaleCI);
-    SmallVector<Value *> Args = {
-        Ident, Builder.getInt32(StaleCI->arg_size() - 2), &OutlinedFn};
-    if (HasShared)
-      Args.push_back(StaleCI->getArgOperand(2));
-    Builder.CreateCall(getOrCreateRuntimeFunctionPtr(
-                           omp::RuntimeFunction::OMPRTL___kmpc_fork_teams),
-                       Args);
+      // Call to the runtime function for teams in the current function.
+      assert(StaleCI && "Error while outlining - no CallInst user found for "
+                        "the outlined function.");
+      Builder.SetInsertPoint(StaleCI);
+      SmallVector<Value *> Args = {
+          Ident, Builder.getInt32(StaleCI->arg_size() - 2), &OutlinedFn};
+      if (HasShared)
+        Args.push_back(StaleCI->getArgOperand(2));
+      Builder.CreateCall(getOrCreateRuntimeFunctionPtr(
+                             omp::RuntimeFunction::OMPRTL___kmpc_fork_teams),
+                         Args);
 
-    while (!ToBeDeleted.empty()) {
-      ToBeDeleted.top()->eraseFromParent();
-      ToBeDeleted.pop();
-    }
-  };
+      while (!ToBeDeleted.empty()) {
+        ToBeDeleted.top()->eraseFromParent();
+        ToBeDeleted.pop();
+      }
+    };
   };
 
   addOutlineInfo(std::move(OI));

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -5803,10 +5803,11 @@ TEST_F(OpenMPIRBuilderTest, TargetRegion) {
 
   TargetRegionEntryInfo EntryInfo("func", 42, 4711, 17);
   OpenMPIRBuilder::LocationDescription OmpLoc({Builder.saveIP(), DL});
-  OMPBuilder.CurrentTargetInfo.emplace();
   Builder.restoreIP(OMPBuilder.createTarget(
       OmpLoc, /*IsSPMD=*/false, Builder.saveIP(), Builder.saveIP(), EntryInfo,
-      Inputs, GenMapInfoCB, BodyGenCB, SimpleArgAccessorCB));
+      /*DefaultBounds=*/OpenMPIRBuilder::TargetKernelDefaultBounds(),
+      /*RuntimeBounds=*/OpenMPIRBuilder::TargetKernelRuntimeBounds(), Inputs,
+      GenMapInfoCB, BodyGenCB, SimpleArgAccessorCB));
   OMPBuilder.finalize();
   Builder.CreateRetVoid();
 
@@ -5908,10 +5909,11 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
   TargetRegionEntryInfo EntryInfo("parent", /*DeviceID=*/1, /*FileID=*/2,
                                   /*Line=*/3, /*Count=*/0);
 
-  OMPBuilder.CurrentTargetInfo.emplace();
   Builder.restoreIP(OMPBuilder.createTarget(
-      Loc, /*IsSPMD=*/false, EntryIP, EntryIP, EntryInfo, CapturedArgs,
-      GenMapInfoCB, BodyGenCB, SimpleArgAccessorCB));
+      Loc, /*IsSPMD=*/false, EntryIP, EntryIP, EntryInfo,
+      /*DefaultBounds=*/OpenMPIRBuilder::TargetKernelDefaultBounds(),
+      /*RuntimeBounds=*/OpenMPIRBuilder::TargetKernelRuntimeBounds(),
+      CapturedArgs, GenMapInfoCB, BodyGenCB, SimpleArgAccessorCB));
 
   Builder.CreateRetVoid();
   OMPBuilder.finalize();

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -1412,8 +1412,17 @@ def TargetOp : OpenMP_Op<"target",[IsolatedFromAbove, OutlineableOpenMPOpInterfa
     The optional $trip_count indicates the total number of loop iterations, only if this
     target region represents a single teams+distribute+parallel worksharing loop.
 
-    The optional $nowait elliminates the implicit barrier so the parent task can make progress
+    The optional $nowait eliminates the implicit barrier so the parent task can make progress
     even if the target task is not yet completed.
+
+    The optional $num_teams_lower, $num_teams_upper and $teams_thread_limit
+    arguments represent the corresponding arguments of a directly nested TeamsOp. They
+    can be only set in this operation when representing combined or composite constructs
+    that include TARGET and TEAMS, so that they can be evaluated in the host device.
+
+    The optional $num_threads argument represents the corresponding argument of a nested
+    ParallelOp, which is only allowed if this target region contains a single (possibly
+    multi-level) nest of OpenMP operations including a ParallelOp.
 
     TODO:  is_device_ptr, depend, defaultmap, in_reduction
 
@@ -1424,7 +1433,11 @@ def TargetOp : OpenMP_Op<"target",[IsolatedFromAbove, OutlineableOpenMPOpInterfa
                        Optional<AnyInteger>:$thread_limit,
                        Optional<AnyInteger>:$trip_count,
                        UnitAttr:$nowait,
-                       Variadic<AnyType>:$map_operands);
+                       Variadic<AnyType>:$map_operands,
+                       Optional<AnyInteger>:$num_teams_lower,
+                       Optional<AnyInteger>:$num_teams_upper,
+                       Optional<AnyInteger>:$teams_thread_limit,
+                       Optional<AnyInteger>:$num_threads);
 
   let regions = (region AnyRegion:$region);
 
@@ -1435,12 +1448,25 @@ def TargetOp : OpenMP_Op<"target",[IsolatedFromAbove, OutlineableOpenMPOpInterfa
     | `trip_count` `(` $trip_count `:` type($trip_count) `)`
     | `nowait` $nowait
     | `map_entries` `(` custom<MapEntries>($map_operands, type($map_operands)) `)`
+    | `num_teams` `(` ( $num_teams_lower^ `:` type($num_teams_lower) )? `to`
+                        $num_teams_upper `:` type($num_teams_upper) `)`
+    | `teams_thread_limit` `(` $teams_thread_limit `:` type($teams_thread_limit) `)`
+    | `num_threads` `(` $num_threads `:` type($num_threads) `)`
     ) $region attr-dict
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+    /// Returns the innermost OpenMP dialect operation nested inside of this
+    /// operation's region. For an operation to be detected as captured, it must
+    /// be inside a (possibly multi-level) nest of OpenMP dialect operation's
+    /// regions where none of these levels contain other operations considered
+    /// not-allowed for these purposes (i.e. only terminator operations are
+    /// allowed from the OpenMP dialect, and other dialect's operations are
+    /// allowed as long as they don't have a memory write effect).
+    Operation *getInnermostCapturedOmpOp();
+
     /// Tells whether this target region represents a single worksharing loop
     /// wrapped by omp.teams omp.distribute and omp.parallel constructs.
     bool isTargetSPMDLoop();


### PR DESCRIPTION
This patch brings back support for the use of `num_teams`, `thread_limit` and `num_threads` clauses of the TEAMS, TEAMS+TARGET and PARALLEL OpenMP directives when generating target device code.

These changes are needed due to recent upstream modifications to the `OpenMPIRBuilder`, which now stores default/constant values for these clauses in a global structure that is created early in the translation process (when the outlined kernel function is created, before processing its contents). The initial conflict resolution that was done when these changes were merged to the ATD branch seemed to work, but it was duplicating some code and yielding different values than clang for equivalent codes.

Also, the addition of the `IsolatedFromAbove` trait to the `omp.target` MLIR operation broke previous support for these clauses as well, since they were defined outside the `omp.target` operation but then passed as arguments to nested `omp.teams` without any mapping clauses.

This is a summary of the changes introduced in this patch, which enable again support for the aforementioned clauses:

  - Split the `OpenMPIRBuilder::TargetRegionInfo` structure into a structure holding runtime values and another structure holding default/constant values. Also, rather than having it introduce state about the current target region being lowered to the `OpenMPIRBuilder` class, these structures are populated and passed to the relevant builder functions from clang/flang.
  - Remove duplicated `OpenMPIRBuilder` code introduced during a merge from main, related to the handling of kernel attributes. Fixed mismatches between clang and flang relating to this.
  - Extract evaluation of clauses of TEAMS and PARALLEL directives to outside the target region they are in and pass these values to new `omp.target` arguments. This approach is temporary, and alternatives are being discussed in the [LLVM-Flang Slack channel](https://flang-compiler.slack.com/archives/C01PY03PP9P/p1700672266767559).
  - Runtime values for the trip count, number of teams and number of threads are casted to the type expected by the corresponding RTL function, so using different types won't result in a compilation error.
  - Prevent `kmpc_push_num_threads` calls being generated for the target device.
  - Improve MLIR pattern checks for the `omp.target` operation to tell whether it represents an SPMD loop.